### PR TITLE
Reset flag offset after onMeasure

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/user/CircularFlagView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/CircularFlagView.kt
@@ -51,6 +51,7 @@ class CircularFlagView @JvmOverloads constructor(
             if (widthMode == MeasureSpec.EXACTLY) width else height
         } else min(width, height)
         setMeasuredDimension(size, size)
+        boundsOffset = null
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
This PR fixes #2819 by resetting the calculated flag bounds offset when the width of the view changes.
Before:
![device-2021-05-01-131902](https://user-images.githubusercontent.com/6892794/116780978-319f6e80-aa80-11eb-87c9-34d0d22c1ada.png)
After:
![device-2021-05-01-131939](https://user-images.githubusercontent.com/6892794/116780980-3532f580-aa80-11eb-8872-0e0109a53c70.png)
