### PR TITLE
document case where comma is needed

### DIFF
--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
@@ -22,7 +22,22 @@ class AddPostboxCollectionTimesTest {
                 WeekdaysTimes(Weekdays(booleanArrayOf(true)), mutableListOf(60)),
                 WeekdaysTimes(Weekdays(booleanArrayOf(false, true)), mutableListOf(120))
             )),
+            // here ; would be fine as well instead of ;
+            // see https://github.com/streetcomplete/StreetComplete/pull/2604#issuecomment-783823068
             StringMapEntryAdd("collection_times", "Mo 01:00, Tu 02:00")
+        )
+    }
+
+    // for non-overlapping day ranges it does not matter whether
+    // comma or semicolon is used - but for overlapping ones it matters
+    // see https://github.com/streetcomplete/StreetComplete/pull/2604#issuecomment-783823068
+    @Test fun `require comma where this matters`() {
+        questType.verifyAnswer(
+            CollectionTimes(listOf(
+                WeekdaysTimes(Weekdays(booleanArrayOf(true, true, true)), mutableListOf(60)),
+                WeekdaysTimes(Weekdays(booleanArrayOf(false, true)), mutableListOf(120))
+            )),
+            StringMapEntryAdd("collection_times", "Mo-We 01:00, Tu 02:00")
         )
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
@@ -22,7 +22,7 @@ class AddPostboxCollectionTimesTest {
                 WeekdaysTimes(Weekdays(booleanArrayOf(true)), mutableListOf(60)),
                 WeekdaysTimes(Weekdays(booleanArrayOf(false, true)), mutableListOf(120))
             )),
-            // here ; would be fine as well instead of ;
+            // here ; would be fine as well instead of ,
             // see https://github.com/streetcomplete/StreetComplete/pull/2604#issuecomment-783823068
             StringMapEntryAdd("collection_times", "Mo 01:00, Tu 02:00")
         )

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
@@ -41,4 +41,14 @@ class AddPostboxCollectionTimesTest {
         )
     }
 
+    @Test fun `require comma where this matters and conflict is between nonadjacent ranges`() {
+        questType.verifyAnswer(
+            CollectionTimes(listOf(
+                WeekdaysTimes(Weekdays(booleanArrayOf(true, true, true)), mutableListOf(60)),
+                WeekdaysTimes(Weekdays(booleanArrayOf(false, false, false, true, true, true, true)), mutableListOf(120)),
+                WeekdaysTimes(Weekdays(booleanArrayOf(true)), mutableListOf(180))
+            )),
+            StringMapEntryAdd("collection_times", "Mo-We 01:00, Th-Su 02:00, Mo 03:00")
+        )
+    }
 }


### PR DESCRIPTION
also, mention that for simple cases semicolons are fine, as long as it is not breaking complex cases

I added test for overlapping ranges so @TurnrDev  and other people interested in moving from `,` to `;` will know what is the actual blocker.

Not committing directly as apparently people have strong feelings about this topic and would be nice to check whatever I missed something.

This change has no effect on how StreetComplete behaves, it is only documentation of case where "lets replace all commas with semicolons for day range separation" breaks down.