### PR TITLE
Fix keyboard not appearing in TimeRangePickerDialog (fixes #2799)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/TimeRangePickerDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/TimeRangePickerDialog.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.opening_hours
 
 import android.content.Context
 import android.content.DialogInterface
+import android.os.Bundle
 import com.google.android.material.tabs.TabLayout
 import androidx.viewpager.widget.PagerAdapter
 import androidx.viewpager.widget.ViewPager
@@ -9,6 +10,7 @@ import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.CheckBox
 import android.widget.TimePicker
 
@@ -79,6 +81,13 @@ class TimeRangePickerDialog(
             override fun onTabUnselected(tab: TabLayout.Tab) { }
             override fun onTabReselected(tab: TabLayout.Tab) { }
         })
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)
     }
 
     private fun setCurrentTab(position: Int) {


### PR DESCRIPTION
As explained in the `AlertDialog`'s [Javadoc](https://developer.android.com/reference/android/app/AlertDialog), the class normally automatically takes care of setting the `WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM` window flag by checking if the dialog's view contains an `EditText`. However, this does not seem to work with the `TimePicker`, which displays a clock dial by default. This PR fixes this problem by setting the correct window flags by hand. On my device, the keyboard can now be opened by clicking in the text fields.