### PR TITLE
Include `building=unclassified` in building type quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -10,7 +10,7 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
     // information about the purpose of the building, so no need to force asking it
     // same goes (more or less) for tourism, amenity, leisure. See #1854, #1891
     override val elementFilter = """
-        ways, relations with building = yes
+        ways, relations with (building = yes or building = unclassified)
          and !man_made
          and !historic
          and !military


### PR DESCRIPTION
It's used 3425 times and is deprecated: https://taginfo.openstreetmap.org/tags/?key=building&value=unclassified#overview