### PR TITLE
Exclude strictly vegetarian/vegan places from kosher quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -13,6 +13,7 @@ class AddKosher : OsmFilterQuestType<String>() {
           amenity ~ restaurant|cafe|fast_food|ice_cream
           or shop ~ butcher|supermarket|ice_cream
         )
+        and diet:vegetarian != only and diet:vegan != only
         and name and (
           !diet:kosher
           or diet:kosher != only and diet:kosher older today -4 years


### PR DESCRIPTION
Because of https://wiki.openstreetmap.org/wiki/Key:diet:

> Places tagged as strictly vegetarian or vegan should be implicitly understood by renderers as also being kosher and halal. 