### PR TITLE
OpenStreetCam rebranded as KartaView

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
@@ -87,8 +87,8 @@ object AchievementsModule {
         // TODO not sure where to put these links
         Link(
             "openstreetcam",
-            "https://openstreetcam.org",
-            "OpenStreetCam",
+            "https://kartaview.org/map/",
+            "KartaView",
             LinkCategory.INTRO,
             R.drawable.ic_link_openstreetcam,
             R.string.link_openstreetcam_description


### PR DESCRIPTION
Description has no need for change.

Not sure whatever change id or keep it the same (what is the impact here?).

Not sure whatever https://kartaview.org/map/ or https://kartaview.org is preferable

Logo also needs to be updated.