### PR TITLE
Check for container recycling still existing

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -42,6 +42,7 @@ class CheckExistence(
             or advertising ~ column|board|poster_box
             or traffic_calming ~ bump|hump|island|cushion|choker|rumble_strip|chicane|dip
             or traffic_calming = table and !highway and !crossing
+            or amenity = recycling and recycling_type = container
           )
           and (${lastChecked(4.0)})
         )) and access !~ no|private


### PR DESCRIPTION
Untested

This was triggered by some clothes recycling bins which have moved within a few months of being added (and I think initially appeared during the pandemic). I don't know if they are deliberately moving it around or were just trying to find the best spot to place it.

Could narrow it down to just certain types if we don't feel the glass/plastic/paper ones are very likely to move (which I'd probably agree as they're normally council based).

I think the one I saw was more almost charity fundraising like this one:
https://commons.wikimedia.org/wiki/File:Clothing_recycling_bin.JPG