### PR TITLE
Extract remaining quest data models

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 
-class AddBoardType : OsmFilterQuestType<String>() {
+class AddBoardType : OsmFilterQuestType<BoardType>() {
 
     override val elementFilter = """
         nodes with information = board
@@ -20,11 +20,11 @@ class AddBoardType : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddBoardTypeForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        if(answer == "map") {
+    override fun applyAnswerTo(answer: BoardType, changes: StringMapChangesBuilder) {
+        if(answer == BoardType.MAP) {
             changes.modify("information", "map")
         } else {
-            changes.addOrModify("board_type", answer)
+            changes.addOrModify("board_type", answer.osmValue)
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
@@ -6,9 +6,10 @@ import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
-import kotlinx.android.synthetic.main.quest_parking_access.*
+import de.westnordost.streetcomplete.quests.board_type.BoardType.*
+import kotlinx.android.synthetic.main.quest_board_type.*
 
-class AddBoardTypeForm : AbstractQuestFormAnswerFragment<String>() {
+class AddBoardTypeForm : AbstractQuestFormAnswerFragment<BoardType>() {
 
     override val defaultExpanded = false
 
@@ -20,7 +21,7 @@ class AddBoardTypeForm : AbstractQuestFormAnswerFragment<String>() {
         AlertDialog.Builder(requireContext())
                 .setTitle(R.string.quest_board_type_map_title)
                 .setMessage(R.string.quest_board_type_map_description)
-                .setPositiveButton(R.string.quest_generic_hasFeature_yes) { _, _ -> applyAnswer("map") }
+                .setPositiveButton(R.string.quest_generic_hasFeature_yes) { _, _ -> applyAnswer(MAP) }
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()
     }
@@ -34,13 +35,13 @@ class AddBoardTypeForm : AbstractQuestFormAnswerFragment<String>() {
 
     override fun onClickOk() {
         applyAnswer(when (radioButtonGroup.checkedRadioButtonId) {
-            R.id.history -> "history"
-            R.id.geology -> "geology"
-            R.id.plants -> "plants"
-            R.id.wildlife -> "wildlife"
-            R.id.nature -> "nature"
-            R.id.public_transport -> "public_transport"
-            R.id.notice -> "notice"
+            R.id.history -> HISTORY
+            R.id.geology -> GEOLOGY
+            R.id.plants -> PLANTS
+            R.id.wildlife -> WILDLIFE
+            R.id.nature -> NATURE
+            R.id.public_transport -> PUBLIC_TRANSPORT
+            R.id.notice -> NOTICE
             else -> throw NullPointerException()
         })
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/BoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/BoardType.kt
@@ -1,0 +1,12 @@
+package de.westnordost.streetcomplete.quests.board_type
+
+enum class BoardType(val osmValue: String) {
+    HISTORY("history"),
+    GEOLOGY("geology"),
+    PLANTS("plants"),
+    WILDLIFE("wildlife"),
+    NATURE("nature"),
+    PUBLIC_TRANSPORT("public_transport"),
+    NOTICE("notice"),
+    MAP("map"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddDietTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddDietTypeForm.kt
@@ -6,11 +6,11 @@ import androidx.core.os.bundleOf
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
-import de.westnordost.streetcomplete.quests.diet_type.DietType.*
+import de.westnordost.streetcomplete.quests.diet_type.DietAvailability.*
 import kotlinx.android.synthetic.main.quest_buttonpanel_yes_no_only.*
 import kotlinx.android.synthetic.main.quest_diet_type_explanation.*
 
-class AddDietTypeForm : AbstractQuestAnswerFragment<DietType>() {
+class AddDietTypeForm : AbstractQuestAnswerFragment<DietAvailability>() {
 
     override val contentLayoutResId = R.layout.quest_diet_type_explanation
     override val buttonsResId = R.layout.quest_buttonpanel_yes_no_only

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddDietTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddDietTypeForm.kt
@@ -6,10 +6,11 @@ import androidx.core.os.bundleOf
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.diet_type.DietType.*
 import kotlinx.android.synthetic.main.quest_buttonpanel_yes_no_only.*
 import kotlinx.android.synthetic.main.quest_diet_type_explanation.*
 
-class AddDietTypeForm : AbstractQuestAnswerFragment<String>() {
+class AddDietTypeForm : AbstractQuestAnswerFragment<DietType>() {
 
     override val contentLayoutResId = R.layout.quest_diet_type_explanation
     override val buttonsResId = R.layout.quest_buttonpanel_yes_no_only
@@ -17,9 +18,9 @@ class AddDietTypeForm : AbstractQuestAnswerFragment<String>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        yesButton.setOnClickListener { applyAnswer("yes") }
-        noButton.setOnClickListener { applyAnswer("no") }
-        onlyButton.setOnClickListener { applyAnswer("only") }
+        yesButton.setOnClickListener { applyAnswer(DIET_YES) }
+        noButton.setOnClickListener { applyAnswer(DIET_NO) }
+        onlyButton.setOnClickListener { applyAnswer(DIET_ONLY) }
 
         val resId = arguments?.getInt(ARG_DIET) ?: 0
         if (resId > 0) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 
-class AddKosher : OsmFilterQuestType<DietType>() {
+class AddKosher : OsmFilterQuestType<DietAvailability>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -27,7 +27,7 @@ class AddKosher : OsmFilterQuestType<DietType>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_kosher)
 
-    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailability, changes: StringMapChangesBuilder) {
         changes.updateWithCheckDate("diet:kosher", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 
-class AddKosher : OsmFilterQuestType<String>() {
+class AddKosher : OsmFilterQuestType<DietType>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -27,7 +27,7 @@ class AddKosher : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_kosher)
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("diet:kosher", answer)
+    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("diet:kosher", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddVegan : OsmFilterQuestType<String>() {
+class AddVegan : OsmFilterQuestType<DietType>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -28,7 +28,7 @@ class AddVegan : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegan)
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("diet:vegan", answer)
+    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("diet:vegan", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddVegan : OsmFilterQuestType<DietType>() {
+class AddVegan : OsmFilterQuestType<DietAvailability>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -28,7 +28,7 @@ class AddVegan : OsmFilterQuestType<DietType>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegan)
 
-    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailability, changes: StringMapChangesBuilder) {
         changes.updateWithCheckDate("diet:vegan", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddVegetarian : OsmFilterQuestType<String>() {
+class AddVegetarian : OsmFilterQuestType<DietType>() {
 
     override val elementFilter = """
         nodes, ways with amenity ~ restaurant|cafe|fast_food
@@ -25,7 +25,7 @@ class AddVegetarian : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegetarian)
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("diet:vegetarian", answer)
+    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("diet:vegetarian", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddVegetarian : OsmFilterQuestType<DietType>() {
+class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
 
     override val elementFilter = """
         nodes, ways with amenity ~ restaurant|cafe|fast_food
@@ -25,7 +25,7 @@ class AddVegetarian : OsmFilterQuestType<DietType>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegetarian)
 
-    override fun applyAnswerTo(answer: DietType, changes: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailability, changes: StringMapChangesBuilder) {
         changes.updateWithCheckDate("diet:vegetarian", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/DietAvailability.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/DietAvailability.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.diet_type
 
-enum class DietType(val osmValue: String) {
+enum class DietAvailability(val osmValue: String) {
     DIET_YES("yes"),
     DIET_NO("no"),
     DIET_ONLY("only"),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/DietType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/DietType.kt
@@ -1,0 +1,7 @@
+package de.westnordost.streetcomplete.quests.diet_type
+
+enum class DietType(val osmValue: String) {
+    DIET_YES("yes"),
+    DIET_NO("no"),
+    DIET_ONLY("only"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddInternetAccess : OsmFilterQuestType<String>() {
+class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with
@@ -32,7 +32,7 @@ class AddInternetAccess : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddInternetAccessForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("internet_access", answer)
+    override fun applyAnswerTo(answer: InternetAccess, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("internet_access", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccessForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccessForm.kt
@@ -23,7 +23,7 @@ class AddInternetAccessForm : AbstractQuestFormAnswerFragment<InternetAccess>() 
     override fun onClickOk() {
         applyAnswer(
             when (radioButtonGroup.checkedRadioButtonId) {
-                R.id.wlan ->     WLAN
+                R.id.wifi ->     WIFI
                 R.id.no ->       NO
                 R.id.terminal -> TERMINAL
                 R.id.wired ->    WIRED

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccessForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccessForm.kt
@@ -5,10 +5,11 @@ import android.view.View
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
+import de.westnordost.streetcomplete.quests.internet_access.InternetAccess.*
 import kotlinx.android.synthetic.main.quest_internet_access.*
 import kotlin.NullPointerException
 
-class AddInternetAccessForm : AbstractQuestFormAnswerFragment<String>() {
+class AddInternetAccessForm : AbstractQuestFormAnswerFragment<InternetAccess>() {
 
     override val defaultExpanded = false
 
@@ -22,10 +23,10 @@ class AddInternetAccessForm : AbstractQuestFormAnswerFragment<String>() {
     override fun onClickOk() {
         applyAnswer(
             when (radioButtonGroup.checkedRadioButtonId) {
-                R.id.wlan ->     "wlan"
-                R.id.no ->       "no"
-                R.id.terminal -> "terminal"
-                R.id.wired ->    "wired"
+                R.id.wlan ->     WLAN
+                R.id.no ->       NO
+                R.id.terminal -> TERMINAL
+                R.id.wired ->    WIRED
                 else -> throw NullPointerException()
             }
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/InternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/InternetAccess.kt
@@ -1,0 +1,8 @@
+package de.westnordost.streetcomplete.quests.internet_access
+
+enum class InternetAccess(val osmValue: String) {
+    WLAN("wlan"),
+    NO("no"),
+    TERMINAL("terminal"),
+    WIRED("wired"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/InternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/InternetAccess.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.internet_access
 
 enum class InternetAccess(val osmValue: String) {
-    WLAN("wlan"),
+    WIFI("wlan"),
     NO("no"),
     TERMINAL("terminal"),
     WIRED("wired"),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddParkingAccess : OsmFilterQuestType<String>() {
+class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
     // Exclude parking=street_side lacking any access tags, because most of
     // these are found alongside public access roads, and likely will be
@@ -30,7 +30,7 @@ class AddParkingAccess : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddParkingAccessForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.addOrModify("access", answer)
+    override fun applyAnswerTo(answer: ParkingAccess, changes: StringMapChangesBuilder) {
+        changes.addOrModify("access", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccessForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccessForm.kt
@@ -5,9 +5,10 @@ import android.view.View
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
+import de.westnordost.streetcomplete.quests.parking_access.ParkingAccess.*
 import kotlinx.android.synthetic.main.quest_parking_access.*
 
-class AddParkingAccessForm : AbstractQuestFormAnswerFragment<String>() {
+class AddParkingAccessForm : AbstractQuestFormAnswerFragment<ParkingAccess>() {
 
     override val contentLayoutResId = R.layout.quest_parking_access
 
@@ -18,9 +19,9 @@ class AddParkingAccessForm : AbstractQuestFormAnswerFragment<String>() {
 
     override fun onClickOk() {
         applyAnswer(when (radioButtonGroup.checkedRadioButtonId) {
-            R.id.yes            -> "yes"
-            R.id.customers      -> "customers"
-            R.id.private_access -> "private"
+            R.id.yes            -> YES
+            R.id.customers      -> CUSTOMERS
+            R.id.private_access -> PRIVATE
             else -> throw NullPointerException()
         })
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/ParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/ParkingAccess.kt
@@ -1,0 +1,7 @@
+package de.westnordost.streetcomplete.quests.parking_access
+
+enum class ParkingAccess(val osmValue: String) {
+    YES("yes"),
+    CUSTOMERS("customers"),
+    PRIVATE("private"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddWayLit : OsmFilterQuestType<String>() {
+class AddWayLit : OsmFilterQuestType<WayLit>() {
 
     /* Using sidewalk as a tell-tale tag for (urban) streets which reached a certain level of
        development. I.e. non-urban streets will usually not even be lit in industrialized
@@ -57,8 +57,8 @@ class AddWayLit : OsmFilterQuestType<String>() {
 
     override fun createForm() = WayLitForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("lit", answer)
+    override fun applyAnswerTo(answer: WayLit, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("lit", answer.osmValue)
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLit.kt
@@ -1,0 +1,10 @@
+package de.westnordost.streetcomplete.quests.way_lit
+
+enum class WayLit(val osmValue: String) {
+    NIGHT_AND_DAY("24/7"),
+    AUTOMATIC("automatic"),
+    YES("yes"),
+    NO("no"),
+}
+
+fun Boolean.toWayLit(): WayLit = if (this) WayLit.YES else WayLit.NO

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
@@ -1,18 +1,18 @@
 package de.westnordost.streetcomplete.quests.way_lit
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.AYesNoQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.way_lit.WayLit.*
 import de.westnordost.streetcomplete.quests.OtherAnswer
 
-class WayLitForm : AYesNoQuestAnswerFragment<String>() {
+class WayLitForm : AYesNoQuestAnswerFragment<WayLit>() {
 
     override val otherAnswers = listOf(
-        OtherAnswer(R.string.quest_way_lit_24_7) { applyAnswer("24/7") },
-        OtherAnswer(R.string.quest_way_lit_automatic) { applyAnswer("automatic") }
+        OtherAnswer(R.string.quest_way_lit_24_7) { applyAnswer(NIGHT_AND_DAY) },
+        OtherAnswer(R.string.quest_way_lit_automatic) { applyAnswer(AUTOMATIC) }
     )
 
     override fun onClick(answer: Boolean) {
-        applyAnswer(answer.toYesNo())
+        applyAnswer(answer.toWayLit())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.FutureTask
 
 class AddWheelchairAccessBusiness(
     private val featureDictionaryFuture: FutureTask<FeatureDictionary>
-) : OsmFilterQuestType<String>()
+) : OsmFilterQuestType<WheelchairAccess>()
 {
     override val elementFilter = """
         nodes, ways, relations with
@@ -98,8 +98,8 @@ class AddWheelchairAccessBusiness(
 
     override fun createForm() = AddWheelchairAccessBusinessForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.add("wheelchair", answer)
+    override fun applyAnswerTo(answer: WheelchairAccess, changes: StringMapChangesBuilder) {
+        changes.add("wheelchair", answer.osmValue)
     }
 
     private fun hasFeatureName(tags: Map<String, String>?): Boolean =

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddWheelchairAccessOutside : OsmFilterQuestType<String>() {
+class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with leisure = dog_park
@@ -19,7 +19,7 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddWheelchairAccessOutsideForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("wheelchair", answer)
+    override fun applyAnswerTo(answer: WheelchairAccess, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddWheelchairAccessPublicTransport : OsmFilterQuestType<String>() {
+class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with (amenity = bus_station or railway ~ station|subway_entrance)
@@ -42,7 +42,7 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddWheelchairAccessPublicTransportForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("wheelchair", answer)
+    override fun applyAnswerTo(answer: WheelchairAccess, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddWheelchairAccessToilets : OsmFilterQuestType<String>() {
+class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways with amenity = toilets
@@ -29,7 +29,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("wheelchair", answer)
+    override fun applyAnswerTo(answer: WheelchairAccess, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 
-class AddWheelchairAccessToiletsPart : OsmFilterQuestType<String>() {
+class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with name and toilets = yes
@@ -25,7 +25,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.updateWithCheckDate("toilets:wheelchair", answer)
+    override fun applyAnswerTo(answer: WheelchairAccess, changes: StringMapChangesBuilder) {
+        changes.updateWithCheckDate("toilets:wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccess.kt
@@ -1,0 +1,7 @@
+package de.westnordost.streetcomplete.quests.wheelchair_access
+
+enum class WheelchairAccess(val osmValue: String) {
+    YES("yes"),
+    LIMITED("limited"),
+    NO("no"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccessAnswerForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccessAnswerForm.kt
@@ -5,17 +5,18 @@ import android.view.View
 import de.westnordost.streetcomplete.R
 
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.wheelchair_access.WheelchairAccess.*
 import kotlinx.android.synthetic.main.quest_buttonpanel_yes_limited_no.*
 
-open class WheelchairAccessAnswerForm : AbstractQuestAnswerFragment<String>() {
+open class WheelchairAccessAnswerForm : AbstractQuestAnswerFragment<WheelchairAccess>() {
 
     override val buttonsResId = R.layout.quest_buttonpanel_yes_limited_no
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        yesButton.setOnClickListener { applyAnswer("yes") }
-        limitedButton.setOnClickListener { applyAnswer("limited") }
-        noButton.setOnClickListener { applyAnswer("no") }
+        yesButton.setOnClickListener { applyAnswer(YES) }
+        limitedButton.setOnClickListener { applyAnswer(LIMITED) }
+        noButton.setOnClickListener { applyAnswer(NO) }
     }
 }

--- a/app/src/main/res/layout/quest_internet_access.xml
+++ b/app/src/main/res/layout/quest_internet_access.xml
@@ -6,7 +6,7 @@
     android:id="@+id/radioButtonGroup" >
 
     <RadioButton
-        android:id="@+id/wlan"
+        android:id="@+id/wifi"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"


### PR DESCRIPTION
Follow-up to #2501. References #2494.

Now the only quests extending `OsmFilterQuestType<String>` are those with a free-text input field (with suggestions), namely `AddAtmOperator` and `AddChargingStationOperator`.