### PR TITLE
"does not exist" enabled for more quests, fixes #2913

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -22,9 +22,9 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
     """
     override val commitMessage = "Add baby changing table"
     override val wikiLink = "Key:changing_table"
+    override val icon = R.drawable.ic_quest_baby
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val isReplaceShopEnabled = true
-    override val icon = R.drawable.ic_quest_baby
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
@@ -7,9 +7,9 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
 
     override val elementFilter = "ways with man_made = bridge and !bridge:structure and !bridge:movable"
-    override val icon = R.drawable.ic_quest_bridge
     override val commitMessage = "Add bridge structures"
     override val wikiLink = "Key:bridge:structure"
+    override val icon = R.drawable.ic_quest_bridge
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bridge_structure_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -17,7 +17,6 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether defibrillator is inside building"
     override val wikiLink = "Key:indoor"
     override val icon = R.drawable.ic_quest_defibrillator
-    override val isDeleteElementEnabled = true
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_is_defibrillator_inside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -17,6 +17,7 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether defibrillator is inside building"
     override val wikiLink = "Key:indoor"
     override val icon = R.drawable.ic_quest_defibrillator
+    override val isDeleteElementEnabled = true
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_is_defibrillator_inside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -19,6 +19,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
     override val commitMessage = "Add whether water is drinkable"
     override val wikiLink = "Key:drinking_water"
     override val icon = R.drawable.ic_quest_drinking_water
+    override val isDeleteElementEnabled = true
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_drinking_water_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -10,6 +10,7 @@ class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
     override val commitMessage = "Add fire hydrant type"
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = R.drawable.ic_quest_fire_hydrant
+    override val isDeleteElementEnabled = true
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_fireHydrant_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -21,9 +21,9 @@ class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
     /* Don't ask again for postboxes without signed collection times. This is very unlikely to
     *  change and problematic to tag clearly with the check date scheme */
 
-    override val icon = R.drawable.ic_quest_mail
     override val commitMessage = "Add postbox collection times"
     override val wikiLink = "Key:collection_times"
+    override val icon = R.drawable.ic_quest_mail
     override val isDeleteElementEnabled = true
 
     // See overview here: https://ent8r.github.io/blacklistr/?streetcomplete=postbox_collection_times/AddPostboxCollectionTimes.kt

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -11,9 +11,9 @@ class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
 
     override val elementFilter = "nodes with amenity = post_box and !ref and !ref:signed"
 
-    override val icon = R.drawable.ic_quest_mail_ref
     override val commitMessage = "Add postbox refs"
     override val wikiLink = "Tag:amenity=post_box"
+    override val icon = R.drawable.ic_quest_mail_ref
     override val isDeleteElementEnabled = true
 
     // source: https://commons.wikimedia.org/wiki/Category:Post_boxes_by_country

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -15,6 +15,7 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
     override val icon = R.drawable.ic_quest_crown
     override val commitMessage = "Add postbox royal cypher"
     override val wikiLink = "Key:royal_cypher"
+    override val isDeleteElementEnabled = true
     override val enabledInCountries = NoCountriesExcept(
         "GB"
     )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -12,9 +12,9 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
           amenity = post_box
           and !royal_cypher
     """
+    override val icon = R.drawable.ic_quest_crown
     override val commitMessage = "Add postbox royal cypher"
     override val wikiLink = "Key:royal_cypher"
-    override val icon = R.drawable.ic_quest_crown
     override val enabledInCountries = NoCountriesExcept(
         "GB"
     )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -12,9 +12,9 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
           amenity = post_box
           and !royal_cypher
     """
-    override val icon = R.drawable.ic_quest_crown
     override val commitMessage = "Add postbox royal cypher"
     override val wikiLink = "Key:royal_cypher"
+    override val icon = R.drawable.ic_quest_crown
     override val isDeleteElementEnabled = true
     override val enabledInCountries = NoCountriesExcept(
         "GB"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -10,6 +10,7 @@ class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
     override val commitMessage = "Add information type to tourist information"
     override val wikiLink = "Tag:tourism=information"
     override val icon = R.drawable.ic_quest_information
+    override val isDeleteElementEnabled = true
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
@@ -12,11 +12,11 @@ open class TestQuestTypeA : OsmElementQuestType<String> {
     override fun getTitle(tags: Map<String, String>) = 0
     override fun isApplicableTo(element: Element):Boolean? = null
     override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {}
-    override val icon = 0
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
     override val commitMessage = "test me"
     override fun getApplicableElements(mapData: MapDataWithGeometry) = mapData.filter { isApplicableTo(it) == true }
     override val wikiLink: String? = null
+    override val icon = 0
 }
 
 class TestQuestTypeB : TestQuestTypeA()


### PR DESCRIPTION
I thought about adding it for bus stop quests, but `highway=bus_stop` is fully valid also for unremarkable piece of dirt where people enter into bus - even if not marked in any way whatsoever. So extra step for deletion is useful here.

workaround for github bug: fixes #2913