### PR TITLE
Crossing island quest with footways

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -23,6 +23,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
     private val excludedWaysFilter by lazy { """
         ways with 
           highway and access ~ private|no
+          or highway = service
           or highway and oneway and oneway != no
     """.toElementFilterExpression()}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -24,7 +24,6 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
         ways with 
           highway and access ~ private|no
           or highway and oneway and oneway != no
-          or highway ~ path|footway|cycleway|pedestrian
     """.toElementFilterExpression()}
 
     override val commitMessage = "Add whether pedestrian crossing has an island"


### PR DESCRIPTION
WIP on allowing crossing:island quests when footways/cycleways etc are mapped separately. 

See https://github.com/streetcomplete/StreetComplete/issues/2454 for issue.