### PR TITLE
Add building=bungalow to buildings with an address

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -182,7 +182,7 @@ private val buildingsWithMissingAddressFilter by lazy { """
     """.toElementFilterExpression()}
 
 private val buildingTypesThatShouldHaveAddresses = listOf(
-    "house", "residential", "apartments", "detached", "terrace", "dormitory", "semi",
+    "house", "residential", "apartments", "bungalow", "detached", "terrace", "dormitory", "semi",
     "semidetached_house", "farm", "school", "civic", "college", "university", "public", "hospital",
     "kindergarten", "train_station", "hotel", "retail", "shop", "commercial"
 )


### PR DESCRIPTION
In the UK at least a bungalow is most often a residential house, that
happens to be single story.