### PR TITLE
Ensure the list of tags checked for to decide the title type matches those used to fetch the name

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -67,7 +67,7 @@ class CheckExistence(
     override val icon = R.drawable.ic_quest_check
 
     override fun getTitle(tags: Map<String, String>): Int =
-        if (tags.containsAnyKey("name", "brand", "operator"))
+        if (tags.containsAnyKey("name", "ref", "brand", "operator"))
             R.string.quest_existence_name_title
         else
             R.string.quest_existence_title


### PR DESCRIPTION
Fixes bug introduced in 84f39d8124eb7f496992de3caf100a3f7baea069

At least I'm pretty confident it's a bug.