### PR TITLE
Canary Islands has very different climates, biomes and culture

### DIFF
--- a/res/country_metadata/orchardProduces.yml
+++ b/res/country_metadata/orchardProduces.yml
@@ -59,6 +59,7 @@ EC: [banana, cacao, pineapple, orange, guava, mango, mangosteen, tomato, papaya,
 EE: [apple, tomato, strawberry, plum, raspberry, cherry]
 EG: [tomato, grape, date, guava, mango, mangosteen, banana, orange, olive, apple, strawberry, peach, lemon, lime, fig, apricot, pear, chilli_pepper, sweet_pepper]
 ES: [olive, grape, tomato, orange, peach, chilli_pepper, sweet_pepper, lemon, lime, apple, banana, strawberry, persimmon, pear, almond, plum, apricot]
+ES-CN: [olive, grape, tomato, orange, peach, chilli_pepper, sweet_pepper, lemon, lime, apple, banana, strawberry, persimmon, pear, almond, plum, apricot, pineapple, mango, avocado, chestnut, fig]
 ET: [banana, coffee, chilli_pepper, sweet_pepper, guava, mango, mangosteen, avocado, papaya, hop, tomato, orange, tea, pineapple, lemon, lime, grape, pepper, sisal]
 FI: [tomato, strawberry, apple, raspberry, chilli_pepper, sweet_pepper]
 FJ: [coconut, pineapple, banana, papaya, tomato, guava, mango, mangosteen, pepper, chilli_pepper, sweet_pepper, orange, coffee, cacao]

--- a/res/country_metadata/orchardProduces.yml
+++ b/res/country_metadata/orchardProduces.yml
@@ -59,7 +59,7 @@ EC: [banana, cacao, pineapple, orange, guava, mango, mangosteen, tomato, papaya,
 EE: [apple, tomato, strawberry, plum, raspberry, cherry]
 EG: [tomato, grape, date, guava, mango, mangosteen, banana, orange, olive, apple, strawberry, peach, lemon, lime, fig, apricot, pear, chilli_pepper, sweet_pepper]
 ES: [olive, grape, tomato, orange, peach, chilli_pepper, sweet_pepper, lemon, lime, apple, banana, strawberry, persimmon, pear, almond, plum, apricot]
-ES-CN: [olive, grape, tomato, orange, peach, chilli_pepper, sweet_pepper, lemon, lime, apple, banana, strawberry, persimmon, pear, almond, plum, apricot, pineapple, mango, avocado, chestnut, fig]
+IC: [olive, grape, tomato, orange, peach, chilli_pepper, sweet_pepper, lemon, lime, apple, banana, strawberry, persimmon, pear, almond, plum, apricot, pineapple, mango, avocado, chestnut, fig]
 ET: [banana, coffee, chilli_pepper, sweet_pepper, guava, mango, mangosteen, avocado, papaya, hop, tomato, orange, tea, pineapple, lemon, lime, grape, pepper, sisal]
 FI: [tomato, strawberry, apple, raspberry, chilli_pepper, sweet_pepper]
 FJ: [coconut, pineapple, banana, papaya, tomato, guava, mango, mangosteen, pepper, chilli_pepper, sweet_pepper, orange, coffee, cacao]

--- a/res/country_metadata/popularSports.yml
+++ b/res/country_metadata/popularSports.yml
@@ -22,6 +22,7 @@ CZ: [soccer, tennis, volleyball, beachvolleyball, ice_hockey, handball]
 DE: [soccer, tennis, equestrian]
 DO: [baseball, basketball, tennis]
 ES: [soccer, tennis, basketball, golf, paddle_tennis, pelota]
+ES-CN: [soccer, tennis, basketball, golf, paddle_tennis, pelota, wrestling, boules] # wrestling is lucha_canaria, boules is bola_canaria
 FI: [soccer, tennis, basketball, beachvolleyball, shooting, ice_hockey]
 FR: [soccer, tennis, basketball, boules, equestrian, rugby]
 GB: [soccer, tennis, bowls, cricket, golf, basketball, rugby]

--- a/res/country_metadata/popularSports.yml
+++ b/res/country_metadata/popularSports.yml
@@ -22,7 +22,6 @@ CZ: [soccer, tennis, volleyball, beachvolleyball, ice_hockey, handball]
 DE: [soccer, tennis, equestrian]
 DO: [baseball, basketball, tennis]
 ES: [soccer, tennis, basketball, golf, paddle_tennis, pelota]
-ES-CN: [soccer, tennis, basketball, golf, paddle_tennis, pelota, wrestling, boules] # wrestling is lucha_canaria, boules is bola_canaria
 FI: [soccer, tennis, basketball, beachvolleyball, shooting, ice_hockey]
 FR: [soccer, tennis, basketball, boules, equestrian, rugby]
 GB: [soccer, tennis, bowls, cricket, golf, basketball, rugby]


### PR DESCRIPTION
Canary Islands has very different climates and biomes compared to
mainland Spain: The vulcanic land surface ranges from sealevel to 3718
meters above sealevel, and is located 1000 km south of mainland Spain,
very close to Sahara, therefore they have (also) different
produces.
And Canary Islands have also quite a different culture, therefore very
common regional sports pitches on all seven islands.

Therefore I added some country_metadata for the country subdivision ES-CN, because the most important (and most common) produces and sports were missing.