### PR TITLE
Allow handrail quest to split the way

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -25,6 +25,7 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether steps have a handrail"
     override val wikiLink = "Key:handrail"
     override val icon = R.drawable.ic_quest_steps_handrail
+    override val isSplitWayEnabled = true
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
 


### PR DESCRIPTION
Because handrails may not exist the whole way along a staircase.

Untested but trivial, I assume this automagically deals with the can't say/other answers switching without additional changes?