### PR TITLE
Do not create bitmap with height 0 in PointerPinView

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/PointerPinView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/PointerPinView.kt
@@ -101,12 +101,16 @@ class PointerPinView @JvmOverloads constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         pointerPinBitmap?.recycle()
 
-        val size = min(width, height)
-        val bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bmp)
-        pointerPin.setBounds(0,0, size, size)
-        pointerPin.draw(canvas)
-        pointerPinBitmap = bmp
+        if (w <= 0 || h <= 0) {
+            pointerPinBitmap = null
+        } else {
+            val size = min(width, height)
+            val bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(bmp)
+            pointerPin.setBounds(0, 0, size, size)
+            pointerPin.draw(canvas)
+            pointerPinBitmap = bmp
+        }
     }
 
     override fun onDraw(canvas: Canvas?) {


### PR DESCRIPTION
Fixes #2943. The crash was caused by the `PointerPinView`'s parent height being `0` when the keyboard completely covers the StreetComplete app.

Before:
https://user-images.githubusercontent.com/6892794/120892133-ee9b6280-c60c-11eb-9a55-3fd85fdd5cc2.mp4

After:
https://user-images.githubusercontent.com/6892794/120892140-f3f8ad00-c60c-11eb-9706-de6f92251de8.mp4



