### PR TITLE
remove crossings with cycle-only ways from sound and vibration quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -1,28 +1,48 @@
 package de.westnordost.streetcomplete.quests.traffic_signals_sound
 
+import de.westnordost.osmapi.map.MapDataWithGeometry
+import de.westnordost.osmapi.map.data.Element
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
-class AddTrafficSignalsSound : OsmFilterQuestType<Boolean>() {
+class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
 
-    override val elementFilter = """
+    private val crossingFilter by lazy { """
         nodes with crossing = traffic_signals and highway ~ crossing|traffic_signals and foot != no
         and (
           !$SOUND_SIGNALS
           or $SOUND_SIGNALS = no and $SOUND_SIGNALS older today -4 years
           or $SOUND_SIGNALS older today -8 years
         )
-    """
+    """.toElementFilterExpression() }
+
+    private val excludedWaysFilter by lazy { """
+        ways with
+          highway = cycleway and foot !~ yes|designated
+    """.toElementFilterExpression() }
 
     override val commitMessage = "Add whether traffic signals have sound signals"
     override val wikiLink = "Key:$SOUND_SIGNALS"
     override val icon = R.drawable.ic_quest_blind_traffic_lights_sound
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_sound_title
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
+        val excludedWayNodeIds = mutableSetOf<Long>()
+        mapData.ways
+            .filter { excludedWaysFilter.matches(it) }
+            .flatMapTo(excludedWayNodeIds) { it.nodeIds }
+
+        return mapData.nodes
+            .filter { crossingFilter.matches(it) && it.id !in excludedWayNodeIds }
+    }
+
+    override fun isApplicableTo(element: Element): Boolean? = null
 
     override fun createForm() = YesNoQuestAnswerFragment()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -42,7 +42,11 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
             .filter { crossingFilter.matches(it) && it.id !in excludedWayNodeIds }
     }
 
-    override fun isApplicableTo(element: Element): Boolean? = null
+    override fun isApplicableTo(element: Element): Boolean? =
+        if (!crossingFilter.matches(element))
+            false
+        else
+            null
 
     override fun createForm() = YesNoQuestAnswerFragment()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -41,7 +41,11 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
             .filter { crossingFilter.matches(it) && it.id !in excludedWayNodeIds }
     }
 
-    override fun isApplicableTo(element: Element): Boolean? = null
+    override fun isApplicableTo(element: Element): Boolean? =
+        if (!crossingFilter.matches(element))
+            false
+        else
+            null
 
     override fun createForm() = AddTrafficSignalsVibrationForm()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -1,27 +1,47 @@
 package de.westnordost.streetcomplete.quests.traffic_signals_vibrate
 
+import de.westnordost.osmapi.map.MapDataWithGeometry
+import de.westnordost.osmapi.map.data.Element
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.osmquest.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
 import de.westnordost.streetcomplete.ktx.toYesNo
 
-class AddTrafficSignalsVibration : OsmFilterQuestType<Boolean>() {
+class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
 
-    override val elementFilter = """
+    private val crossingFilter by lazy { """
         nodes with crossing = traffic_signals and highway ~ crossing|traffic_signals and foot!=no
         and (
           !$VIBRATING_BUTTON
           or $VIBRATING_BUTTON = no and $VIBRATING_BUTTON older today -4 years
           or $VIBRATING_BUTTON older today -8 years
         )
-    """
+    """.toElementFilterExpression() }
+
+    private val excludedWaysFilter by lazy { """
+        ways with
+          highway = cycleway and foot !~ yes|designated
+    """.toElementFilterExpression() }
 
     override val commitMessage = "Add whether traffic signals have tactile indication that it's safe to cross"
     override val wikiLink = "Key:$VIBRATING_BUTTON"
     override val icon = R.drawable.ic_quest_blind_traffic_lights
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_vibrate_title
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
+        val excludedWayNodeIds = mutableSetOf<Long>()
+        mapData.ways
+            .filter { excludedWaysFilter.matches(it) }
+            .flatMapTo(excludedWayNodeIds) { it.nodeIds }
+
+        return mapData.nodes
+            .filter { crossingFilter.matches(it) && it.id !in excludedWayNodeIds }
+    }
+
+    override fun isApplicableTo(element: Element): Boolean? = null
 
     override fun createForm() = AddTrafficSignalsVibrationForm()
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSoundTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSoundTest.kt
@@ -1,0 +1,36 @@
+package de.westnordost.streetcomplete.quests.traffic_signals_sound
+
+import de.westnordost.osmapi.map.data.OsmNode
+import de.westnordost.osmapi.map.data.OsmWay
+import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
+import org.junit.Assert.*
+import org.junit.Test
+
+class AddTrafficSignalsSoundTest {
+    private val questType = AddTrafficSignalsSound()
+
+    @Test fun `applicable to crossing`() {
+        val mapData = TestMapDataWithGeometry(listOf(
+            OsmNode(1L, 1, 0.0,0.0, mapOf(
+                "highway" to "crossing",
+                "crossing" to "traffic_signals"
+            ))
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `not applicable to crossing of cycleway without foot access`() {
+        val mapData = TestMapDataWithGeometry(listOf(
+            OsmNode(1L, 1, 0.0,0.0, mapOf(
+                "highway" to "crossing",
+                "crossing" to "traffic_signals"
+            )),
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "cycleway",
+                "foot" to "no"
+            ))
+        ))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+    }
+
+}

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibrationTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibrationTest.kt
@@ -1,0 +1,36 @@
+package de.westnordost.streetcomplete.quests.traffic_signals_vibrate
+
+import de.westnordost.osmapi.map.data.OsmNode
+import de.westnordost.osmapi.map.data.OsmWay
+import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
+import org.junit.Assert.*
+import org.junit.Test
+
+class AddTrafficSignalsVibrationTest {
+    private val questType = AddTrafficSignalsVibration()
+
+    @Test fun `applicable to crossing`() {
+        val mapData = TestMapDataWithGeometry(listOf(
+            OsmNode(1L, 1, 0.0,0.0, mapOf(
+                "highway" to "crossing",
+                "crossing" to "traffic_signals"
+            ))
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `not applicable to crossing of cycleway without foot access`() {
+        val mapData = TestMapDataWithGeometry(listOf(
+            OsmNode(1L, 1, 0.0,0.0, mapOf(
+                "highway" to "crossing",
+                "crossing" to "traffic_signals"
+            )),
+            OsmWay(1L, 1, listOf(1,2,3), mapOf(
+                "highway" to "cycleway",
+                "foot" to "no"
+            ))
+        ))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+    }
+
+}


### PR DESCRIPTION
For the tactile pavings quest, crossings with cycle-only ways are already excluded, so I simply copied and slightly adjusted the relevant parts to the sound and vibration quests.

Tested and works as expected: The sound signal quest does indeed not show up on crossings with cycleways with foot=no (without this PR it does for the same corssing)