### PR TITLE
Simplify the sending of emails

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,11 +26,6 @@
             <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="geo"/>
         </intent>
-        <!-- send crash report mail -->
-        <intent>
-            <action android:name="android.intent.action.SENDTO"/>
-            <data android:scheme="mailto"/>
-        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -1,6 +1,5 @@
 package de.westnordost.streetcomplete.about
 
-import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -13,9 +12,10 @@ import androidx.core.widget.TextViewCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.recyclerview.widget.RecyclerView
-import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.BuildConfig
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.tryStartActivity
+import de.westnordost.streetcomplete.util.sendEmail
 import de.westnordost.streetcomplete.view.ListAdapter
 import kotlinx.android.synthetic.main.cell_labeled_icon_select_right.view.*
 import java.util.*
@@ -98,29 +98,18 @@ class AboutFragment : PreferenceFragmentCompat() {
 
     private fun openUrl(url: String): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-        return tryStartActivity(intent)
+        tryStartActivity(intent)
+        return true
     }
 
     private fun sendFeedbackEmail(): Boolean {
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = "mailto:".toUri()
-        intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("osm@westnordost.de"))
-        intent.putExtra(Intent.EXTRA_SUBJECT, ApplicationConstants.USER_AGENT + " Feedback")
-        return tryStartActivity(intent)
+        sendEmail(requireActivity(),"osm@westnordost.de", "Feedback")
+        return true
     }
 
     private fun openGooglePlayStorePage(): Boolean {
         val appPackageName = context?.applicationContext?.packageName ?: return false
         return openUrl("market://details?id=$appPackageName")
-    }
-
-    private fun tryStartActivity(intent: Intent): Boolean {
-        return try {
-            startActivity(intent)
-            true
-        } catch (e: ActivityNotFoundException) {
-            false
-        }
     }
 
     private fun showDonateDialog() {

--- a/app/src/main/java/de/westnordost/streetcomplete/user/ProfileFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/ProfileFragment.kt
@@ -1,6 +1,5 @@
 package de.westnordost.streetcomplete.user
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -18,6 +17,7 @@ import de.westnordost.streetcomplete.data.quest.UnsyncedChangesCountSource
 import de.westnordost.streetcomplete.data.user.*
 import de.westnordost.streetcomplete.data.user.achievements.UserAchievementsDao
 import de.westnordost.streetcomplete.ktx.createBitmap
+import de.westnordost.streetcomplete.ktx.tryStartActivity
 import kotlinx.android.synthetic.main.fragment_profile.*
 import kotlinx.coroutines.*
 import java.io.File
@@ -164,12 +164,4 @@ class ProfileFragment : Fragment(R.layout.fragment_profile),
         return tryStartActivity(intent)
     }
 
-    private fun tryStartActivity(intent: Intent): Boolean {
-        return try {
-            startActivity(intent)
-            true
-        } catch (e: ActivityNotFoundException) {
-            false
-        }
-    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/CrashReportExceptionHandler.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/CrashReportExceptionHandler.kt
@@ -2,13 +2,9 @@ package de.westnordost.streetcomplete.util
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.core.net.toUri
-import androidx.core.os.bundleOf
-import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.BuildConfig
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.toast
@@ -67,7 +63,7 @@ $error
             .setTitle(titleResourceId)
             .setMessage(R.string.crash_message)
             .setPositiveButton(R.string.crash_compose_email) { _, _ ->
-                sendEmail(activityCtx, report)
+                sendEmail(activityCtx, mailReportTo, "Error Report", report)
             }
             .setNegativeButton(android.R.string.no) { _, _ ->
                 activityCtx.toast("\uD83D\uDE22")
@@ -112,19 +108,4 @@ $stackTrace
         appCtx.deleteFile(crashReportFile)
     }
 
-    private fun sendEmail(activityCtx: Activity, text: String) {
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = "mailto:".toUri()
-        intent.putExtras(bundleOf(
-            Intent.EXTRA_EMAIL to arrayOf(mailReportTo),
-            Intent.EXTRA_SUBJECT to ApplicationConstants.USER_AGENT + " Error Report",
-            Intent.EXTRA_TEXT to text
-        ))
-
-        if (intent.resolveActivity(activityCtx.packageManager) != null) {
-            activityCtx.startActivity(intent)
-        } else {
-            activityCtx.toast(R.string.no_email_client)
-        }
-    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Email.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Email.kt
@@ -1,0 +1,26 @@
+package de.westnordost.streetcomplete.util
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.core.net.toUri
+import de.westnordost.streetcomplete.ApplicationConstants
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.toast
+
+fun sendEmail(activity: Activity, email: String, subject: String, text: String? = null) {
+    val intent = Intent(Intent.ACTION_SENDTO).apply {
+        data = "mailto:".toUri()
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(email))
+        putExtra(Intent.EXTRA_SUBJECT, ApplicationConstants.USER_AGENT + " " + subject)
+        if (text != null) {
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+    }
+
+    try {
+        activity.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        activity.toast(R.string.no_email_client)
+    }
+}


### PR DESCRIPTION
This pull request

- adds a new utility function to send emails, thus unifying the previous two separate implementations for it,
- removes the therefore no longer necessary `SENDTO` `intent` element in the `AndroidManifest`'s `queries` list, and
- removes duplicate `tryStartActivity()` implementations.