### PR TITLE
Ask for roof shape for all buildings with levels (except in low-rainfall countries)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -30,8 +30,10 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
     override fun getApplicableElements(mapData: MapDataWithGeometry) =
         mapData.filter {
             filter.matches(it) && (
-                it.tags?.get("roof:levels") != "0" ||
-                roofsAreUsuallyFlatAt(it, mapData) == false
+                (
+                    it.tags?.get("roof:levels") != null &&
+                    it.tags?.get("roof:levels") != "0"
+                ) || roofsAreUsuallyFlatAt(it, mapData) == false
             )
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
 class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType<RoofShape> {
 
     private val filter by lazy { """
-        ways, relations with building ~ ${BUILDINGS_WITH_ROOFS.joinToString("|")}
+        ways, relations with (building:levels or roof:levels)
           and !roof:shape and !3dr:type and !3dr:roof
     """.toElementFilterExpression() }
 
@@ -49,10 +49,3 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
         return countryInfos.get(center.longitude, center.latitude).isRoofsAreUsuallyFlat
     }
 }
-
-private val BUILDINGS_WITH_ROOFS = arrayOf(
-    "house","residential","apartments","detached","terrace","dormitory","semi",
-    "semidetached_house","bungalow","school","civic","college","university","public",
-    "hospital","kindergarten","transportation","train_station", "hotel","retail",
-    "commercial","office","industrial","manufacture","parking","farm","farm_auxiliary",
-    "cabin")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -30,10 +30,8 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
     override fun getApplicableElements(mapData: MapDataWithGeometry) =
         mapData.filter {
             filter.matches(it) && (
-                (
-                    it.tags?.get("roof:levels") != null &&
-                    it.tags?.get("roof:levels") != "0"
-                ) || roofsAreUsuallyFlatAt(it, mapData) == false
+                it.tags?.get("roof:levels") ?: "0" != "0"
+                || roofsAreUsuallyFlatAt(it, mapData) == false
             )
         }
 
@@ -42,7 +40,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
         // if it has 0 roof levels, or the roof levels aren't specified,
         // the quest should only be shown in certain countries. But whether
         // the element is in a certain country cannot be ascertained at this point
-        if (element.tags?.get("roof:levels") == "0") return null
+        if (element.tags?.get("roof:levels") ?: "0" == "0") return null
         return true
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -11,8 +11,8 @@ import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
 class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType<RoofShape> {
 
     private val filter by lazy { """
-        ways, relations with
-          roof:levels and !roof:shape and !3dr:type and !3dr:roof
+        ways, relations with with building ~ ${BUILDINGS_WITH_ROOFS.joinToString("|")}
+          and !roof:shape and !3dr:type and !3dr:roof
     """.toElementFilterExpression() }
 
     override val commitMessage = "Add roof shapes"
@@ -37,7 +37,8 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
 
     override fun isApplicableTo(element: Element): Boolean? {
         if (!filter.matches(element)) return false
-        // if it has 0 roof levels, the quest should only be shown in certain countries. But whether
+        // if it has 0 roof levels, or the roof levels aren't specified,
+        // the quest should only be shown in certain countries. But whether
         // the element is in a certain country cannot be ascertained at this point
         if (element.tags?.get("roof:levels") == "0") return null
         return true
@@ -48,3 +49,10 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
         return countryInfos.get(center.longitude, center.latitude).isRoofsAreUsuallyFlat
     }
 }
+
+private val BUILDINGS_WITH_ROOFS = arrayOf(
+    "house","residential","apartments","detached","terrace","dormitory","semi",
+    "semidetached_house","bungalow","school","civic","college","university","public",
+    "hospital","kindergarten","transportation","train_station", "hotel","retail",
+    "commercial","office","industrial","manufacture","parking","farm","farm_auxiliary",
+    "cabin")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
 class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType<RoofShape> {
 
     private val filter by lazy { """
-        ways, relations with with building ~ ${BUILDINGS_WITH_ROOFS.joinToString("|")}
+        ways, relations with building ~ ${BUILDINGS_WITH_ROOFS.joinToString("|")}
           and !roof:shape and !3dr:type and !3dr:roof
     """.toElementFilterExpression() }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
@@ -5,6 +5,7 @@ import de.westnordost.osmapi.map.data.OsmWay
 import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.meta.CountryInfos
 import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementPointGeometry
+import de.westnordost.streetcomplete.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.mock
 import de.westnordost.streetcomplete.on
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
@@ -41,6 +42,12 @@ class AddRoofShapeTest {
         ))
     }
 
+    @Test fun `unknown if applicable to roofs with no roof levels tag`() {
+        assertEquals(null, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "5"))
+        ))
+    }
+
     @Test fun `create quest for roofs`() {
         val element = OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "1"))
 
@@ -49,7 +56,7 @@ class AddRoofShapeTest {
         assertEquals(element, quests.single())
     }
 
-    @Test fun `create quest for 0-level roofs only in countries with no flat roofs`() {
+    @Test fun `create quest for 0 or null-level roofs only in countries with no flat roofs`() {
         val noFlatRoofs = CountryInfo()
         val field = noFlatRoofs.javaClass.getDeclaredField("roofsAreUsuallyFlat")
         field.isAccessible = true
@@ -57,16 +64,18 @@ class AddRoofShapeTest {
 
         on(countryInfos.get(anyDouble(), anyDouble())).thenReturn(noFlatRoofs)
         val element = OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "0"))
+        val element2 = OsmWay(2L, 1, listOf(), mapOf("building:levels" to "3"))
 
-        val mapData = TestMapDataWithGeometry(listOf(element))
+        val mapData = TestMapDataWithGeometry(listOf(element, element2))
         mapData.wayGeometriesById[1L] = ElementPointGeometry(OsmLatLon(0.0,0.0))
+        mapData.wayGeometriesById[2L] = ElementPointGeometry(OsmLatLon(0.0,0.0))
 
         val quests = questType.getApplicableElements(mapData)
 
-        assertEquals(element, quests.single())
+        assertTrue(quests.containsExactlyInAnyOrder(listOf(element, element2)))
     }
 
-    @Test fun `create quest for 0-level roofs not in countries with flat roofs`() {
+    @Test fun `create quest for 0 or null-level roofs not in countries with flat roofs`() {
         val flatRoofs = CountryInfo()
         val field = flatRoofs.javaClass.getDeclaredField("roofsAreUsuallyFlat")
         field.isAccessible = true
@@ -74,9 +83,11 @@ class AddRoofShapeTest {
 
         on(countryInfos.get(anyDouble(), anyDouble())).thenReturn(flatRoofs)
         val element = OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "0"))
+        val element2 = OsmWay(2L, 1, listOf(), mapOf("building:levels" to "3"))
 
-        val mapData = TestMapDataWithGeometry(listOf(element))
+        val mapData = TestMapDataWithGeometry(listOf(element, element2))
         mapData.wayGeometriesById[1L] = ElementPointGeometry(OsmLatLon(0.0,0.0))
+        mapData.wayGeometriesById[2L] = ElementPointGeometry(OsmLatLon(0.0,0.0))
 
         val quests = questType.getApplicableElements(mapData)
 


### PR DESCRIPTION
As the value of `roof:levels` is no longer important for the `roof:shape` quest (except in low-rainfall countries), and as StreetComplete does not require `roof:levels` to be specified in the `building:levels` quest, I thought it would make sense to include buildings with no `roof:levels` tag in the `roof:shape` quest.

In order to not show this quest for all buildings, I have limited the quest to buildings that have had either the `building:levels` or the `roof:levels` tagged with some value.

For low rainfall countries, I think it should only show up if `roof:levels` exists and is not `0` - but I haven't tested this.