### PR TITLE
Replace awaitPreDraw with awaitLayout (fixes #2801)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/user/AchievementsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/AchievementsFragment.kt
@@ -15,7 +15,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.user.UserStore
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
 import de.westnordost.streetcomplete.data.user.achievements.UserAchievementsSource
-import de.westnordost.streetcomplete.ktx.awaitPreDraw
+import de.westnordost.streetcomplete.ktx.awaitLayout
 import de.westnordost.streetcomplete.ktx.toPx
 import de.westnordost.streetcomplete.view.GridLayoutSpacingItemDecoration
 import de.westnordost.streetcomplete.view.ListAdapter
@@ -50,8 +50,8 @@ class AchievementsFragment : Fragment(R.layout.fragment_achievements) {
         val minCellWidth = 144f.toPx(ctx)
         val itemSpacing = ctx.resources.getDimensionPixelSize(R.dimen.achievements_item_margin)
 
-        lifecycleScope.launch {
-            view.awaitPreDraw()
+        viewLifecycleOwner.lifecycleScope.launch {
+            view.awaitLayout()
 
             emptyText.visibility = View.GONE
 

--- a/app/src/main/java/de/westnordost/streetcomplete/user/LinksFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/LinksFragment.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.user.UserStore
 import de.westnordost.streetcomplete.data.user.achievements.UserLinksSource
-import de.westnordost.streetcomplete.ktx.awaitPreDraw
+import de.westnordost.streetcomplete.ktx.awaitLayout
 import de.westnordost.streetcomplete.ktx.toDp
 import de.westnordost.streetcomplete.ktx.tryStartActivity
 import de.westnordost.streetcomplete.view.GridLayoutSpacingItemDecoration
@@ -37,8 +37,8 @@ class LinksFragment : Fragment(R.layout.fragment_links) {
         val minCellWidth = 280f
         val itemSpacing = ctx.resources.getDimensionPixelSize(R.dimen.links_item_margin)
 
-        lifecycleScope.launch {
-            view.awaitPreDraw()
+        viewLifecycleOwner.lifecycleScope.launch {
+            view.awaitLayout()
 
             emptyText.visibility = View.GONE
 


### PR DESCRIPTION
Due to the way the `ViewPager2`'s `RecyclerView` works, the `onPreDraw` callback is not always called. This results in the links list not being displayed correctly. This PR fixes this behavior by instead using the `awaitLayout()` function.

Interestingly, the bug can also be fixed by setting the `ViewPager2`'s [OffscreenPageLimit](https://developer.android.com/reference/androidx/viewpager2/widget/ViewPager2#setOffscreenPageLimit(int)) to the value `1`. Since the bug seems to be related to the preloading of the fragments, I have also adjusted the corresponding place in the `AchievementsFragment`. Otherwise, the problem would probably also occur there if the order of the pages were to be changed.