### PR TITLE
Repeat last answer for sidewalk/bicycle lane

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/StreetSideRotater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/StreetSideRotater.kt
@@ -11,7 +11,8 @@ import de.westnordost.streetcomplete.view.StreetRotateable
 class StreetSideRotater(
     private val puzzle: StreetRotateable,
     private val compassView: View,
-    geometry: ElementPolylinesGeometry
+    geometry: ElementPolylinesGeometry,
+    private val lastAnswerButton: StreetRotateable? = null
 ) {
     private val wayOrientationAtCenter = geometry.getOrientationAtCenterLineInDegrees()
     private val uiHandler = Handler(Looper.getMainLooper())
@@ -28,6 +29,7 @@ class StreetSideRotater(
         puzzle.setStreetRotation(wayOrientationAtCenter + rotation.toDegrees())
         compassView.rotation = rotation.toDegrees()
         compassView.rotationX = tilt.toDegrees()
+        lastAnswerButton?.setStreetRotation(wayOrientationAtCenter + rotation.toDegrees())
     }
 
     private fun Float.toDegrees() = (180 * this / Math.PI).toFloat()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
@@ -26,7 +26,6 @@ class AddSidewalkForm : AbstractQuestFormAnswerFragment<SidewalkAnswer>() {
     override val contentPadding = false
 
     private var streetSideRotater: StreetSideRotater? = null
-    private var rotateTheButton: StreetSideRotater? = null
     private var leftSide: Sidewalk? = null
     private var rightSide: Sidewalk? = null
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
@@ -46,11 +46,8 @@ class AddSidewalkForm : AbstractQuestFormAnswerFragment<SidewalkAnswer>() {
             if (isLeftHandTraffic) R.drawable.ic_sidewalk_unknown_l
             else                   R.drawable.ic_sidewalk_unknown
 
-        PickLastLeftRightButton.isGone = LAST_ANSWER_LEFT == null
-        if (LAST_ANSWER_LEFT != null) {
-            PickLastLeftRightButton.leftSideContainer.isClickable = false
-            PickLastLeftRightButton.rightSideContainer.isClickable = false
-
+        PickLastLeftRightButton.isGone = (LAST_ANSWER_LEFT == null).and(LAST_ANSWER_RIGHT == null)
+        if (!(LAST_ANSWER_LEFT == null).and(LAST_ANSWER_RIGHT == null)) {
             PickLastLeftRightButton.setLeftSideImage(ResImage(LAST_ANSWER_LEFT?.puzzleResId ?: defaultResId))
             PickLastLeftRightButton.setRightSideImage(ResImage(LAST_ANSWER_RIGHT?.puzzleResId ?: defaultResId))
 
@@ -64,8 +61,8 @@ class AddSidewalkForm : AbstractQuestFormAnswerFragment<SidewalkAnswer>() {
                     PickLastLeftRightButton.visibility = View.GONE
                 }
                 else{
-                    PickLastLeftRightButton.replaceLeftSideImage(ResImage(rightSide?.puzzleResId ?: defaultResId))
-                    PickLastLeftRightButton.replaceRightSideImage(ResImage(leftSide?.puzzleResId ?: defaultResId))
+                    PickLastLeftRightButton.setLeftSideImage(ResImage(rightSide?.puzzleResId ?: defaultResId))
+                    PickLastLeftRightButton.setRightSideImage(ResImage(leftSide?.puzzleResId ?: defaultResId))
                     LAST_ANSWER_LEFT = rightSide
                     LAST_ANSWER_RIGHT = leftSide
                 }
@@ -75,7 +72,7 @@ class AddSidewalkForm : AbstractQuestFormAnswerFragment<SidewalkAnswer>() {
 
         puzzleView.onClickSideListener = { isRight -> showSidewalkSelectionDialog(isRight) }
 
-        streetSideRotater = StreetSideRotater(puzzleView, compassNeedleView, elementGeometry as ElementPolylinesGeometry, PickLastLeftRightButton)
+        streetSideRotater = StreetSideRotater(puzzleView, compassNeedleView, elementGeometry as ElementPolylinesGeometry)
 
         puzzleView.setLeftSideImage(ResImage(leftSide?.puzzleResId ?: defaultResId))
         puzzleView.setRightSideImage(ResImage(rightSide?.puzzleResId ?: defaultResId))

--- a/app/src/main/java/de/westnordost/streetcomplete/view/StreetSideButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/StreetSideButton.kt
@@ -1,0 +1,97 @@
+package de.westnordost.streetcomplete.view
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.drawable.BitmapDrawable
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.doOnPreDraw
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.getBitmapDrawable
+import kotlinx.android.synthetic.main.side_select_puzzle.view.*
+import kotlinx.android.synthetic.main.view_road_left_right_button.view.*
+import kotlin.math.max
+import kotlin.math.min
+
+class StreetSideButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private var leftImage: Image? = null
+    private var rightImage: Image? = null
+    private var isLeftImageSet: Boolean = false
+    private var isRightImageSet: Boolean = false
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.view_road_left_right_button, this, true)
+        doOnPreDraw {
+            buttonLeftSideImage.pivotX = buttonLeftSideContainer.width.toFloat()
+            buttonRightSideImage.pivotX = 0f
+        }
+
+//        addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+//            val width = right - left
+//            val height = bottom - top
+//            val params = buttonContainer.layoutParams
+//            if(width != params.width || height != params.height) {
+//                params.width = width
+//                params.height = height
+//                buttonContainer.layoutParams = params
+//            }
+//
+//            val streetWidth = width / 2
+//            val leftImage = leftImage
+//            if (!isLeftImageSet && leftImage != null) {
+//                setStreetDrawable(leftImage, streetWidth, buttonLeftSideImage, true)
+//                isLeftImageSet = true
+//            }
+//            val rightImage = rightImage
+//            if (!isRightImageSet && rightImage != null) {
+//                setStreetDrawable(rightImage, streetWidth, buttonRightSideImage, false)
+//                isRightImageSet = true
+//            }
+//        }
+    }
+
+    fun setLeftSideImage(image: Image?) {
+        leftImage = image
+        replace(image, buttonLeftSideImage, true)
+    }
+
+    fun setRightSideImage(image: Image?) {
+        rightImage = image
+        replace(image, buttonRightSideImage, false)
+    }
+
+    private fun replace(image: Image?, imgView: ImageView, flip180Degrees: Boolean) {
+        val width = buttonContainer.width / 2
+        if (width == 0) return
+        setStreetDrawable(image, width, imgView, flip180Degrees)
+    }
+
+    private fun setStreetDrawable(image: Image?, width: Int, imageView: ImageView, flip180Degrees: Boolean) {
+        if (image == null) {
+            imageView.setImageDrawable(null)
+        } else {
+            val drawable = scaleToWidth(resources.getBitmapDrawable(image), width, flip180Degrees)
+            imageView.setImageDrawable(drawable)
+        }
+    }
+
+    private fun scaleToWidth(drawable: BitmapDrawable, width: Int, flip180Degrees: Boolean): BitmapDrawable {
+        val m = Matrix()
+        val scale = width.toFloat() / drawable.intrinsicWidth
+        m.postScale(scale, scale)
+        if (flip180Degrees) m.postRotate(180f)
+        val bitmap = Bitmap.createBitmap(
+            drawable.bitmap, 0, 0,
+            drawable.intrinsicWidth, drawable.intrinsicHeight, m, true
+        )
+        return BitmapDrawable(resources, bitmap)
+    }
+}

--- a/app/src/main/res/layout/quest_street_side_puzzle.xml
+++ b/app/src/main/res/layout/quest_street_side_puzzle.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -30,5 +31,15 @@
 
         <!-- note the other compass in fragment_main -->
         <include layout="@layout/view_little_compass"/>
+
+        <de.westnordost.streetcomplete.view.StreetSideSelectPuzzle
+            android:id="@+id/PickLastLeftRightButton"
+            style="@style/Widget.AppCompat.Button.Small"
+            android:layout_width="wrap_content"
+            android:layout_height="100dp"
+            android:layout_alignBottom="@id/puzzleView"
+            android:layout_alignParentRight="true" />
+
     </RelativeLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/quest_street_side_puzzle.xml
+++ b/app/src/main/res/layout/quest_street_side_puzzle.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -32,13 +33,14 @@
         <!-- note the other compass in fragment_main -->
         <include layout="@layout/view_little_compass"/>
 
-        <de.westnordost.streetcomplete.view.StreetSideSelectPuzzle
+        <de.westnordost.streetcomplete.view.StreetSideButton
             android:id="@+id/PickLastLeftRightButton"
             style="@style/Widget.AppCompat.Button.Small"
-            android:layout_width="wrap_content"
+            android:layout_width="150dp"
             android:layout_height="100dp"
             android:layout_alignBottom="@id/puzzleView"
-            android:layout_alignParentRight="true" />
+            android:layout_alignParentRight="true"
+            tools:ignore="RtlHardcoded"/>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/view_road_left_right_button.xml
+++ b/app/src/main/res/layout/view_road_left_right_button.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <RelativeLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <View
+            android:id="@+id/buttonStrut"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_centerHorizontal="true" />
+
+        <RelativeLayout
+            android:id="@+id/buttonLeftSideContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignParentLeft="true"
+            android:layout_toLeftOf="@id/buttonStrut"
+            android:clickable="false"
+            tools:ignore="RtlHardcoded">
+
+            <ImageView
+                android:id="@+id/buttonLeftSideImage"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentLeft="true"
+                android:scaleType="fitXY"
+                tools:src="@drawable/ic_cycleway_track"
+                tools:ignore="RtlHardcoded"/>
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/buttonRightSideContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignParentRight="true"
+            android:layout_toRightOf="@id/buttonStrut"
+            android:clickable="false"
+            tools:ignore="RtlHardcoded">
+
+            <ImageView
+                android:id="@+id/buttonRightSideImage"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentLeft="true"
+                android:scaleType="fitXY"
+                tools:src="@drawable/ic_cycleway_sidewalk"
+                tools:ignore="RtlHardcoded"/>
+        </RelativeLayout>
+
+    </RelativeLayout>
+</merge>


### PR DESCRIPTION
fixes #2542 

Here's a first attempt at adding a 'repeat last answer' button for quests about sides of the road.

So far I've just added it for the sidewalks quest as that seemed like a simple place to start, because it only has yes or no options for each side of the road.

Before pressing the button:
![image](https://user-images.githubusercontent.com/77166354/108238510-ed6b2600-7140-11eb-818c-1dcb11f4f339.png)
After pressing the button:
![image](https://user-images.githubusercontent.com/77166354/108238515-f0661680-7140-11eb-945c-354c11ab968b.png)


Done:
The button shows up only if you have answered the quest in this session and tapping it puts the values into the form.
Tapping it then swaps the button over so that a second tap would swap the sides of the road over (but only if there's a different answer for each side).
The button rotates with the map (the same as the compass and main puzzle bit do)

Still to do:
Make the button look better, it's not as clear as it could be right now because it's sort of too wide for the button. I could do with some help here.
Move the button (possibly only once it's been pressed) so that it doesn't overlap the OK button, again could probably do with some help/pointers here.

Once this seems ok I'll then look at the bicycle lane quest (they use the same layout so at the moment a blank button shows up). But it will use basically the same code so actually I'll look to separate the code out so they can both use it (and any other quests now or in the future, as appropriate).