### PR TITLE
disable housenumber quest in France, fixes #2427

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.kt
@@ -26,7 +26,8 @@ class AddHousenumber :  OsmElementQuestType<HousenumberAnswer> {
             "DK", // https://lists.openstreetmap.org/pipermail/talk-dk/2017-November/004898.html
             "NO", // https://forum.openstreetmap.org/viewtopic.php?id=60357
             "CZ", // https://lists.openstreetmap.org/pipermail/talk-cz/2017-November/017901.html
-            "IT"  // https://lists.openstreetmap.org/pipermail/talk-it/2018-July/063712.html
+            "IT", // https://lists.openstreetmap.org/pipermail/talk-it/2018-July/063712.html
+            "FR"  // https://github.com/streetcomplete/StreetComplete/issues/2427 https://t.me/osmfr/26320
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_title
@@ -145,7 +146,7 @@ private val nonBuildingAreasWithAddressFilter by lazy { """
     """.toElementFilterExpression()}
 
 private val nonMultipolygonRelationsWithAddressFilter by lazy { """
-    relations with 
+    relations with
       type != multipolygon
       and ~"addr:(housenumber|housename|conscriptionnumber|streetnumber)"
     """.toElementFilterExpression()}


### PR DESCRIPTION
French community considers as aceptable to import address nodes outside buildings, this unusual tagging breaks SC assumption
There were also some other issues raised, but this one breaks fundamental assumptions made by SC
Street name quest remains available as it still makes sense even with street numbers outside buildings