### PR TITLE
Use more Compat classes.

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -7,6 +7,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Point;
+import android.location.LocationManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -25,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.core.location.LocationManagerCompat;
 import androidx.core.text.util.LinkifyCompat;
 import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -428,7 +430,8 @@ public class MainActivity extends AppCompatActivity implements
 
 	private void updateLocationAvailability()
 	{
-		if(LocationUtil.isLocationOn(this))
+		LocationManager locationManager = ContextCompat.getSystemService(this, LocationManager.class);
+		if(LocationManagerCompat.isLocationEnabled(locationManager))
 		{
 			questAutoSyncer.startPositionTracking();
 		}

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -1,26 +1,17 @@
 package de.westnordost.streetcomplete;
 
-import android.content.res.Configuration;
-import android.graphics.Point;
-import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.graphics.Point;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.AnyThread;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceManager;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
 import android.view.KeyEvent;
@@ -28,6 +19,18 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.AnyThread;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.text.util.LinkifyCompat;
+import androidx.fragment.app.Fragment;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.preference.PreferenceManager;
+
+import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 
@@ -39,13 +42,13 @@ import de.westnordost.osmapi.map.data.LatLon;
 import de.westnordost.osmapi.map.data.OsmLatLon;
 import de.westnordost.streetcomplete.controls.NotificationButtonFragment;
 import de.westnordost.streetcomplete.data.download.DownloadItem;
+import de.westnordost.streetcomplete.data.download.DownloadProgressListener;
+import de.westnordost.streetcomplete.data.download.QuestDownloadController;
 import de.westnordost.streetcomplete.data.notifications.Notification;
 import de.westnordost.streetcomplete.data.notifications.NotificationsSource;
 import de.westnordost.streetcomplete.data.quest.Quest;
 import de.westnordost.streetcomplete.data.quest.QuestAutoSyncer;
 import de.westnordost.streetcomplete.data.quest.QuestController;
-import de.westnordost.streetcomplete.data.download.DownloadProgressListener;
-import de.westnordost.streetcomplete.data.download.QuestDownloadController;
 import de.westnordost.streetcomplete.data.quest.UnsyncedChangesCountSource;
 import de.westnordost.streetcomplete.data.upload.UploadController;
 import de.westnordost.streetcomplete.data.upload.UploadProgressListener;
@@ -55,10 +58,10 @@ import de.westnordost.streetcomplete.location.LocationRequestFragment;
 import de.westnordost.streetcomplete.location.LocationState;
 import de.westnordost.streetcomplete.location.LocationUtil;
 import de.westnordost.streetcomplete.map.MainFragment;
-import de.westnordost.streetcomplete.notifications.NotificationsContainerFragment;
 import de.westnordost.streetcomplete.map.tangram.CameraPosition;
-import de.westnordost.streetcomplete.util.CrashReportExceptionHandler;
+import de.westnordost.streetcomplete.notifications.NotificationsContainerFragment;
 import de.westnordost.streetcomplete.tutorial.TutorialFragment;
+import de.westnordost.streetcomplete.util.CrashReportExceptionHandler;
 import de.westnordost.streetcomplete.util.GeoLocation;
 import de.westnordost.streetcomplete.util.GeoUriKt;
 import de.westnordost.streetcomplete.view.dialogs.RequestLoginDialog;
@@ -319,7 +322,7 @@ public class MainActivity extends AppCompatActivity implements
 					{
 						TextView messageText = (TextView) messageView;
 						messageText.setMovementMethod(LinkMovementMethod.getInstance());
-						Linkify.addLinks(messageText, Linkify.WEB_URLS);
+						LinkifyCompat.addLinks(messageText, Linkify.WEB_URLS);
 					}
 				}
 				else if(e instanceof OsmConnectionException)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/Activity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/Activity.kt
@@ -1,0 +1,7 @@
+package de.westnordost.streetcomplete.ktx
+
+import android.app.Activity
+import androidx.core.app.ActivityCompat
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun Activity.recreateCompat() = ActivityCompat.recreate(this)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/LocationManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/LocationManager.kt
@@ -1,0 +1,7 @@
+package de.westnordost.streetcomplete.ktx
+
+import android.location.LocationManager
+import androidx.core.location.LocationManagerCompat
+
+inline val LocationManager.isLocationEnabledCompat: Boolean
+    get() = LocationManagerCompat.isLocationEnabled(this)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/PlatformInsets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/PlatformInsets.kt
@@ -1,0 +1,9 @@
+package de.westnordost.streetcomplete.ktx
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.graphics.Insets
+
+@Suppress("NOTHING_TO_INLINE")
+@RequiresApi(Build.VERSION_CODES.Q)
+inline fun android.graphics.Insets.toCompatInsets() = Insets.toCompatInsets(this)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/View.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/View.kt
@@ -8,9 +8,7 @@ import android.view.ViewPropertyAnimator
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import androidx.core.os.postDelayed
-import androidx.core.view.doOnLayout
-import androidx.core.view.doOnPreDraw
-import androidx.core.view.updateLayoutParams
+import androidx.core.view.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -72,3 +70,8 @@ fun View.updateMargins(left: Int? = null, top: Int? = null, right: Int? = null, 
         )
     }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun View.setOnApplyWindowInsetsCompatListener(
+    noinline listener: ((View, WindowInsetsCompat) -> WindowInsetsCompat)?
+) = ViewCompat.setOnApplyWindowInsetsListener(this, listener)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/WindowInsets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/WindowInsets.kt
@@ -1,0 +1,10 @@
+package de.westnordost.streetcomplete.ktx
+
+import android.os.Build
+import android.view.WindowInsets
+import androidx.annotation.RequiresApi
+import androidx.core.view.WindowInsetsCompat
+
+@Suppress("NOTHING_TO_INLINE")
+@RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
+inline fun WindowInsets.toWindowInsetsCompat() = WindowInsetsCompat.toWindowInsetsCompat(this)

--- a/app/src/main/java/de/westnordost/streetcomplete/location/LocationRequestFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/location/LocationRequestFragment.kt
@@ -5,12 +5,15 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.location.LocationManager
 import android.os.Bundle
 import android.provider.Settings
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.isLocationEnabledCompat
 
 /** Manages the process to ensure that the app can access the user's location. Two steps:
  *
@@ -110,7 +113,7 @@ class LocationRequestFragment : Fragment() {
     /* Step 1: Ask for location to be turned on */
 
     private fun requestLocationSettingsToBeOn() {
-        if (LocationUtil.isLocationOn(context)) {
+        if (requireContext().getSystemService<LocationManager>()!!.isLocationEnabledCompat) {
             state = LocationState.ENABLED
             nextStep()
         } else {

--- a/app/src/main/java/de/westnordost/streetcomplete/location/LocationUtil.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/location/LocationUtil.java
@@ -5,39 +5,13 @@ import android.content.Context;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.provider.Settings;
+
 import androidx.core.content.ContextCompat;
-import android.text.TextUtils;
 
 import static android.location.LocationManager.PROVIDERS_CHANGED_ACTION;
 
 public class LocationUtil
 {
-	public static boolean isLocationOn(Context context)
-	{
-		if(!hasLocationPermission(context)) return false;
-
-		String locationProviders;
-		try
-		{
-			if (isNewLocationApi())
-			{
-				int locationMode = Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.LOCATION_MODE);
-				return locationMode != Settings.Secure.LOCATION_MODE_OFF;
-			}
-			else
-			{
-				locationProviders = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
-				return !TextUtils.isEmpty(locationProviders);
-			}
-		}
-		catch(Settings.SettingNotFoundException e)
-		{
-			e.printStackTrace();
-			return false;
-		}
-	}
-
 	public static boolean hasLocationPermission(Context context)
 	{
 		return ContextCompat.checkSelfPermission(context,
@@ -46,15 +20,10 @@ public class LocationUtil
 
 	public static IntentFilter createLocationAvailabilityIntentFilter()
 	{
-		String action = LocationUtil.isNewLocationApi() ? MODE_CHANGED : PROVIDERS_CHANGED_ACTION;
+		String action = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ? MODE_CHANGED : PROVIDERS_CHANGED_ACTION;
 		return new IntentFilter(action);
 	}
 
 	// because LocationManager.MODE_CHANGED is not defined before KitKat
 	private static final String MODE_CHANGED = "android.location.MODE_CHANGED";
-
-	private static boolean isNewLocationApi()
-	{
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
-	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -429,7 +429,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
     //region Location - Request location and update location status
 
     private fun updateLocationAvailability() {
-        if (LocationUtil.isLocationOn(activity)) {
+        if (requireContext().getSystemService<LocationManager>()!!.isLocationEnabledCompat) {
             onLocationIsEnabled()
         } else {
             onLocationIsDisabled()

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -29,6 +29,7 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.minus
 import androidx.core.graphics.toPointF
 import androidx.core.graphics.toRectF
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
@@ -92,7 +93,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
 
     private var locationWhenOpenedQuest: Location? = null
 
-    private var windowInsets: Rect? = null
+    private var windowInsets: WindowInsetsCompat? = null
 
     private var mapFragment: QuestsMapFragment? = null
     private val bottomSheetFragment: Fragment? get() = childFragmentManagerOrNull?.findFragmentByTag(BOTTOM_SHEET)
@@ -135,10 +136,8 @@ class MainFragment : Fragment(R.layout.fragment_main),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mapControls.respectSystemInsets(View::setMargins)
-        view.respectSystemInsets { left, top, right, bottom ->
-            windowInsets = Rect(left, top, right, bottom)
-        }
+        mapControls.respectSystemInsets()
+        view.respectSystemInsets { windowInsets = WindowInsetsCompat.Builder().setSystemWindowInsets(it).build() }
 
         locationPointerPin.setOnClickListener { onClickLocationPointer() }
 
@@ -661,7 +660,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
 
         var target = mapFragment.getClippedPointOf(displayedPosition) ?: return
         windowInsets?.let {
-            target -= PointF(it.left.toFloat(), it.top.toFloat())
+            target -= PointF(it.systemWindowInsetLeft.toFloat(), it.systemWindowInsetTop.toFloat())
         }
         val intersection = findClosestIntersection(mapControls, target)
         if (intersection != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MapFragment.kt
@@ -33,7 +33,6 @@ import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.awaitLayout
 import de.westnordost.streetcomplete.ktx.containsAll
-import de.westnordost.streetcomplete.ktx.setMargins
 import de.westnordost.streetcomplete.ktx.tryStartActivity
 import de.westnordost.streetcomplete.map.tangram.*
 import de.westnordost.streetcomplete.view.insets_animation.respectSystemInsets
@@ -104,7 +103,7 @@ open class MapFragment : Fragment(),
         mapTileProviderLink.text = vectorTileProvider.copyrightText
         mapTileProviderLink.setOnClickListener { showOpenUrlDialog(vectorTileProvider.copyrightLink) }
 
-        attributionContainer.respectSystemInsets(View::setMargins)
+        attributionContainer.respectSystemInsets()
 
         launch { initMap() }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractBottomSheetFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractBottomSheetFragment.kt
@@ -10,7 +10,9 @@ import android.view.View
 import android.view.animation.AnimationUtils
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AlertDialog
-import androidx.core.view.*
+import androidx.core.view.isGone
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
@@ -56,10 +58,10 @@ abstract class AbstractBottomSheetFragment : Fragment(), IsCloseableBottomSheet 
 
         closeButton.setOnClickListener { activity?.onBackPressed() }
 
-        view.respectSystemInsets { left, top, right, bottom ->
-            scrollViewChild.updatePadding(bottom = bottom)
-            bottomSheetContainer.updateMargins(top = top, left = left, right = right)
-            okButton.updateMargins(bottom = bottom + 8f.toPx(context).toInt())
+        view.respectSystemInsets {
+            scrollViewChild.updatePadding(bottom = it.bottom)
+            bottomSheetContainer.updateMargins(top = it.top, left = it.left, right = it.right)
+            okButton.updateMargins(bottom = it.bottom + 8f.toPx(context).toInt())
         }
 
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/SplitWayFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/SplitWayFragment.kt
@@ -20,13 +20,12 @@ import de.westnordost.osmapi.map.data.LatLon
 import de.westnordost.osmapi.map.data.OsmLatLon
 import de.westnordost.osmapi.map.data.Way
 import de.westnordost.streetcomplete.Injector
-
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.quest.QuestGroup
 import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.splitway.SplitAtLinePosition
 import de.westnordost.streetcomplete.data.osm.splitway.SplitAtPoint
 import de.westnordost.streetcomplete.data.osm.splitway.SplitPolylineAtPosition
+import de.westnordost.streetcomplete.data.quest.QuestGroup
 import de.westnordost.streetcomplete.ktx.*
 import de.westnordost.streetcomplete.util.SoundFx
 import de.westnordost.streetcomplete.util.alongTrackDistanceTo
@@ -86,7 +85,7 @@ class SplitWayFragment : Fragment(R.layout.fragment_split_way),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        bottomSheetContainer.respectSystemInsets(View::setMargins)
+        bottomSheetContainer.respectSystemInsets()
 
         splitWayRoot.setOnTouchListener { _, event ->
             clickPos = PointF(event.x, event.y)

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -19,6 +19,7 @@ import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmQuestController
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuest
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestController
+import de.westnordost.streetcomplete.ktx.recreateCompat
 import de.westnordost.streetcomplete.ktx.toast
 import kotlinx.coroutines.*
 import javax.inject.Inject
@@ -121,7 +122,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
             Prefs.THEME_SELECT -> {
                 val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
                 AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
-                activity?.recreate()
+                activity?.recreateCompat()
             }
             Prefs.RESURVEY_INTERVALS -> {
                 resurveyIntervalsUpdater.update()

--- a/app/src/main/java/de/westnordost/streetcomplete/tutorial/TutorialFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/tutorial/TutorialFragment.kt
@@ -39,7 +39,7 @@ class TutorialFragment : Fragment(R.layout.fragment_tutorial) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        view.respectSystemInsets(View::setPadding)
+        view.respectSystemInsets { setPadding(it.left, it.top, it.right, it.bottom) }
 
         updateIndicatorDots()
 


### PR DESCRIPTION
* Use [`LocationManagerCompat.isLocationEnabled()`](https://developer.android.com/reference/kotlin/androidx/core/location/LocationManagerCompat#islocationenabled), as [`Settings.Secure.LOCATION_MODE`](https://developer.android.com/reference/android/provider/Settings.Secure#LOCATION_MODE) has been deprecated and the SDK documentation recommends using `LocationManager.isLocationEnabled()` instead.
* Use [`LinkifyCompat.addLinks()`](https://developer.android.com/reference/kotlin/androidx/core/text/util/LinkifyCompat#addlinks_1) to make improvements to `Linkify.addLinks()` introduced in API level 28 available on older API levels.
* Use `WindowInsetsCompat`.
* Use [`ActivityCompat.recreate()`](https://developer.android.com/reference/androidx/core/app/ActivityCompat#recreate(android.app.Activity)) to work around bugs in the `recreate()` method on API levels below 28.