### PR TITLE
Add lit tag in UK for implicit maxspeed

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -56,6 +56,16 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
                 changes.modify("highway", "living_street")
             }
             is ImplicitMaxSpeed -> {
+                if (answer.countryCode == "GB") {
+                    // nsl_restricted only gets added if the road is lit (whether already set or answered by the user in this quest)
+                    if (answer.roadType == "nsl_restricted") {
+                        changes.add("lit", "yes")
+                    }
+                    // The other answers, nsl_single and nsl_dual, only get added if the road is not lit
+                    else {
+                        changes.add("lit", "no")
+                    }
+                }
                 changes.add("maxspeed:type", answer.countryCode + ":" + answer.roadType)
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -58,12 +58,13 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
             is ImplicitMaxSpeed -> {
                 if (answer.countryCode == "GB") {
                     // nsl_restricted only gets added if the road is lit (whether already set or answered by the user in this quest)
+                    // Lit is either already set or has been answered by the user, so this wouldn't change the value of the lit tag
                     if (answer.roadType == "nsl_restricted") {
-                        changes.add("lit", "yes")
+                        changes.addOrModify("lit", "yes")
                     }
                     // The other answers, nsl_single and nsl_dual, only get added if the road is not lit
                     else {
-                        changes.add("lit", "no")
+                        changes.addOrModify("lit", "no")
                     }
                 }
                 changes.add("maxspeed:type", answer.countryCode + ":" + answer.roadType)


### PR DESCRIPTION
#2745 (what it was originally opened for)

Comments in the file explain why it's done like this.

A later PR with national speed limit option will change how this works when there are other ways of adding `nsl_single` or `nsl_dual`.