### PR TITLE
[One-way quest] Also show quest for streets where there are no sidewalks

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -25,11 +25,8 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
         ways with highway ~ living_street|residential|service|tertiary|unclassified
          and !oneway and area != yes and junction != roundabout
          and (access !~ private|no or (foot and foot !~ private|no))
-         and (
-               (lanes <= 1 and width)
-              or
-               (sidewalk ~ none|no)
-             )
+         and lanes <= 1 
+         and (width or sidewalk ~ none|no)
     """.toElementFilterExpression() }
 
     override val commitMessage = "Add whether this road is a one-way road because it is quite slim"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -25,7 +25,11 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
         ways with highway ~ living_street|residential|service|tertiary|unclassified
          and !oneway and area != yes and junction != roundabout
          and (access !~ private|no or (foot and foot !~ private|no))
-         and lanes <= 1 and width
+         and (
+               (lanes <= 1 and width)
+              or
+               (sidewalk ~ none|no)
+             )
     """.toElementFilterExpression() }
 
     override val commitMessage = "Add whether this road is a one-way road because it is quite slim"


### PR DESCRIPTION
Hi, it's me again. This morning, while out, I noticed that most of the roads which were one way had no sidewalks, indeed they were so narrow that adding sidewalks would have made car access impossible. 
I must specify that in southern Italy (at least in my area) we have a lot of narrow roads like that and that's true almost always (no sidewalks = narrow = one-way road), but that could not be the always true for all other roads in the world.
But I think that this would not cause much spam and could actually be useful if asked after the sidewalk quest (maybe also after the lane quest). 
With the current settings, this quest is almost never shown as I think there's no quest that asks for width (correct me if I'm wrong, they are so many 😂), so adding this other option (and maybe more in the future) could actually help as this quest is maybe the only one which can help mapping one-way roads in areas where there's not much data for the suspect one-way quest.
Let me know what you think about it!