### PR TITLE
Use the new Activity Result API in the AttachPhotoFragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,10 +17,6 @@
     <uses-feature android:name="android.hardware.screen.portrait"/>
 
     <queries>
-        <!-- take a photo to attach to a note -->
-        <intent>
-            <action android:name="android.media.action.IMAGE_CAPTURE"/>
-        </intent>
         <!-- open location in another app -->
         <intent>
             <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
@@ -11,7 +11,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -109,7 +108,7 @@ class AttachPhotoFragment : Fragment() {
             takePhoto.launch(photoUri)
         } catch (e: ActivityNotFoundException) {
             Log.e(TAG, "Could not find a camera app", e)
-            context?.toast(R.string.no_camera_app, Toast.LENGTH_LONG)
+            context?.toast(R.string.no_camera_app)
         } catch (e: IOException) {
             Log.e(TAG, "Unable to create file for photo", e)
             context?.toast(R.string.quest_leave_new_note_create_image_error)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
@@ -1,18 +1,18 @@
 package de.westnordost.streetcomplete.quests.note_discussion
 
-import android.app.Activity.RESULT_OK
-import android.content.Intent
+import android.content.ActivityNotFoundException
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.provider.MediaStore
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.core.view.isGone
@@ -41,6 +41,8 @@ class AttachPhotoFragment : Fragment() {
     private var currentImagePath: String? = null
 
     private lateinit var noteImageAdapter: NoteImageAdapter
+
+    private val takePhoto = registerForActivityResult(ActivityResultContracts.TakePicture(), ::onTakePhotoResult)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_attach_photo, container, false)
@@ -94,53 +96,48 @@ class AttachPhotoFragment : Fragment() {
     }
 
     private fun takePhoto() {
-        val takePhotoIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        activity?.packageManager?.let { packageManager ->
-            if (takePhotoIntent.resolveActivity(packageManager) != null) {
-                try {
-                    val photoFile = createImageFile()
-                    val photoUri = if (Build.VERSION.SDK_INT > 21) {
-                        //Use FileProvider for getting the content:// URI, see: https://developer.android.com/training/camera/photobasics.html#TaskPath
-                        FileProvider.getUriForFile(requireContext(),getString(R.string.fileprovider_authority),photoFile)
-                    } else {
-                        photoFile.toUri()
-                    }
-                    currentImagePath = photoFile.path
-                    takePhotoIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoUri)
-                    startActivityForResult(takePhotoIntent, REQUEST_TAKE_PHOTO)
-                } catch (e: IOException) {
-                    Log.e(TAG, "Unable to create file for photo", e)
-                    context?.toast(R.string.quest_leave_new_note_create_image_error)
-                } catch (e: IllegalArgumentException) {
-                    Log.e(TAG, "Unable to create file for photo", e)
-                    context?.toast(R.string.quest_leave_new_note_create_image_error)
-                }
+        try {
+            val photoFile = createImageFile()
+            val photoUri = if (Build.VERSION.SDK_INT > 21) {
+                // Use FileProvider for getting the content:// URI, see:
+                // https://developer.android.com/training/camera/photobasics.html#TaskPath
+                FileProvider.getUriForFile(requireContext(), getString(R.string.fileprovider_authority), photoFile)
+            } else {
+                photoFile.toUri()
             }
+            currentImagePath = photoFile.path
+            takePhoto.launch(photoUri)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(TAG, "Could not find a camera app", e)
+            context?.toast(R.string.no_camera_app, Toast.LENGTH_LONG)
+        } catch (e: IOException) {
+            Log.e(TAG, "Unable to create file for photo", e)
+            context?.toast(R.string.quest_leave_new_note_create_image_error)
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "Unable to create file for photo", e)
+            context?.toast(R.string.quest_leave_new_note_create_image_error)
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == REQUEST_TAKE_PHOTO) {
-            if (resultCode == RESULT_OK) {
-                try {
-                    val path = currentImagePath!!
-                    val bitmap = decodeScaledBitmapAndNormalize(path, ATTACH_PHOTO_MAXWIDTH, ATTACH_PHOTO_MAXHEIGHT) ?: throw IOException()
-                    val out = FileOutputStream(path)
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, ATTACH_PHOTO_QUALITY, out)
+    private fun onTakePhotoResult(saved: Boolean) {
+        if (saved) {
+            try {
+                val path = currentImagePath!!
+                val bitmap = decodeScaledBitmapAndNormalize(path, ATTACH_PHOTO_MAXWIDTH, ATTACH_PHOTO_MAXHEIGHT) ?: throw IOException()
+                val out = FileOutputStream(path)
+                bitmap.compress(Bitmap.CompressFormat.JPEG, ATTACH_PHOTO_QUALITY, out)
 
-                    noteImageAdapter.list.add(path)
-                    noteImageAdapter.notifyItemInserted(imagePaths.size - 1)
-                } catch (e: IOException) {
-                    Log.e(TAG, "Unable to rescale the photo", e)
-                    context?.toast(R.string.quest_leave_new_note_create_image_error)
-                    removeCurrentImage()
-                }
-
-            } else {
+                noteImageAdapter.list.add(path)
+                noteImageAdapter.notifyItemInserted(imagePaths.size - 1)
+            } catch (e: IOException) {
+                Log.e(TAG, "Unable to rescale the photo", e)
+                context?.toast(R.string.quest_leave_new_note_create_image_error)
                 removeCurrentImage()
             }
-            currentImagePath = null
+        } else {
+            removeCurrentImage()
         }
+        currentImagePath = null
     }
 
     private fun removeCurrentImage() {
@@ -167,7 +164,6 @@ class AttachPhotoFragment : Fragment() {
     companion object {
 
         private const val TAG = "AttachPhotoFragment"
-        private const val REQUEST_TAKE_PHOTO = 1
 
         private const val PHOTO_PATHS = "photo_paths"
         private const val CURRENT_PHOTO_PATH = "current_photo_path"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,6 +472,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="about_category_feedback">Feedback</string>
     <string name="quest_cycleway_value_sidewalk">explicitly shared sidewalk</string>
     <string name="quest_leave_new_note_create_image_error">Unable to create file for photo</string>
+    <string name="no_camera_app">"No external camera app available. Is your pre-installed camera app disabled?"</string>
     <string name="quest_carWashType_title">What kind of car wash is this?</string>
     <string name="quest_carWashType_automated">Automated</string>
     <string name="quest_carWashType_selfService">Self service</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,7 +472,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="about_category_feedback">Feedback</string>
     <string name="quest_cycleway_value_sidewalk">explicitly shared sidewalk</string>
     <string name="quest_leave_new_note_create_image_error">Unable to create file for photo</string>
-    <string name="no_camera_app">"No external camera app available. Is your pre-installed camera app disabled?"</string>
+    <string name="no_camera_app">No camera app available</string>
     <string name="quest_carWashType_title">What kind of car wash is this?</string>
     <string name="quest_carWashType_automated">Automated</string>
     <string name="quest_carWashType_selfService">Self service</string>


### PR DESCRIPTION
This PR replaces the usage of the deprecated `startActivityForResult` method in the `AttachPhotoFragment` with the new [Activity Results API](https://developer.android.com/training/basics/intents/result) introduced in AndroidX. In addition, it fixes #2911 by displaying a `Toast` when no external camera app can be found. I tested both changes on my device and everything works fine.