### PR TITLE
assume track to be a line when on a closed way

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/Element.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/Element.kt
@@ -44,7 +44,7 @@ private val IS_AREA_EXPR = """
     or (emergency and emergency !~ yes|no)
     or historic
     or landuse
-    or leisure
+    or (leisure and leisure != track)
     or office
     or place
     or public_transport


### PR DESCRIPTION
fixes #2698

previously it was assumed to be an area when on closed way, and breaking when tagged as way without having explicit area tag
now it will be assumed to be line, even when on closed way and breaking when tagged as area without having an explicit tag

if SC can detect in quest filter closed ways, maybe adding explicit `yes/no` can be an useful quest? It can be often done from imagery, but would avoid such confusion within SC itself.

![screen05](https://user-images.githubusercontent.com/899988/112968675-ce52b180-914c-11eb-93cd-292de2917820.png)
