### PR TITLE
Ignore parking=street_side unless access=unknown

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -6,7 +6,22 @@ import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
 class AddParkingAccess : OsmFilterQuestType<String>() {
 
-    override val elementFilter = "nodes, ways, relations with amenity=parking and (!access or access=unknown)"
+    // Exclude parking=street_side lacking any access tags, because most of
+    // these are found alongside public access roads, and likely will be
+    // access=yes by default. Leaving these in makes this quest repetitive and
+    // leads to users adding lots of redundant access=yes tags to satisfy the
+    // quest. parking=street_side with access=unknown seems like a valid target
+    // though.
+    //
+    // Cf. #2408: Parking access might omit parking=street_side
+    override val elementFilter = """
+        nodes, ways, relations with amenity=parking
+        and (
+            access=unknown
+            or (!access and -parking=street_side)
+        )
+    """
+
     override val commitMessage = "Add type of parking access"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_access

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -18,7 +18,7 @@ class AddParkingAccess : OsmFilterQuestType<String>() {
         nodes, ways, relations with amenity=parking
         and (
             access=unknown
-            or (!access and -parking=street_side)
+            or (!access and parking != street_side)
         )
     """
 


### PR DESCRIPTION
Fixes #2408.

This does allow `parking=street_side` when `access=unknown`, which seems sensible.

-----

I am a Java developer, but I don't work with Kotlin, and don't have a smartphone I can test this on. I have only amended the `elementFilter`, and tested the filter string with JOSM on Overpass. It seems to work, but please review for formatting and correctness.