### PR TITLE
Remember more building level quest answers

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -25,8 +25,8 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
     override fun createForm() = AddBuildingLevelsForm()
 
     override fun applyAnswerTo(answer: BuildingLevelsAnswer, changes: StringMapChangesBuilder) {
-        changes.add("building:levels", answer.levels)
-        answer.roofLevels?.let { changes.addOrModify("roof:levels", it) }
+        changes.add("building:levels", answer.levels.toString())
+        answer.roofLevels?.let { changes.addOrModify("roof:levels", it.toString()) }
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -25,8 +25,8 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
     override fun createForm() = AddBuildingLevelsForm()
 
     override fun applyAnswerTo(answer: BuildingLevelsAnswer, changes: StringMapChangesBuilder) {
-        changes.add("building:levels", answer.levels.toString())
-        answer.roofLevels?.let { changes.addOrModify("roof:levels", it.toString()) }
+        changes.add("building:levels", answer.levels)
+        answer.roofLevels?.let { changes.addOrModify("roof:levels", it) }
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -55,12 +55,13 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     }
 
     private fun onLastPickedButtonClicked(position: Int) {
-        levelsInput.setText(lastPickedAnswers[position].levels)
-        roofLevelsInput.setText(lastPickedAnswers[position].roofLevels ?: "")
+        levelsInput.setText(lastPickedAnswers[position].levels.toString())
+        roofLevelsInput.setText(lastPickedAnswers[position].roofLevels?.toString() ?: "")
     }
 
     override fun onClickOk() {
-        val answer = BuildingLevelsAnswer(levels, if (roofLevels.isEmpty()) null else roofLevels)
+        val roofLevelsNumber = if (roofLevels.isEmpty()) null else roofLevels.toInt()
+        val answer = BuildingLevelsAnswer(levels.toInt(), roofLevelsNumber)
         favs.add(javaClass.simpleName, answer.toSerializedString(), max = 5)
         applyAnswer(answer)
     }
@@ -101,8 +102,8 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
         }
 
         override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
-            viewHolder.lastLevelsLabel.text = lastPickedAnswers[position].levels
-            viewHolder.lastRoofLevelsLabel.text = lastPickedAnswers[position].roofLevels ?: " "
+            viewHolder.lastLevelsLabel.text = lastPickedAnswers[position].levels.toString()
+            viewHolder.lastRoofLevelsLabel.text = lastPickedAnswers[position].roofLevels?.toString() ?: " "
         }
 
         override fun getItemCount() = lastPickedAnswers.size
@@ -113,4 +114,4 @@ private fun BuildingLevelsAnswer.toSerializedString() =
     listOfNotNull(levels, roofLevels).joinToString("#")
 
 private fun String.toBuildingLevelAnswer() =
-    this.split("#").let { BuildingLevelsAnswer(it[0], it.getOrNull(1)) }
+    this.split("#").let { BuildingLevelsAnswer(it[0].toInt(), it.getOrNull(1)?.toInt()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -61,7 +61,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
 
     override fun onClickOk() {
         val answer = BuildingLevelsAnswer(levels, if (roofLevels.isEmpty()) null else roofLevels)
-        favs.add(javaClass.simpleName, answer.toSerializedString(), max = 6)
+        favs.add(javaClass.simpleName, answer.toSerializedString(), max = 5)
         applyAnswer(answer)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -84,16 +84,12 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
         class ViewHolder(
             view: View,
             private val onItemClicked: (position: Int) -> Unit
-        ) : RecyclerView.ViewHolder(view), View.OnClickListener {
+        ) : RecyclerView.ViewHolder(view) {
             val lastLevelsLabel: TextView = view.findViewById(R.id.lastLevelsLabel)
             val lastRoofLevelsLabel: TextView = view.findViewById(R.id.lastRoofLevelsLabel)
 
             init {
-                itemView.setOnClickListener(this)
-            }
-
-            override fun onClick(view: View) {
-                onItemClicked(bindingAdapterPosition)
+                itemView.setOnClickListener { _ -> onItemClicked(bindingAdapterPosition) }
             }
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -15,6 +15,8 @@ import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.util.TextChangedWatcher
 
 import kotlinx.android.synthetic.main.quest_building_levels.*
+import kotlinx.android.synthetic.main.quest_building_levels_last_picked_button.lastLevelsLabel
+import kotlinx.android.synthetic.main.quest_building_levels_last_picked_button.lastRoofLevelsLabel
 
 class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnswer>() {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/BuildingLevelsAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/BuildingLevelsAnswer.kt
@@ -1,3 +1,3 @@
 package de.westnordost.streetcomplete.quests.building_levels
 
-data class BuildingLevelsAnswer(val levels:Int, val roofLevels:Int?)
+data class BuildingLevelsAnswer(val levels: String, val roofLevels: String?)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/BuildingLevelsAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/BuildingLevelsAnswer.kt
@@ -1,3 +1,3 @@
 package de.westnordost.streetcomplete.quests.building_levels
 
-data class BuildingLevelsAnswer(val levels: String, val roofLevels: String?)
+data class BuildingLevelsAnswer(val levels: Int, val roofLevels: Int?)

--- a/app/src/main/res/layout/quest_building_levels.xml
+++ b/app/src/main/res/layout/quest_building_levels.xml
@@ -83,49 +83,56 @@
 
     <RelativeLayout
         android:id="@+id/containerRoofLevelsInput"
-        android:layout_toRightOf="@id/buildingImage"
-        android:layout_alignTop="@id/buildingImage"
-        android:layout_alignParentRight="true"
-        android:layout_above="@id/pickLastButton"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_above="@id/lastPickedButtons"
+        android:layout_alignTop="@id/buildingImage"
+        android:layout_alignParentRight="true"
         android:layout_marginLeft="-34dp"
+        android:layout_toRightOf="@id/buildingImage"
         android:gravity="top"
         tools:ignore="RtlHardcoded">
 
         <EditText
-            android:layout_height="wrap_content"
+            android:id="@+id/roofLevelsInput"
             android:layout_width="wrap_content"
-            android:textSize="20dp"
-            tools:text="2"
-            android:layout_alignParentTop="true"
+            android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
+            android:layout_alignParentTop="true"
             android:ems="2"
             android:gravity="center_horizontal"
-            android:id="@+id/roofLevelsInput"
+            android:imeOptions="actionDone"
             android:inputType="number"
             android:maxLines="1"
             android:nextFocusUp="@+id/levelsInput"
-            android:imeOptions="actionDone"
-            tools:ignore="SpUsage" />
+            android:textSize="20dp"
+            tools:ignore="SpUsage"
+            tools:text="2" />
 
         <TextView
-            android:text="@string/quest_buildingLevels_roofLevelsLabel2"
-            android:labelFor="@+id/roofLevelsInput"
-            app:autoSizeTextType="uniform"
-            app:autoSizeMaxTextSize="16dp"
-            app:autoSizeMinTextSize="12dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/roofLevelsInput"
             android:layout_alignParentBottom="true"
+            android:layout_marginLeft="4dp"
             android:gravity="left"
-            android:layout_marginLeft="4dp"/>
+            android:labelFor="@+id/roofLevelsInput"
+            android:text="@string/quest_buildingLevels_roofLevelsLabel2"
+            app:autoSizeMaxTextSize="16dp"
+            app:autoSizeMinTextSize="12dp"
+            app:autoSizeTextType="uniform" />
 
     </RelativeLayout>
 
-    <include
-        android:id="@+id/pickLastButton"
-        layout="@layout/quest_building_levels_last_picked_button" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/lastPickedButtons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/buildingImage"
+        android:orientation="horizontal"
+        android:padding="4dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:itemCount="6"
+        tools:listitem="@layout/quest_building_levels_last_picked_button" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/quest_building_levels.xml
+++ b/app/src/main/res/layout/quest_building_levels.xml
@@ -124,42 +124,8 @@
 
     </RelativeLayout>
 
-    <RelativeLayout
+    <include
         android:id="@+id/pickLastButton"
-        android:layout_width="wrap_content"
-        android:layout_height="51dp"
-        android:layout_alignParentRight="true"
-        android:layout_alignBottom="@id/buildingImage"
-        style="@style/Widget.AppCompat.Button.Small"
-        tools:ignore="RtlHardcoded">
-
-        <ImageView
-            android:id="@+id/lastBuildingIllustrationIcon"
-            android:src="@drawable/ic_building_levels_illustration"
-            android:layout_toRightOf="@id/lastLevelsLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:ignore="RtlHardcoded"/>
-
-        <TextView
-            android:id="@+id/lastLevelsLabel"
-            android:layout_alignParentLeft="true"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:textSize="14sp"
-            tools:text="3"
-            tools:ignore="RtlHardcoded"/>
-
-        <TextView
-            android:id="@+id/lastRoofLevelsLabel"
-            android:layout_toRightOf="@id/lastBuildingIllustrationIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="14sp"
-            tools:text="1"
-            tools:ignore="RtlHardcoded"/>
-
-    </RelativeLayout>
+        layout="@layout/quest_building_levels_last_picked_button" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
+++ b/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
@@ -1,38 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.AppCompat.Button.Small"
     android:layout_width="wrap_content"
     android:layout_height="51dp"
-    android:layout_alignParentRight="true"
     android:layout_alignBottom="@id/buildingImage"
-    style="@style/Widget.AppCompat.Button.Small"
+    android:layout_alignParentRight="true"
     tools:ignore="RtlHardcoded">
 
     <ImageView
         android:id="@+id/lastBuildingIllustrationIcon"
-        android:src="@drawable/ic_building_levels_illustration"
-        android:layout_toRightOf="@id/lastLevelsLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:src="@drawable/ic_building_levels_illustration"
+        app:layout_constraintLeft_toRightOf="@id/lastLevelsLabel"
+        app:layout_constraintTop_toTopOf="parent"
         tools:ignore="RtlHardcoded" />
 
     <TextView
         android:id="@+id/lastLevelsLabel"
-        android:layout_alignParentLeft="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
         android:textSize="14sp"
-        tools:text="3"
-        tools:ignore="RtlHardcoded" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        tools:ignore="RtlHardcoded"
+        tools:text="3" />
 
     <TextView
         android:id="@+id/lastRoofLevelsLabel"
-        android:layout_toRightOf="@id/lastBuildingIllustrationIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="14sp"
-        tools:text="1"
-        tools:ignore="RtlHardcoded" />
+        app:layout_constraintLeft_toRightOf="@id/lastBuildingIllustrationIcon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="RtlHardcoded"
+        tools:text="1" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
+++ b/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="51dp"
+    android:layout_alignParentRight="true"
+    android:layout_alignBottom="@id/buildingImage"
+    style="@style/Widget.AppCompat.Button.Small"
+    tools:ignore="RtlHardcoded">
+
+    <ImageView
+        android:id="@+id/lastBuildingIllustrationIcon"
+        android:src="@drawable/ic_building_levels_illustration"
+        android:layout_toRightOf="@id/lastLevelsLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:ignore="RtlHardcoded" />
+
+    <TextView
+        android:id="@+id/lastLevelsLabel"
+        android:layout_alignParentLeft="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:textSize="14sp"
+        tools:text="3"
+        tools:ignore="RtlHardcoded" />
+
+    <TextView
+        android:id="@+id/lastRoofLevelsLabel"
+        android:layout_toRightOf="@id/lastBuildingIllustrationIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        tools:text="1"
+        tools:ignore="RtlHardcoded" />
+
+</RelativeLayout>


### PR DESCRIPTION
Closes #1772.

### Screenshots

<table>
<tr>
	<th>First time opening the quest:<br>Unchanged interface.
	<th>One saved answer:<br>The button position changed.
	<th>Two saved answers:<br>The latest one is on the left.
<tr>
	<td><img src="https://user-images.githubusercontent.com/202916/120024558-b209ae80-bfef-11eb-931c-bf62008a4a8f.png" width="300">
	<td><img src="https://user-images.githubusercontent.com/202916/120024557-b0d88180-bfef-11eb-9af1-4da7c28de97d.png" width="300">
	<td><img src="https://user-images.githubusercontent.com/202916/120024550-af0ebe00-bfef-11eb-85e9-4066a198704d.png" width="300">
<tr>
	<td colspan="3">
<tr>
	<th>After selecting a saved answer:<br>The buttons remain there.
	<th colspan="2">When there is too little space:<br>The buttons can scroll horizontally. There are at most 5 saved answers.
<tr>
	<td><img src="https://user-images.githubusercontent.com/202916/120024872-1cbaea00-bff0-11eb-87fa-be3b931edab6.png" width="300">
	<td><img src="https://user-images.githubusercontent.com/202916/120024571-b59d3580-bfef-11eb-90fb-0010aed214fa.png" width="300">
    <td><img src="https://user-images.githubusercontent.com/202916/120024563-b33adb80-bfef-11eb-9209-a87cbcfeba50.png" width="300">
</table>