### PR TITLE
clarify crossings where there is a blinking traffic light [review of proposed change is welcomed]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.view.image_select.Item
 class AddCrossingTypeForm : AImageListQuestAnswerFragment<CrossingType, CrossingType>() {
 
     override val items = listOf(
-        Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals),
+        Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals_controlled),
         Item(MARKED, R.drawable.crossing_type_zebra, R.string.quest_crossing_type_marked),
         Item(UNMARKED, R.drawable.crossing_type_unmarked, R.string.quest_crossing_type_unmarked)
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_maxspeed_answer_living_street">It is a living street</string>
     <string name="quest_maxspeed_answer_living_street_confirmation_title">So, there is a sign like this?</string>
     <string name="quest_crossing_type_title">What kind of crossing is this?</string>
-    <string name="quest_crossing_type_signals">Crossing controlled by traffic lights</string>
+    <string name="quest_crossing_type_signals_controlled">Crossing controlled by traffic lights</string>
     <string name="quest_crossing_type_marked">Marked crossing</string>
     <string name="quest_crossing_type_unmarked">Crossing without road markings</string>
     <string name="compass_north_one_letter">N</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_maxspeed_answer_living_street">It is a living street</string>
     <string name="quest_maxspeed_answer_living_street_confirmation_title">So, there is a sign like this?</string>
     <string name="quest_crossing_type_title">What kind of crossing is this?</string>
-    <string name="quest_crossing_type_signals">Crossing with traffic lights</string>
+    <string name="quest_crossing_type_signals">Crossing controlled by traffic lights</string>
     <string name="quest_crossing_type_marked">Marked crossing</string>
     <string name="quest_crossing_type_unmarked">Crossing without road markings</string>
     <string name="compass_north_one_letter">N</string>


### PR DESCRIPTION
it is not controlling crossing, so traffic lights is not applicable
but it matches the current answer

And at least I got confused (OSM Wiki check fixed it, but it should not be expected from a typical user)

it is about crossings like

![IMG_20210405_121457](https://user-images.githubusercontent.com/899988/114264803-4347a600-99ed-11eb-920d-59550b65d7a6.jpg)

draft as in case of acceptance I need to realign photo - or get help to express it in a shorter from

![screen01](https://user-images.githubusercontent.com/899988/114266862-fe297100-99f8-11eb-916e-8c8f690b0b0f.png)
