### PR TITLE
Add via to note comments

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
@@ -30,7 +30,7 @@ import javax.inject.Singleton
             noteId,
             position,
             action,
-            fulltext,
+            fullText,
             imagePaths,
             currentTimeMillis(),
             false,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osmnotes.edits
 
+import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmnotes.Note
@@ -23,12 +24,13 @@ import javax.inject.Singleton
         text: String? = null,
         imagePaths: List<String> = emptyList()
     ) {
+        val fullText = "$text\n\nvia ${ApplicationConstants.USER_AGENT}"
         val edit = NoteEdit(
             0,
             noteId,
             position,
             action,
-            text,
+            fulltext,
             imagePaths,
             currentTimeMillis(),
             false,


### PR DESCRIPTION
Add a 'via StreetComplete <version>' to note comments added by StreetComplete. This will allow (in a different, future change) the notes quest to differentiate between note comments created in StreetComplete or elsewhere, allowing notes to be reactivated in StreetComplete when commented on elsewhere even by the StreetComplete user.