### PR TITLE
fix isRoofProbablyVisibleFromBelow

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -50,7 +50,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
 
     private fun isRoofProbablyVisibleFromBelow(tags: Map<String,String>?): Boolean? {
         if (tags == null) return null
-        val roofLevels = tags["roof:levels"]?.toIntOrNull() ?: return null
+        val roofLevels = tags["roof:levels"]?.toFloatOrNull() ?: 0
         val buildingLevels = tags["building:levels"]?.toIntOrNull() ?: return null
         if (roofLevels < 0 || buildingLevels < 0) return null
         return buildingLevels / (roofLevels + 2f) < 2f

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -33,7 +33,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
             filter.matches(element)
             && isRoofProbablyVisibleFromBelow(element.tags) != false
             && (
-                element.tags?.get("roof:levels")?.toIntOrNull() ?: 0 > 0
+                element.tags?.get("roof:levels")?.toFloatOrNull() ?: 0f > 0f
                 || roofsAreUsuallyFlatAt(element, mapData) == false
             )
         }
@@ -44,15 +44,15 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
         /* if it has 0 roof levels, or the roof levels aren't specified,
            the quest should only be shown in certain countries. But whether
            the element is in a certain country cannot be ascertained at this point */
-        if (element.tags?.get("roof:levels")?.toIntOrNull() ?: 0 == 0) return null
+        if (element.tags?.get("roof:levels")?.toFloatOrNull() ?: 0f == 0f) return null
         return true
     }
 
     private fun isRoofProbablyVisibleFromBelow(tags: Map<String,String>?): Boolean? {
         if (tags == null) return null
-        val roofLevels = tags["roof:levels"]?.toFloatOrNull() ?: 0
-        val buildingLevels = tags["building:levels"]?.toIntOrNull() ?: return null
-        if (roofLevels < 0 || buildingLevels < 0) return null
+        val roofLevels = tags["roof:levels"]?.toFloatOrNull() ?: 0f
+        val buildingLevels = tags["building:levels"]?.toFloatOrNull() ?: return null
+        if (roofLevels < 0f || buildingLevels < 0f) return null
         return buildingLevels / (roofLevels + 2f) < 2f
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
@@ -60,24 +60,42 @@ class AddRoofShapeTest {
         ))
     }
 
-    @Test fun `not applicable to buildings with too many levels`() {
+    @Test fun `not applicable to buildings with many levels and few or no roof levels`() {
         assertEquals(false, questType.isApplicableTo(
-            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "6", "roof:levels" to "1", "building" to "apartments"))
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "6.5", "roof:levels" to "1", "building" to "apartments"))
         ))
         assertEquals(false, questType.isApplicableTo(
             OsmWay(1L, 1, listOf(), mapOf("building:levels" to "8", "roof:levels" to "2", "building" to "apartments"))
         ))
-    }
-
-    @Test fun `unknown if applicable to roofs with 0 roof levels`() {
-        assertEquals(null, questType.isApplicableTo(
-            OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "0", "building" to "apartments"))
+        assertEquals(false, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "5", "building" to "apartments"))
+        ))
+        assertEquals(false, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "4", "roof:levels" to "0", "building" to "apartments"))
         ))
     }
 
-    @Test fun `unknown if applicable to roofs with no roof levels tag`() {
+    @Test fun `applicable to buildings with many levels and enough roof levels to be visible from below`() {
+        assertEquals(true, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "6", "roof:levels" to "1.5", "building" to "apartments"))
+        ))
+        assertEquals(true, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "8", "roof:levels" to "3", "building" to "apartments"))
+        ))
+        assertEquals(true, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "4.5", "roof:levels" to "0.5", "building" to "apartments"))
+        ))
+    }
+
+    @Test fun `unknown if applicable to buildings with no or few levels and 0 or no roof levels`() {
         assertEquals(null, questType.isApplicableTo(
-            OsmWay(1L, 1, listOf(), mapOf("building:levels" to "5", "building" to "apartments"))
+            OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "0", "building" to "apartments"))
+        ))
+        assertEquals(null, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("roof:levels" to "0", "building" to "apartments", "building:levels" to "3"))
+        ))
+        assertEquals(null, questType.isApplicableTo(
+            OsmWay(1L, 1, listOf(), mapOf("building" to "apartments", "building:levels" to "2"))
         ))
     }
 


### PR DESCRIPTION
> The app should probably interpret a missing roof:levels as roof:levels=0 for the roof shape quest.

fix #2666 
Additionally now the quite common fractional value of `roof:levels` (often 0.5 or 1.5) is now understood correctly. (according to [this](https://play.kotlinlang.org/#eyJ2ZXJzaW9uIjoiMS40LjMwIiwicGxhdGZvcm0iOiJqYXZhIiwiYXJncyI6IiIsImpzQ29kZSI6IiIsIm5vbmVNYXJrZXJzIjp0cnVlLCJ0aGVtZSI6ImlkZWEiLCJjb2RlIjoiLyoqXG4gKiBZb3UgY2FuIGVkaXQsIHJ1biwgYW5kIHNoYXJlIHRoaXMgY29kZS4gXG4gKiBwbGF5LmtvdGxpbmxhbmcub3JnIFxuICovXG5cbmZ1biBtYWluKCkge1xuICAgIHZhbCByb29mTGV2ZWxzID0gXCIxLjVcIlxuICAgIHByaW50bG4ocm9vZkxldmVscz8udG9GbG9hdE9yTnVsbCgpID86IDApXG4gICAgcHJpbnRsbihyb29mTGV2ZWxzPy50b0ludE9yTnVsbCgpID86IDApXG59In0=))