### PR TITLE
Improve resurveying of postbox collection times

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.containsAny
-import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupported
+import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupportedOpeningHours
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
 import java.util.concurrent.FutureTask
 
@@ -144,7 +144,7 @@ class AddOpeningHours (
         // invalid opening_hours rules -> applicable because we want to ask for opening hours again
         val rules = oh.toOpeningHoursRules() ?: return true
         // only display supported rules
-        return rules.isSupported()
+        return rules.isSupportedOpeningHours()
     }
 
     override fun createForm() = AddOpeningHoursForm()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 /** A time range from [start,end). The times are specified in minutes. */
 @Serializable
-data class TimeRange(val start: Int, val end: Int, val isOpenEnded: Boolean = false) : Comparable<TimeRange> {
+data class TimeRange(val start: Int, val end: Int = UNDEFINED_TIME, val isOpenEnded: Boolean = false) : Comparable<TimeRange> {
 
     fun intersects(other: TimeRange): Boolean =
         isOpenEnded && other.start >= start ||
@@ -32,7 +32,7 @@ data class TimeRange(val start: Int, val end: Int, val isOpenEnded: Boolean = fa
     fun toStringUsing(locale: Locale, range: String): String {
         val sb = StringBuilder()
         sb.append(timeOfDayToString(locale, start))
-        if (start != end) {
+        if (end != UNDEFINED_TIME && (start != end || !isOpenEnded)) {
             sb.append(range)
             var displayEnd = timeOfDayToString(locale, end)
             if (displayEnd == "00:00") displayEnd = "24:00"
@@ -51,5 +51,9 @@ data class TimeRange(val start: Int, val end: Int, val isOpenEnded: Boolean = fa
             .toInstant()
             .toEpochMilli()
         return DateFormat.getTimeInstance(DateFormat.SHORT, locale).format(todayAt)
+    }
+
+    companion object {
+        const val UNDEFINED_TIME = Int.MIN_VALUE
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 /** A time range from [start,end). The times are specified in minutes. */
 @Serializable
-data class TimeRange(val start: Int, val end: Int = UNDEFINED_TIME, val isOpenEnded: Boolean = false) : Comparable<TimeRange> {
+data class TimeRange(val start: Int, val end: Int, val isOpenEnded: Boolean = false) : Comparable<TimeRange> {
 
     fun intersects(other: TimeRange): Boolean =
         isOpenEnded && other.start >= start ||
@@ -31,7 +31,7 @@ data class TimeRange(val start: Int, val end: Int = UNDEFINED_TIME, val isOpenEn
     fun toStringUsing(locale: Locale, range: String): String {
         val sb = StringBuilder()
         sb.append(timeOfDayToString(locale, start))
-        if (end != UNDEFINED_TIME && (start != end || !isOpenEnded)) {
+        if (start != end || !isOpenEnded) {
             sb.append(range)
             var displayEnd = timeOfDayToString(locale, end)
             if (displayEnd == "00:00") displayEnd = "24:00"
@@ -42,8 +42,4 @@ data class TimeRange(val start: Int, val end: Int = UNDEFINED_TIME, val isOpenEn
     }
 
     override fun toString() = toStringUsing(Locale.GERMANY, "-")
-
-    companion object {
-        const val UNDEFINED_TIME = Int.MIN_VALUE
-    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -32,7 +32,7 @@ data class TimeRange(val start: Int, val end: Int, val isOpenEnded: Boolean = fa
     fun toStringUsing(locale: Locale, range: String): String {
         val sb = StringBuilder()
         sb.append(timeOfDayToString(locale, start))
-        if (start != end || !isOpenEnded) {
+        if (start != end) {
             sb.append(range)
             var displayEnd = timeOfDayToString(locale, end)
             if (displayEnd == "00:00") displayEnd = "24:00"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -1,8 +1,7 @@
 package de.westnordost.streetcomplete.quests.opening_hours.model
 
+import de.westnordost.streetcomplete.util.timeOfDayToString
 import kotlinx.serialization.Serializable
-import java.text.DateFormat
-import java.time.*
 import java.util.Locale
 
 /** A time range from [start,end). The times are specified in minutes. */
@@ -43,15 +42,6 @@ data class TimeRange(val start: Int, val end: Int = UNDEFINED_TIME, val isOpenEn
     }
 
     override fun toString() = toStringUsing(Locale.GERMANY, "-")
-
-    private fun timeOfDayToString(locale: Locale, minutes: Int): String {
-        val seconds = (minutes % (24*60)) * 60L
-        val todayAt = LocalDateTime.of(LocalDate.now(), LocalTime.ofSecondOfDay(seconds))
-            .atZone(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
-        return DateFormat.getTimeInstance(DateFormat.SHORT, locale).format(todayAt)
-    }
 
     companion object {
         const val UNDEFINED_TIME = Int.MIN_VALUE

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
@@ -133,7 +133,8 @@ fun Rule.isSupportedCollectionTimes(): Boolean =
     // all sub-elements must be supported if specified
     holidays?.all { it.isSupported() } ?: true &&
     days?.all { it.isSupported() } ?: true &&
-    // only time points are supported for collection times
+    // times must be defined, and may not be ranges or something that implies ranges
+    !times.isNullOrEmpty() &&
     times?.all { it.isSupportedCollectionTimes() } ?: true &&
     // months not supported
     dates == null
@@ -188,7 +189,8 @@ fun TimeSpan.isSupportedCollectionTimes(): Boolean =
     interval == 0 &&
     start != TimeSpan.UNDEFINED_TIME &&
     // only support time points
-    end == TimeSpan.UNDEFINED_TIME
+    end == TimeSpan.UNDEFINED_TIME &&
+    !isOpenEnded
 
 /* ------------------------------ Collision/Intersection checking ------------------------------- */
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
@@ -63,11 +63,7 @@ fun OpeningHoursRuleList.toCollectionTimesRows(): List<OpeningHoursRow>? {
     val result = mutableListOf<OpeningHoursRow>()
 
     for (rule in rules) {
-        if (rule.modifier != null && rule.modifier!!.isSimpleOff()) {
-            result.add(rule.createOffDays())
-        } else {
-            result.addAll(rule.createOpeningWeekdays())
-        }
+        result.addAll(rule.createOpeningWeekdays())
     }
 
     return result
@@ -138,12 +134,8 @@ fun Rule.isSupportedCollectionTimes(): Boolean =
     years == null &&
     // "05-08 08:00-11:00" not supported
     weeks == null &&
-    (
-        // for normal rules, only "Mo-Fr" not supported. "open" modifier is ok as long as it does not have a comment
-        (modifier == null || modifier!!.isSimpleOpen()) && !times.isNullOrEmpty() ||
-        // "off"/"closed" only compatible without comment and no times
-        (modifier != null && times.isNullOrEmpty() && modifier!!.isSimpleOff())
-    ) &&
+    // modifiers are not supported
+    modifier == null &&
     // all sub-elements must be supported if specified
     holidays?.all { it.isSupported() } ?: true &&
     days?.all { it.isSupported() } ?: true &&

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParser.kt
@@ -25,7 +25,7 @@ fun String.toOpeningHoursRules(): OpeningHoursRuleList? {
 
 /** returns null if the list of rules cannot be displayed by the opening hours widget */
 fun OpeningHoursRuleList.toOpeningHoursRows(): List<OpeningHoursRow>? {
-    if (!isSupported()) {
+    if (!isSupportedOpeningHours()) {
         // parsable, but not supported by StreetComplete
         return null
     }
@@ -75,7 +75,7 @@ fun OpeningHoursRuleList.toCollectionTimesRows(): List<OpeningHoursRow>? {
 
 /* ---------------------------------- Checks if it is supported --------------------------------- */
 
-fun OpeningHoursRuleList.isSupported(): Boolean = rules.isSupported()
+fun OpeningHoursRuleList.isSupportedOpeningHours(): Boolean = rules.isSupportedOpeningHours()
 fun OpeningHoursRuleList.isSupportedCollectionTimes(): Boolean = rules.isSupportedCollectionTimes()
 
 /** Returns true if supported by StreetComplete
@@ -85,9 +85,9 @@ fun OpeningHoursRuleList.isSupportedCollectionTimes(): Boolean = rules.isSupport
  * is it possible to recreate it by taking only supported parts
  * later it checks also some additional limitations imposed by SC */
 @JvmName("isSupportedRuleList")
-fun List<Rule>.isSupported(): Boolean =
+fun List<Rule>.isSupportedOpeningHours(): Boolean =
     // all rules must be supported
-    all { it.isSupported() } &&
+    all { it.isSupportedOpeningHours() } &&
     // this kind of opening hours specification likely require fix
     // anyway, it is not representable directly by SC
     (!weekdaysCollideWithAnother())
@@ -102,7 +102,7 @@ fun List<Rule>.isSupportedCollectionTimes(): Boolean =
         // anyway, it is not representable directly by SC
         (!weekdaysCollideWithAnother())
 
-fun Rule.isSupported(): Boolean =
+fun Rule.isSupportedOpeningHours(): Boolean =
     !isEmpty &&
     // 24/7 not supported
     !isTwentyfourseven &&
@@ -123,8 +123,8 @@ fun Rule.isSupported(): Boolean =
     // all sub-elements must be supported if specified
     holidays?.all { it.isSupported() } ?: true &&
     days?.all { it.isSupported() } ?: true &&
-    times?.all { it.isSupported() } ?: true &&
-    dates?.all { it.isSupported() } ?: true
+    times?.all { it.isSupportedOpeningHours() } ?: true &&
+    dates?.all { it.isSupportedOpeningHours() } ?: true
 
 fun Rule.isSupportedCollectionTimes(): Boolean =
     !isEmpty &&
@@ -152,8 +152,8 @@ fun Rule.isSupportedCollectionTimes(): Boolean =
     // months not supported
     dates == null
 
-fun DateRange.isSupported(): Boolean =
-    startDate.isSupported() && (endDate?.isSupported() ?: true) && interval == 0
+fun DateRange.isSupportedOpeningHours(): Boolean =
+    startDate.isSupportedOpeningHours() && (endDate?.isSupportedOpeningHours() ?: true) && interval == 0
 
 fun RuleModifier.isSimpleOpen(): Boolean =
     comment == null && modifier == RuleModifier.Modifier.OPEN
@@ -161,7 +161,7 @@ fun RuleModifier.isSimpleOpen(): Boolean =
 fun RuleModifier.isSimpleOff(): Boolean =
     comment == null && (modifier == RuleModifier.Modifier.OFF || modifier == RuleModifier.Modifier.CLOSED)
 
-fun DateWithOffset.isSupported(): Boolean =
+fun DateWithOffset.isSupportedOpeningHours(): Boolean =
     // "Jan+" not supported
     !isOpenEnded &&
     // "Jan +Fr" not supported
@@ -190,7 +190,7 @@ fun WeekDayRange.isSupported(): Boolean =
     // not sure how/if this can be null, just to be sure
     startDay != null
 
-fun TimeSpan.isSupported(): Boolean =
+fun TimeSpan.isSupportedOpeningHours(): Boolean =
     // "sunrise" etc not supported
     startEvent == null && endEvent == null &&
     interval == 0 &&
@@ -345,7 +345,7 @@ private fun TimeSpan.toTimeRange() = TimeRange(
 )
 
 private fun DateRange.toCircularSection(): CircularSection {
-    require(isSupported())
+    require(isSupportedOpeningHours())
     return CircularSection(startDate.month.ordinal, (endDate ?: startDate).month.ordinal)
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.QuestCollectionTimesBinding
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRows
+import de.westnordost.streetcomplete.quests.opening_hours.parser.toCollectionTimesRows
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
 import de.westnordost.streetcomplete.util.AdapterDataChangedWatcher
 import kotlinx.serialization.decodeFromString
@@ -92,7 +92,7 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
 
     private fun initStateFromTags() {
         val ct = osmElement!!.tags["collection_times"]
-        val rows = ct?.toOpeningHoursRules()?.toOpeningHoursRows()
+        val rows = ct?.toOpeningHoursRules()?.toCollectionTimesRows()
         if (rows != null) {
             collectionTimesAdapter.collectionTimesRows = rows.toMutableList()
             setAsResurvey(true)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
@@ -6,12 +6,15 @@ import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.QuestCollectionTimesBinding
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.AnswerItem
+import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRows
+import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
 import de.westnordost.streetcomplete.util.AdapterDataChangedWatcher
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -23,22 +26,39 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
     override val contentLayoutResId = R.layout.quest_collection_times
     private val binding by contentViewBinding(QuestCollectionTimesBinding::bind)
 
+    override val buttonPanelAnswers get() =
+        if(isDisplayingPreviousCollectionTimes) listOf(
+            AnswerItem(R.string.quest_generic_hasFeature_no) { setAsResurvey(false) },
+            AnswerItem(R.string.quest_generic_hasFeature_yes) {
+                applyAnswer(CollectionTimes(osmElement!!.tags["collection_times"]!!.toOpeningHoursRules()!!))
+            }
+        )
+        else emptyList()
+
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_collectionTimes_answer_no_times_specified) { confirmNoTimes() }
     )
 
     private lateinit var collectionTimesAdapter: CollectionTimesAdapter
 
+    private var isDisplayingPreviousCollectionTimes: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val viewData = loadCollectionTimesData(savedInstanceState)
-        collectionTimesAdapter = CollectionTimesAdapter(viewData, requireContext(), countryInfo)
-        collectionTimesAdapter.registerAdapterDataObserver( AdapterDataChangedWatcher { checkIsFormComplete() })
+        collectionTimesAdapter = CollectionTimesAdapter(requireContext(), countryInfo)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (savedInstanceState != null) {
+            onLoadInstanceState(savedInstanceState)
+        } else {
+            initStateFromTags()
+        }
+
+        collectionTimesAdapter.registerAdapterDataObserver( AdapterDataChangedWatcher { checkIsFormComplete() })
 
         binding.collectionTimesList.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         binding.collectionTimesList.adapter = collectionTimesAdapter
@@ -70,8 +90,21 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
         }
     }
 
-    private fun loadCollectionTimesData(savedInstanceState: Bundle?): List<WeekdaysTimesRow> =
-        savedInstanceState?.let { Json.decodeFromString(it.getString(TIMES_DATA)!!) } ?: listOf()
+    private fun initStateFromTags() {
+        val ct = osmElement!!.tags["collection_times"]
+        val rows = ct?.toOpeningHoursRules()?.toOpeningHoursRows()
+        if (rows != null) {
+            collectionTimesAdapter.collectionTimesRows = rows.toMutableList()
+            setAsResurvey(true)
+        } else {
+            setAsResurvey(false)
+        }
+    }
+
+    private fun onLoadInstanceState(savedInstanceState: Bundle) {
+        collectionTimesAdapter.collectionTimesRows = Json.decodeFromString(savedInstanceState.getString(TIMES_DATA)!!)
+        setAsResurvey(savedInstanceState.getBoolean(IS_DISPLAYING_PREVIOUS_TIMES))
+    }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
@@ -82,6 +115,13 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
         applyAnswer(CollectionTimes(collectionTimesAdapter.createCollectionTimes()))
     }
 
+    private fun setAsResurvey(resurvey: Boolean) {
+        collectionTimesAdapter.isEnabled = !resurvey
+        isDisplayingPreviousCollectionTimes = resurvey
+        binding.addTimesButton.isGone = resurvey
+        updateButtonPanel()
+    }
+
     private fun confirmNoTimes() {
         AlertDialog.Builder(requireContext())
             .setTitle(R.string.quest_generic_confirmation_title)
@@ -90,9 +130,10 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
             .show()
     }
 
-    override fun isFormComplete() = collectionTimesAdapter.createCollectionTimes().isNotEmpty()
+    override fun isFormComplete() = collectionTimesAdapter.collectionTimesRows.isNotEmpty() && !isDisplayingPreviousCollectionTimes
 
     companion object {
         private const val TIMES_DATA = "times_data"
+        private const val IS_DISPLAYING_PREVIOUS_TIMES = "ct_is_displaying_previous_times"
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -59,7 +59,9 @@ class AddPostboxCollectionTimes : OsmElementQuestType<CollectionTimesAnswer> {
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "brand", "operator", "ref")
-        // treat invalid collection times like it is not set at all
+        /* treat invalid collection times like it is not set at all. Any opening hours are
+           legal tagging for collection times, even though they are not supported in
+           this app, i.e. are never asked again */
         val hasValidCollectionTimes = tags["collection_times"]?.toOpeningHoursRules() != null
         return if (hasValidCollectionTimes) {
             when {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
+import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
 
 class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
 
@@ -52,11 +53,22 @@ class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
         arrayOfNotNull(getNameOrBrandOrOperatorOrRef(tags))
 
-    override fun getTitle(tags: Map<String, String>): Int =
-        if (tags.containsAnyKey("name", "brand", "operator", "ref"))
-            R.string.quest_postboxCollectionTimes_name_title
-        else
-            R.string.quest_postboxCollectionTimes_title
+    override fun getTitle(tags: Map<String, String>): Int {
+        val hasName = tags.containsAnyKey("name", "brand", "operator", "ref")
+        // treat invalid collection times like it is not set at all
+        val hasValidCollectionTimes = tags["collection_times"]?.toOpeningHoursRules() != null
+        return if (hasValidCollectionTimes) {
+            when {
+                hasName -> R.string.quest_postboxCollectionTimes_resurvey_name_title
+                else    -> R.string.quest_postboxCollectionTimes_resurvey_title
+            }
+        } else {
+            when {
+                hasName -> R.string.quest_postboxCollectionTimes_name_title
+                else    -> R.string.quest_postboxCollectionTimes_title
+            }
+        }
+    }
 
     override fun createForm() = AddCollectionTimesForm()
 
@@ -66,7 +78,7 @@ class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
                 changes.add("collection_times:signed", "no")
             }
             is CollectionTimes -> {
-                changes.updateWithCheckDate("collection_times", answer.times.joinToString(", "))
+                changes.updateWithCheckDate("collection_times", answer.times.toString())
             }
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
@@ -81,7 +81,7 @@ class CollectionTimesAdapter(
 
     private fun add(weekdays: Weekdays, minutes: Int) {
         val insertIndex = itemCount
-        val timeRange = TimeRange(minutes, minutes)
+        val timeRange = TimeRange(minutes)
         collectionTimesRows.add(OpeningWeekdaysRow(weekdays, timeRange))
         notifyItemInserted(insertIndex)
     }
@@ -115,7 +115,7 @@ class CollectionTimesAdapter(
             binding.hoursLabel.text = times.timeRange.toStringUsing(Locale.getDefault(), "–")
             binding.hoursLabel.setOnClickListener {
                 openSetTimeDialog(times.timeRange.start) { minutes ->
-                    times.timeRange = TimeRange(minutes, minutes)
+                    times.timeRange = TimeRange(minutes)
                     notifyItemChanged(adapterPosition)
                 }
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAnswer.kt
@@ -1,6 +1,8 @@
 package de.westnordost.streetcomplete.quests.postbox_collection_times
 
+import de.westnordost.streetcomplete.quests.opening_hours.model.OpeningHoursRuleList
+
 sealed class CollectionTimesAnswer
 
-data class CollectionTimes(val times:List<WeekdaysTimes>) : CollectionTimesAnswer()
+data class CollectionTimes(val times: OpeningHoursRuleList) : CollectionTimesAnswer()
 object NoCollectionTimesSign : CollectionTimesAnswer()

--- a/app/src/main/java/de/westnordost/streetcomplete/util/DateTime.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/DateTime.kt
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.util
+
+import java.text.DateFormat
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.Locale
+
+fun timeOfDayToString(locale: Locale, minutes: Int): String {
+    val seconds = (minutes % (24*60)) * 60L
+    val todayAt = LocalDateTime.of(LocalDate.now(), LocalTime.ofSecondOfDay(seconds))
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
+    return DateFormat.getTimeInstance(DateFormat.SHORT, locale).format(todayAt)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -582,6 +582,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_cycleway_value_suggestion_lane">bicycle suggestion lane</string>
     <string name="quest_postboxCollectionTimes_title">What are the collection times of this postbox?</string>
     <string name="quest_postboxCollectionTimes_name_title">What are the collection times of this %s postbox?</string>
+    <string name="quest_postboxCollectionTimes_resurvey_title">Are the collection times of this postbox still correct?</string>
+    <string name="quest_postboxCollectionTimes_resurvey_name_title">Are the collection times of this %s postbox still correct?</string>
     <string name="quest_postboxRef_title">What is the reference number of this postbox?</string>
     <string name="quest_postboxRef_name_title">What is the reference number of this %s postbox?</string>
     <string name="quest_ref_answer_noRef">"No reference number visible…"</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/OpeningHoursParsingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/OpeningHoursParsingTest.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete
 import ch.poole.openinghoursparser.YearRange
 import de.westnordost.streetcomplete.quests.opening_hours.parser.weekdaysCollideWithAnother
 import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupported
+import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupportedOpeningHours
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRows
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
 import kotlinx.coroutines.launch
@@ -92,13 +93,13 @@ fun main() = runBlocking {
                         if(r.any { rule -> rule.times?.any { it.startEvent != null || it.endEvent != null } == true }) {
                             timeEvents++
                         }
-                        if(r.any { rule -> rule.times?.any { !it.isSupported() && it.startEvent == null && it.endEvent == null  } == true }) {
+                        if(r.any { rule -> rule.times?.any { !it.isSupportedOpeningHours() && it.startEvent == null && it.endEvent == null  } == true }) {
                             complicatedTimes++
                         }
-                        if(r.any { rule -> rule.dates?.any { !it.isSupported() } == true}) {
+                        if(r.any { rule -> rule.dates?.any { !it.isSupportedOpeningHours() } == true}) {
                             complicatedDates++
                         }
-                        if (r.all { it.isSupported() } && r.weekdaysCollideWithAnother()) {
+                        if (r.all { it.isSupportedOpeningHours() } && r.weekdaysCollideWithAnother()) {
                             selfColliding++
                         }
                     }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt
@@ -1,7 +1,11 @@
 package de.westnordost.streetcomplete.quests
 
+import ch.poole.openinghoursparser.Rule
+import ch.poole.openinghoursparser.TimeSpan
+import ch.poole.openinghoursparser.WeekDay
+import ch.poole.openinghoursparser.WeekDayRange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
-import de.westnordost.streetcomplete.quests.opening_hours.model.weekdays
+import de.westnordost.streetcomplete.quests.opening_hours.model.*
 import de.westnordost.streetcomplete.quests.postbox_collection_times.*
 import org.junit.Test
 
@@ -18,10 +22,25 @@ class AddPostboxCollectionTimesTest {
 
     @Test fun `apply collection times answer`() {
         questType.verifyAnswer(
-            CollectionTimes(listOf(
-                WeekdaysTimes(weekdays(0b10000000), mutableListOf(60)),
-                WeekdaysTimes(weekdays(0b01000000), mutableListOf(120))
-            )),
+            CollectionTimes(OpeningHoursRuleList(listOf(
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.MO
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60
+                    })
+                },
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.TU
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60*2
+                    })
+                    isAdditive = true
+                },
+            ))),
             // here ; would be fine as well instead of ,
             // see https://github.com/streetcomplete/StreetComplete/pull/2604#issuecomment-783823068
             StringMapEntryAdd("collection_times", "Mo 01:00, Tu 02:00")
@@ -33,21 +52,62 @@ class AddPostboxCollectionTimesTest {
     // see https://github.com/streetcomplete/StreetComplete/pull/2604#issuecomment-783823068
     @Test fun `require comma where this matters`() {
         questType.verifyAnswer(
-            CollectionTimes(listOf(
-                WeekdaysTimes(weekdays(0b11100000), mutableListOf(60)),
-                WeekdaysTimes(weekdays(0b01000000), mutableListOf(120))
-            )),
+            CollectionTimes(OpeningHoursRuleList(listOf(
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.MO
+                        it.endDay = WeekDay.WE
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60
+                    })
+                },
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.TU
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60*2
+                    })
+                    isAdditive = true
+                },
+            ))),
             StringMapEntryAdd("collection_times", "Mo-We 01:00, Tu 02:00")
         )
     }
 
     @Test fun `require comma where this matters and conflict is between nonadjacent ranges`() {
         questType.verifyAnswer(
-            CollectionTimes(listOf(
-                WeekdaysTimes(weekdays(0b11100000), mutableListOf(60)),
-                WeekdaysTimes(weekdays(0b00011110), mutableListOf(120)),
-                WeekdaysTimes(weekdays(0b10000000), mutableListOf(180))
-            )),
+            CollectionTimes(OpeningHoursRuleList(listOf(
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.MO
+                        it.endDay = WeekDay.WE
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60
+                    })
+                },
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.TH
+                        it.endDay = WeekDay.SU
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60*2
+                    })
+                    isAdditive = true
+                },
+                Rule().apply {
+                    days = listOf(WeekDayRange().also {
+                        it.startDay = WeekDay.MO
+                    })
+                    times = listOf(TimeSpan().also {
+                        it.start = 60*3
+                    })
+                    isAdditive = true
+                },
+            ))),
             StringMapEntryAdd("collection_times", "Mo-We 01:00, Th-Su 02:00, Mo 03:00")
         )
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRangeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRangeTest.kt
@@ -85,5 +85,15 @@ class TimeRangeTest {
             "00:00 - 24:00",
             TimeRange(0, 24*60).toStringUsing(Locale.GERMANY, " - ")
         )
+
+        assertEquals(
+            "12:00 AM",
+            TimeRange(0).toStringUsing(Locale.US, " - ")
+        )
+
+        assertEquals(
+            "00:00",
+            TimeRange(0).toStringUsing(Locale.GERMANY, " - ")
+        )
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRangeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRangeTest.kt
@@ -85,15 +85,5 @@ class TimeRangeTest {
             "00:00 - 24:00",
             TimeRange(0, 24*60).toStringUsing(Locale.GERMANY, " - ")
         )
-
-        assertEquals(
-            "12:00 AM",
-            TimeRange(0).toStringUsing(Locale.US, " - ")
-        )
-
-        assertEquals(
-            "00:00",
-            TimeRange(0).toStringUsing(Locale.GERMANY, " - ")
-        )
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParserAndGeneratorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/parser/OpeningHoursParserAndGeneratorTest.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.quests.opening_hours.parser
 
 import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningHoursRow
+import de.westnordost.streetcomplete.quests.postbox_collection_times.CollectionTimesRow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -34,6 +35,7 @@ class OpeningHoursParserAndGeneratorTest {
         reject("Mo-Fr") // just weekdays
         reject("PH") // just holidays
 
+        // dates, months, months ranges
         reject("Jan-Dec") // month range, without hours range
         reject("Jun+: Mo 08:30-09:00") // extended ranges for dates
         reject("Jun +Fr: Mo 08:30-09:00") // and all that other stuff...
@@ -44,6 +46,7 @@ class OpeningHoursParserAndGeneratorTest {
         reject("Jul 01-Sep 19 Th 17:30-19:30") // date range not limited to months
         reject("Jul 01-Sep 30 Th 17:30-19:30") // date range with explicit days
 
+        // holidays
         reject("SH 08:00-10:00") // school holiday
         reject("PH Mo 08:00-10:00") // ph on mondays
         reject("PH +5 days 08:00-10:00") // ph with offset
@@ -200,6 +203,164 @@ class OpeningHoursParserAndGeneratorTest {
 
     private fun parse(oh: String): List<OpeningHoursRow>? {
         return oh.toOpeningHoursRules()?.toOpeningHoursRows()
+    }
+
+    private fun reject(oh: String) {
+        assertNull(parse(oh))
+    }
+
+    private fun accept(oh: String, result: String = oh) {
+        assertEquals(result, parseAndGenerate(oh))
+    }
+}
+
+class CollectionTimesParserAndGeneratorTest {
+
+    @Test fun `reject invalid or unsupported syntax`() {
+        reject("gibberish")
+
+        reject("Mo-Fr 09:00 \"comment text\"") // comments
+        reject("08:00 || 10:00") // with fallback
+
+        reject("2000 Mo 09:00") // years
+        reject("2000+ Mo 09:00") // years+
+        reject("2000-2044 Mo 09:00") // year ranges
+        reject("2000-2044/8 Mo 09:00") // year ranges with lap years
+
+        reject("week 01 Mo 06:00") // week indexing
+        reject("week 01,03 Mo 06:00") // weeks
+        reject("week 01-51 Mo 06:00") // week range indexing
+        reject("week 01-51/4 Mo 06:00") // week range with lap weeks
+
+        // modifiers
+        reject("Mo 09:00 open")
+        reject("Mo off")
+        reject("Mo closed")
+        reject("Tu-Fr 08:00; Mo unknown") // unknown modifier
+        reject("Mo 09:00; PH open") // open only accepted with times
+        reject("Mo 09:00 open \"a comment\"") // open only accepted with times
+        reject("Mo 09:00; PH off \"a comment\"") // no comments supported
+        reject("Mo 09:00; PH closed \"a comment\"") // no comments supported
+
+        reject("Mo-Fr") // just weekdays
+        reject("PH") // just holidays
+
+        // dates, months and months ranges
+        reject("Jun Th 17:30")
+        reject("Sep-Feb Mo 17:00")
+        reject("Jan-Feb Mo 17:00")
+        reject("Jun+: Mo 08:30") // extended ranges for dates
+        reject("Jun +Fr: Mo 08:30") // and all that other stuff...
+        reject("Jun -Fr: Mo 08:30")
+        reject("Jun +Fr +4 days: Mo 08:30")
+        reject("Jun 5: Mo 08:30")
+        reject("easter: Mo 08:30")
+        reject("Jul 01-Sep 19 Th 17:30") // date range not limited to months
+        reject("Jul 01-Sep 30 Th 17:30") // date range with explicit days
+        reject("Mar,Oct Mo-Su 07:00")
+        reject("Apr,Oct-Feb Mo-Su 07:00")
+        reject("Jun-Jul,Nov-Dec Mo 08:30")
+        // partially month based
+        reject("Th 17:30; Jul-Sep Mo 17:00")
+        reject("Jul-Sep Mo 17:00; Th 17:30-19:30")
+
+        // holidays
+        reject("SH 08:00") // school holiday
+        reject("PH Mo 08:00") // ph on mondays
+        reject("PH +5 days 08:00") // ph with offset
+        reject("PH,SH 08:00") // holiday sequence
+        reject("Mo[1] 09:00") // first monday within month
+        reject("Mo +2 days 10:00") // day offsets
+
+        reject("Mo sunrise") // event based
+        reject("Mo 10:00/90") // intervals
+
+        // rules overriding earlier rules
+        reject("Th 17:30; Th 20:00")
+        reject("Mo-Th 17:30; Mo-Th 10:00")
+        reject("PH 08:00; PH 10:00")
+        reject("Mo-Th 17:30; Tu-Su 10:00")
+        reject("Mo-Th 17:30; Tu 20:00")
+        reject("Oct Mo 08:30;Oct Mo 18:30")
+        reject("Jan-Feb Mo 08:30;Oct-Jan Mo 10:30")
+        reject("Th 17:30, Th 20:00; Th 01:00")
+
+        // anything that implies time ranges
+        reject("Mo 06:00-08:00") // actual time range
+        reject("24/7") // 24/7
+        reject("Mo 06:00+") // open end
+    }
+
+    @Test fun `reject rules that are currently not supported but can be reasonably added`() {
+        reject("\"some comment\"")
+    }
+
+    @Test fun `accepted valid and supported rule`() {
+        // without explicit days of week
+        accept("09:00")
+        // simple weekday + time
+        accept("Mo 09:00")
+        accept("Mo: 09:00", "Mo 09:00")
+        accept("Mo 09:35")
+        accept("Mo 00:00")
+        accept("Mo 24:00")
+        accept("Mo 5:00", "Mo 05:00")
+        accept("Mo 09h00", "Mo 09:00")
+        accept("Mo 09.00", "Mo 09:00")
+        accept("Mo 9AM", "Mo 09:00")
+        accept("mo 9h30am", "Mo 09:30")
+        accept("Mo 5", "Mo 05:00")
+        accept("Mon 08:00", "Mo 08:00")
+        accept("Di 08:00", "Tu 08:00")
+        accept("Mo       09:00   ", "Mo 09:00")
+        // multiple times
+        accept("Mo 08:00,13:00")
+        accept("Mo 08:00,13:00,18:00")
+        // weekdays and PH
+        accept("PH 08:00")
+        accept("PH,Mo-Th 08:00")
+        // weekday ranges
+        accept("Mo-Th 08:00")
+        accept("Th-Tu 08:00")
+        accept("Th    -     Tu 08:00    ", "Th-Tu 08:00")
+        accept("Mo  ,   Tu   08:00", "Mo,Tu 08:00")
+        accept("Mo-Tu 08:00", "Mo,Tu 08:00")
+        // multiple weekday ranges
+        accept("Mo-We,Tu 08:00", "Mo-We 08:00")
+        accept("Mo,Tu,We,Th,Fr,Sa,Su 08:00", "Mo-Su 08:00")
+        accept("Mo,We,Fr,Sa 08:00")
+        accept("Mo,We,Fr,Sa-Su 08:00", "We,Fr-Mo 08:00")
+        accept("Mo-We,Fr-Su 08:00", "Fr-We 08:00")
+        accept("Mo-We,Fr-Sa 08:00", "Mo-We,Fr,Sa 08:00")
+    }
+
+    @Test fun `accepted valid and supported rules`() {
+        accept("Mo-We 09:00; Th 08:00")
+        accept("Mo 09:00; Su 10:00; Tu 09:00")
+        // use ";" if weekdays don't collide
+        accept("Su-Tu 09:00; We-Sa 10:00")
+        accept("Mo-We 09:00, Th 08:00", "Mo-We 09:00; Th 08:00")
+        accept("Mo 09:00, Su 10:00, Tu 09:00", "Mo 09:00; Su 10:00; Tu 09:00")
+        accept("Mo-Fr 07:30, Sa-Su 9:00", "Mo-Fr 07:30; Sa,Su 09:00")
+        accept("Mo 17:30, Th 17:00", "Mo 17:30; Th 17:00")
+        accept("Mo-Sa 07:00; PH 07:00")
+        // use "," if weekdays collide
+        accept("Mo-We 09:00, Tu 16:00")
+        accept("Mo-We 09:00, We-Fr 21:00")
+        accept("Mo-Sa 07:00, PH,Sa 22:00")
+        accept("Mo-We 09:00, Tu 16:00; Sa 12:00", "Mo-We 09:00, Tu 16:00, Sa 12:00")
+        // merging consecutive rules with same days
+        accept("Mo 09:00, Mo 21:00", "Mo 09:00,21:00")
+        accept("Mo-Fr 09:00, Mo-Fr 21:00", "Mo-Fr 09:00,21:00")
+        accept("Mo-Fr,Su,PH 09:00, Mo-Fr,Su,PH 21:00", "PH,Su-Fr 09:00,21:00")
+    }
+
+    private fun parseAndGenerate(oh: String): String? {
+        return oh.toOpeningHoursRules()?.toCollectionTimesRows()?.toOpeningHoursRules()?.toString()
+    }
+
+    private fun parse(oh: String): List<CollectionTimesRow>? {
+        return oh.toOpeningHoursRules()?.toCollectionTimesRows()
     }
 
     private fun reject(oh: String) {


### PR DESCRIPTION
This adds a yes/no form to ask whether the previous collection times are still correct like for opening hours and is based on that implementation. Fixes #2105 (sparked by #2963).

The tests in https://github.com/streetcomplete/StreetComplete/blob/master/app/src/test/java/de/westnordost/streetcomplete/quests/AddPostboxCollectionTimesTest.kt are broken because I don't understand the format there in order to upgrade them, e.g. what is `WeekdaysTimes(weekdays(0b10000000), mutableListOf(60))`? In general, I'm not really familiar with Kotlin yet, so let me know if anything can be simplified.

One issue so far is that the resurvey form only displays collection times separated by commas (`Mo-Fr 18:15, Su 10:30`), not those separated by semicolons (`Mo-Fr 18:15; Su 10:30`).