### PR TITLE
put add housenumber quest together with add street name quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.quests.accepts_cash.AddAcceptsCash
 import de.westnordost.streetcomplete.quests.address.AddAddressStreet
-import de.westnordost.streetcomplete.quests.housenumber.AddHousenumber
+import de.westnordost.streetcomplete.quests.address.AddHousenumber
 import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
 import de.westnordost.streetcomplete.quests.bench_backrest.AddBenchBackrest
 import de.westnordost.streetcomplete.quests.bike_parking_capacity.AddBikeParkingCapacity

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumberForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumberForm.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 import android.content.res.ColorStateList
 import android.os.Bundle

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswer.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 sealed class HousenumberAnswer
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswerValidator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswerValidator.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 val VALID_CONSCRIPTIONNUMBER_REGEX = Regex("\\p{N}{1,6}")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberParser.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 import de.westnordost.streetcomplete.data.elementfilter.StringWithCursor
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddHousenumberTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddHousenumberTest.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/address/HousenumberParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/address/HousenumberParserKtTest.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.housenumber
+package de.westnordost.streetcomplete.quests.address
 
 import org.junit.Assert.*
 import org.junit.Test


### PR DESCRIPTION
recently I keep running into problem of finding a quest among all of them

it fixes one of problems that I have with

opening PR to check is such reorganization in general and specifically about this one welcomed - and also because there is (tiny) chance that I broke something, so I want to not add it on what is in the next release (though I tested the change)