### PR TITLE
Support cycleway=separate (fixes #2525)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.kt
@@ -228,6 +228,9 @@ class AddCycleway : OsmElementQuestType<CyclewayAnswer> {
             BUSWAY -> {
                 changes.addOrModify(cyclewayKey, "share_busway")
             }
+            SEPARATE -> {
+                changes.addOrModify(cyclewayKey, "separate")
+            }
             else -> {
                 throw IllegalArgumentException("Invalid cycleway")
             }
@@ -259,7 +262,6 @@ class AddCycleway : OsmElementQuestType<CyclewayAnswer> {
         changes.deleteIfExists("$cyclewayKey:oneway")
         changes.deleteIfExists("$cyclewayKey:segregated")
         changes.deleteIfExists("sidewalk$sideVal:bicycle")
-
     }
 
     companion object {
@@ -272,7 +274,7 @@ class AddCycleway : OsmElementQuestType<CyclewayAnswer> {
           - if already tagged, if not older than 8 years or if the cycleway tag uses some unknown value
         */
 
-        // streets what may have cycleway tagging
+        // streets that may have cycleway tagging
         private val roadsFilter by lazy { """
             ways with
               highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service
@@ -345,6 +347,7 @@ class AddCycleway : OsmElementQuestType<CyclewayAnswer> {
             "opposite_track",        // + cycleway:left=track
             "opposite_share_busway", // + cycleway:left=share_busway
             "opposite",              // + cycleway:left=no
+            // treat "separate" as unknown because we do not want to let users check that again
             // ambiguous:
             "yes",   // unclear what type
             "left",  // unclear what type; wrong tagging scheme (sidewalk=left)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/Cycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/Cycleway.kt
@@ -42,6 +42,9 @@ enum class Cycleway {
     // none, but oneway road is not oneway for cyclists (sometimes has pictograms)
     NONE_NO_ONEWAY,
 
+    // cycleway is mapped as a separate way
+    SEPARATE,
+
     // unknown cycleway tag set
     UNKNOWN
 ;

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayItem.kt
@@ -16,12 +16,12 @@ fun Cycleway.isAvailableAsSelection(countryCode: String): Boolean =
     /* unspecified lanes are only ok in Belgium (no distinction made, all lanes are dashed) */
     && (this != UNSPECIFIED_LANE || countryCode == "BE")
 
-fun Cycleway.asItem(isLeftHandTraffic: Boolean) : Item<Cycleway> {
-    if(this == NONE) {
-        return Item(this, R.drawable.ic_cycleway_none_in_selection, getTitleResId())
+fun Cycleway.asItem(isLeftHandTraffic: Boolean) =
+    when(this) {
+        NONE -> Item(this, R.drawable.ic_cycleway_none_in_selection, getTitleResId())
+        SEPARATE -> Item(this, R.drawable.ic_cycleway_separate, getTitleResId())
+        else -> Item(this, getIconResId(isLeftHandTraffic), getTitleResId())
     }
-    return Item(this, getIconResId(isLeftHandTraffic), getTitleResId())
-}
 
 fun Cycleway.getIconResId(isLeftHandTraffic: Boolean): Int =
     if (isLeftHandTraffic) getLeftHandTrafficIconResId() else getRightHandTrafficIconResId()
@@ -39,6 +39,7 @@ private fun Cycleway.getRightHandTrafficIconResId(): Int = when(this) {
     DUAL_LANE -> R.drawable.ic_cycleway_lane_dual
     DUAL_TRACK -> R.drawable.ic_cycleway_track_dual
     BUSWAY -> R.drawable.ic_cycleway_bus_lane
+    SEPARATE -> R.drawable.ic_cycleway_none
     else -> 0
 }
 
@@ -55,6 +56,7 @@ private fun Cycleway.getLeftHandTrafficIconResId(): Int = when(this) {
     DUAL_LANE -> R.drawable.ic_cycleway_lane_dual_l
     DUAL_TRACK -> R.drawable.ic_cycleway_track_dual_l
     BUSWAY -> R.drawable.ic_cycleway_bus_lane_l
+    SEPARATE -> R.drawable.ic_cycleway_none
     else -> 0
 }
 
@@ -71,16 +73,18 @@ fun Cycleway.getTitleResId(): Int = when(this) {
     DUAL_LANE -> R.string.quest_cycleway_value_lane_dual
     DUAL_TRACK -> R.string.quest_cycleway_value_track_dual
     BUSWAY -> R.string.quest_cycleway_value_bus_lane
+    SEPARATE -> R.string.quest_cycleway_value_separate
     else -> 0
 }
 
 val DISPLAYED_CYCLEWAY_ITEMS: List<Cycleway> = listOf(
     NONE,
+    TRACK,
     EXCLUSIVE_LANE,
     ADVISORY_LANE,
     UNSPECIFIED_LANE,
     SUGGESTION_LANE,
-    TRACK,
+    SEPARATE,
     PICTOGRAMS,
     BUSWAY,
     SIDEWALK_EXPLICIT,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayParser.kt
@@ -114,6 +114,7 @@ private fun createCyclewayForSide(tags: Map<String, String>, side: String?): Cyc
                 else          -> TRACK
             }
         }
+        "separate" -> SEPARATE
         "no", "none", "opposite" -> NONE
         "share_busway", "opposite_share_busway" -> BUSWAY
         null -> null

--- a/app/src/main/res/drawable/ic_cycleway_separate.xml
+++ b/app/src/main/res/drawable/ic_cycleway_separate.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="256dp"
+    android:height="256dp"
+    android:viewportWidth="256"
+    android:viewportHeight="256">
+  <path
+      android:pathData="M0,0h160v256h-160z"
+      android:fillColor="#808080"/>
+  <path
+      android:pathData="m239.63,107.62 l-51.897,-36.571m-83.534,64.825c35.557,-35.166 82.687,-33.317 135.43,-28.253m0,0 l-52.941,33.088"
+      android:strokeWidth="20"
+      android:strokeColor="#e48f00"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cycleway_separate.xml
+++ b/app/src/main/res/drawable/ic_cycleway_separate.xml
@@ -7,6 +7,12 @@
       android:pathData="M0,0h160v256h-160z"
       android:fillColor="#808080"/>
   <path
+      android:pathData="m239.63,119.62 l-51.897,-36.571m-83.534,64.825c35.557,-35.166 82.687,-33.317 135.43,-28.253m0,0 l-52.941,33.088"
+      android:strokeAlpha="0.2"
+      android:strokeWidth="20"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+  <path
       android:pathData="m239.63,107.62 l-51.897,-36.571m-83.534,64.825c35.557,-35.166 82.687,-33.317 135.43,-28.253m0,0 l-52.941,33.088"
       android:strokeWidth="20"
       android:strokeColor="#e48f00"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="unglue_hint">Tap to unglue view from position</string>
     <string name="quest_maxspeed_answer_noSign_singleOrDualCarriageway_description">Are the roadways of this road here physically separated (i.e. through a barrier)? The default speed limit depends on whether this is the case or not.</string>
     <string name="quest_cycleway_value_bus_lane">on bus lane</string>
+    <string name="quest_cycleway_value_separate">displayed separately on map</string>
     <string name="about_category_feedback">Feedback</string>
     <string name="quest_cycleway_value_sidewalk">explicitly shared sidewalk</string>
     <string name="quest_leave_new_note_create_image_error">Unable to create file for photo</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddCyclewayTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddCyclewayTest.kt
@@ -117,6 +117,33 @@ class AddCyclewayTest {
         assertEquals(1, questType.getApplicableElements(mapData).toList().size)
     }
 
+    @Test fun `not applicable to road with cycleway=separate`() {
+        assertTrue(questType.getApplicableElements(TestMapDataWithGeometry(listOf(
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "primary",
+                "cycleway" to "separate"
+            ))
+        ))).toList().isEmpty())
+        assertTrue(questType.getApplicableElements(TestMapDataWithGeometry(listOf(
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "primary",
+                "cycleway:left" to "separate"
+            ))
+        ))).toList().isEmpty())
+        assertTrue(questType.getApplicableElements(TestMapDataWithGeometry(listOf(
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "primary",
+                "cycleway:right" to "separate"
+            ))
+        ))).toList().isEmpty())
+        assertTrue(questType.getApplicableElements(TestMapDataWithGeometry(listOf(
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "primary",
+                "cycleway:both" to "separate"
+            ))
+        ))).toList().isEmpty())
+    }
+
     @Test fun `not applicable to road with cycleway that is not old enough`() {
         val mapData = TestMapDataWithGeometry(listOf(
             OsmWay(1L, 1, listOf(1,2,3), mapOf(
@@ -231,6 +258,13 @@ class AddCyclewayTest {
     private fun bothSidesAnswer(bothSides: Cycleway): CyclewayAnswer {
         val side = CyclewaySide(bothSides)
         return CyclewayAnswer(side, side)
+    }
+
+    @Test fun `apply separate cycleway answer`() {
+        questType.verifyAnswer(
+            bothSidesAnswer(SEPARATE),
+            StringMapEntryAdd("cycleway:both", "separate")
+        )
     }
 
     @Test fun `apply dual cycle track answer`() {
@@ -549,6 +583,33 @@ class AddCyclewayTest {
             createElement(mapOf(
                 "highway" to "unclassified",
                 "cycleway:both" to "something"
+            ), "2000-10-10".toCheckDate())
+        )!!)
+    }
+
+    @Test fun `isApplicableTo returns false for tagged old ways with unknown cycleway=separate values`() {
+        assertFalse(questType.isApplicableTo(
+            createElement(mapOf(
+                "highway" to "unclassified",
+                "cycleway" to "separate"
+            ), "2000-10-10".toCheckDate())
+        )!!)
+        assertFalse(questType.isApplicableTo(
+            createElement(mapOf(
+                "highway" to "unclassified",
+                "cycleway:left" to "separate"
+            ), "2000-10-10".toCheckDate())
+        )!!)
+        assertFalse(questType.isApplicableTo(
+            createElement(mapOf(
+                "highway" to "unclassified",
+                "cycleway:right" to "separate"
+            ), "2000-10-10".toCheckDate())
+        )!!)
+        assertFalse(questType.isApplicableTo(
+            createElement(mapOf(
+                "highway" to "unclassified",
+                "cycleway:both" to "separate"
             ), "2000-10-10".toCheckDate())
         )!!)
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/bikeway/CyclewayParserKtTest.kt
@@ -796,6 +796,13 @@ class CyclewayParserKtTest {
         )
     }
 
+    @Test fun separate() {
+        assertEquals(
+            LeftAndRightCycleway(SEPARATE, SEPARATE),
+            parse( "cycleway" to "separate")
+        )
+    }
+
     @Test fun busway() {
         assertEquals(
             LeftAndRightCycleway(BUSWAY, BUSWAY),
@@ -1563,6 +1570,13 @@ class CyclewayParserKtTest {
         )
     }
 
+    @Test fun `separate on left side`() {
+        assertEquals(
+            LeftAndRightCycleway(SEPARATE, null),
+            parse("cycleway:left" to "separate")
+        )
+    }
+
     @Test fun `busway on left side`() {
         assertEquals(
             LeftAndRightCycleway(BUSWAY, null),
@@ -2208,6 +2222,13 @@ class CyclewayParserKtTest {
         )
     }
 
+    @Test fun `separate on right side`() {
+        assertEquals(
+            LeftAndRightCycleway(null, SEPARATE),
+            parse("cycleway:right" to "separate")
+        )
+    }
+
     @Test fun `busway on right side`() {
         assertEquals(
             LeftAndRightCycleway(null, BUSWAY),
@@ -2804,6 +2825,13 @@ class CyclewayParserKtTest {
         assertEquals(
             LeftAndRightCycleway(NONE, NONE),
             parse( "cycleway:both" to "none")
+        )
+    }
+
+    @Test fun `separate on both sides`() {
+        assertEquals(
+            LeftAndRightCycleway(SEPARATE, SEPARATE),
+            parse("cycleway:both" to "separate")
         )
     }
 

--- a/res/graphics/cycleway graphics/separate.svg
+++ b/res/graphics/cycleway graphics/separate.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+ <rect y="1.3767e-6" width="160" height="256" fill="#808080" style="paint-order:stroke fill markers"/>
+ <path d="m239.63 107.62-51.897-36.571m-83.534 64.825c35.557-35.166 82.687-33.317 135.43-28.253m0 0-52.941 33.088" fill="none" stroke="#e48f00" stroke-linecap="round" stroke-width="20"/>
+</svg>

--- a/res/graphics/cycleway graphics/separate.svg
+++ b/res/graphics/cycleway graphics/separate.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg version="1.1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
  <rect y="1.3767e-6" width="160" height="256" fill="#808080" style="paint-order:stroke fill markers"/>
+ <path d="m239.63 119.62-51.897-36.571m-83.534 64.825c35.557-35.166 82.687-33.317 135.43-28.253m0 0-52.941 33.088" fill="none" stroke="#000" stroke-linecap="round" stroke-opacity=".2" stroke-width="20"/>
  <path d="m239.63 107.62-51.897-36.571m-83.534 64.825c35.557-35.166 82.687-33.317 135.43-28.253m0 0-52.941 33.088" fill="none" stroke="#e48f00" stroke-linecap="round" stroke-width="20"/>
 </svg>


### PR DESCRIPTION
Add support for cycleway=separate. In particular, lets the user choose for each side individually "displayed separately on the map".

For each side individually, because this might very well be the real-life occurance: One side is mapped on the road-way, the other is mapped as a separate way.

However, when `cycleway:*=separate` has been added once for a road, the question will not be asked again periodically as with for other cycleway values.

![Screenshot_1616026744](https://user-images.githubusercontent.com/4661658/111555159-19051e80-8788-11eb-9f17-a82ef1b599d3.png)
![Screenshot_1616026755](https://user-images.githubusercontent.com/4661658/111555162-199db500-8788-11eb-8ada-47b8bcc9a5b5.png)
