### PR TITLE
Set BottomSheetBehaviour to expanded in note creation to fix keyboard overlapping input area

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractCreateNoteFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractCreateNoteFragment.kt
@@ -30,9 +30,7 @@ abstract class AbstractCreateNoteFragment : AbstractBottomSheetFragment() {
         val view = inflater.inflate(layoutResId, container, false)
 
         val bottomSheet = view.findViewById<LinearLayout>(R.id.bottomSheet)
-        if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            BottomSheetBehavior.from(bottomSheet).state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        BottomSheetBehavior.from(bottomSheet).state = BottomSheetBehavior.STATE_EXPANDED
 
         val content = view.findViewById<ViewGroup>(R.id.content)
         content.removeAllViews()


### PR DESCRIPTION
Fixes #2442 