### PR TITLE
Changed NSI URL to released minimalised CDN copy.

### DIFF
--- a/buildSrc/src/main/java/UpdateNsiPresetsTask.kt
+++ b/buildSrc/src/main/java/UpdateNsiPresetsTask.kt
@@ -14,7 +14,7 @@ open class UpdateNsiPresetsTask : DefaultTask() {
         val targetDir = targetDir ?: return
 
         val presetsFile = File("$targetDir/presets.json")
-        val presetsUrl = URL("https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/presets/nsi-id-presets.json")
+        val presetsUrl = URL("https://cdn.jsdelivr.net/npm/name-suggestion-index@5/dist/presets/nsi-id-presets.min.json")
         val nsiPresetsJson = Parser.default().parse(presetsUrl.openStream()) as JsonObject
         // NSI uses (atm) a slightly different format than the normal presets: The presets are in
         // a sub-object called "presets"


### PR DESCRIPTION
Changed NSI URL to released minimalised CDN copy, as opposed to the direct repository URL #2731

Very new to this repository so my apologies if this is incorrectly pulled.