### PR TITLE
Clarify that quest selection screen allows reordering

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.ItemTouchHelper
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
@@ -47,6 +48,8 @@ class QuestSelectionAdapter @Inject constructor(
 ) : ListAdapter<QuestVisibility>() {
     private val currentCountryCodes: List<String>
 
+    private val itemTouchHelper by lazy { ItemTouchHelper(TouchHelperCallback()) }
+
     interface Listener {
         fun onReorderedQuests(before: QuestType<*>, after: QuestType<*>)
         fun onChangedQuestVisibility(questType: QuestType<*>, visible: Boolean)
@@ -61,8 +64,7 @@ class QuestSelectionAdapter @Inject constructor(
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
-        val ith = ItemTouchHelper(TouchHelperCallback())
-        ith.attachToRecyclerView(recyclerView)
+        itemTouchHelper.attachToRecyclerView(recyclerView)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder<QuestVisibility> {
@@ -123,6 +125,7 @@ class QuestSelectionAdapter @Inject constructor(
     private inner class QuestVisibilityViewHolder(itemView: View) :
         ListAdapter.ViewHolder<QuestVisibility>(itemView), CompoundButton.OnCheckedChangeListener {
 
+        private val dragHandle: ImageView = itemView.dragHandle
         private val questIcon: ImageView = itemView.questIcon
         private val questTitle: TextView = itemView.questTitle
         private val visibilityCheckBox: CheckBox = itemView.visibilityCheckBox
@@ -151,6 +154,14 @@ class QuestSelectionAdapter @Inject constructor(
             visibilityCheckBox.isChecked = item.visible
             visibilityCheckBox.isEnabled = item.isInteractionEnabled
             visibilityCheckBox.setOnCheckedChangeListener(this)
+
+            dragHandle.setOnTouchListener { v, event ->
+                when (event.actionMasked) {
+                    MotionEvent.ACTION_DOWN -> itemTouchHelper.startDrag(this)
+                    MotionEvent.ACTION_UP -> v.performClick()
+                }
+                true
+            }
 
             countryDisabledText.isGone = isEnabledInCurrentCountry
             if (!isEnabledInCurrentCountry) {

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionFragment.kt
@@ -34,7 +34,7 @@ class QuestSelectionFragment
     @Inject internal lateinit var visibleQuestTypeController: VisibleQuestTypeController
     @Inject internal lateinit var questTypeOrderList: QuestTypeOrderList
 
-    override val title: String get() = getString(R.string.pref_title_quests)
+    override val title: String get() = getString(R.string.pref_title_quests2)
 
     init {
         Injector.applicationComponent.inject(this)

--- a/app/src/main/res/drawable/ic_drag_vertical.xml
+++ b/app/src/main/res/drawable/ic_drag_vertical.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#888"
+        android:pathData="M9,3H11V5H9V3M13,3H15V5H13V3M9,7H11V9H9V7M13,7H15V9H13V7M9,11H11V13H9V11M13,11H15V13H13V11M9,15H11V17H9V15M13,15H15V17H13V15M9,19H11V21H9V19M13,19H15V21H13V19Z" />
+</vector>

--- a/app/src/main/res/layout/row_quest_selection.xml
+++ b/app/src/main/res/layout/row_quest_selection.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="8dp"
-                android:paddingTop="8dp"
-                android:paddingBottom="8dp"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:background="?android:attr/colorBackground"
-                tools:ignore="RtlSymmetry">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/colorBackground"
+    android:paddingStart="8dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    tools:ignore="RtlSymmetry">
 
     <ImageView
         android:id="@+id/questIcon"
@@ -15,33 +16,38 @@
         android:layout_height="@dimen/table_icon_size"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        tools:src="@drawable/ic_quest_street"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_quest_street" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/linearLayout"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_toEndOf="@+id/questIcon"
-        android:layout_toStartOf="@+id/visibilityCheckBoxContainer"
-        android:layout_centerVertical="true"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp">
+        android:paddingEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/visibilityCheckBoxContainer"
+        app:layout_constraintStart_toEndOf="@+id/questIcon"
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
+            android:id="@+id/questTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="@string/quest_lanes_title"
             android:textAppearance="@android:style/TextAppearance.Theme.Dialog"
-            android:id="@+id/questTitle"/>
+            tools:text="@string/quest_lanes_title" />
 
         <TextView
+            android:id="@+id/countryDisabledText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
-            android:textStyle="italic"
-            tools:text="@string/questList_disabled_in_country"
             android:background="@drawable/background_quest_disabled_notice"
-            android:id="@+id/countryDisabledText"/>
+            android:textStyle="italic"
+            tools:text="@string/questList_disabled_in_country" />
 
     </LinearLayout>
 
@@ -49,19 +55,17 @@
         android:id="@+id/visibilityCheckBoxContainer"
         android:layout_width="@dimen/table_icon_size"
         android:layout_height="@dimen/table_icon_size"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
-        >
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <CheckBox
             android:id="@+id/visibilityCheckBox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            />
+            android:layout_gravity="center" />
 
     </FrameLayout>
 
 
-
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/row_quest_selection.xml
+++ b/app/src/main/res/layout/row_quest_selection.xml
@@ -10,24 +10,26 @@
     tools:ignore="RtlSymmetry">
 
     <ImageView
-        android:id="@+id/dragHandle"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:src="@drawable/ic_drag_vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <ImageView
         android:id="@+id/questIcon"
         android:layout_width="@dimen/table_icon_size"
         android:layout_height="@dimen/table_icon_size"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
+        android:layout_marginStart="24dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/dragHandle"
+        app:layout_constraintStart_toStartOf="@+id/dragHandle"
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/ic_quest_street" />
+
+    <ImageView
+        android:id="@+id/dragHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:paddingEnd="24dp"
+        android:src="@drawable/ic_drag_vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout
         android:id="@+id/linearLayout"

--- a/app/src/main/res/layout/row_quest_selection.xml
+++ b/app/src/main/res/layout/row_quest_selection.xml
@@ -5,10 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/colorBackground"
-    android:paddingStart="8dp"
     android:paddingTop="8dp"
     android:paddingBottom="8dp"
     tools:ignore="RtlSymmetry">
+
+    <ImageView
+        android:id="@+id/dragHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:src="@drawable/ic_drag_vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/questIcon"
@@ -17,7 +25,7 @@
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/dragHandle"
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/ic_quest_street" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -482,7 +482,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="resurvey_intervals_less_often">Ask less often</string>
     <string name="resurvey_intervals_default">Default</string>
     <string name="resurvey_intervals_more_often">Ask more often</string>
-    <string name="pref_title_quests">Quest selection</string>
+    <string name="pref_title_quests2">Quest selection and priority</string>
     <string name="quest_enabled">Enabled</string>
     <string name="quest_type">Quest type</string>
     <string name="action_reset">Reset</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,9 +24,8 @@
 
         <Preference
             android:key="quests"
-            android:title="@string/pref_title_quests"
-            android:widgetLayout="@layout/widget_image_next"
-            />
+            android:title="@string/pref_title_quests2"
+            android:widgetLayout="@layout/widget_image_next" />
 
         <ListPreference
             android:key="quests.resurveyIntervals"


### PR DESCRIPTION
Closes #2828.

* Rename screen from "Quest selection" to "Quest selection and priority". I avoided the word "order", as "priority" is already used in that screen and I think it's better to stick with one word for one concept.

  <img src="https://user-images.githubusercontent.com/202916/116974831-ffc81b00-acbe-11eb-9a8d-36d79dad5a35.png" width="40%">

* Add a drag handle at the left of each quest selection row. Dragging there is immediately possible (without long-press), dragging anywhere by long-pressing is still allowed.

  <img src="https://user-images.githubusercontent.com/202916/116975029-43bb2000-acbf-11eb-8054-6cfb9e849805.png" width="40%">

I used the [drag-vertical Material Design Icon](https://materialdesignicons.com/icon/drag-vertical), should I add that to `authors.txt`?