### PR TITLE
link to "FAQ" in "About" menu

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -57,6 +57,10 @@ class AboutFragment : PreferenceFragmentCompat() {
             openUrl("https://github.com/streetcomplete/StreetComplete/")
         }
 
+        findPreference<Preference>("faq")?.setOnPreferenceClickListener {
+            openUrl("https://wiki.openstreetmap.org/wiki/StreetComplete/FAQ")
+        }
+
         findPreference<Preference>("translate")?.summary = resources.getString(
             R.string.about_description_translate,
             Locale.getDefault().displayLanguage,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -18,6 +18,7 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
           )
           and surface ~ ${ANYTHING_PAVED.joinToString("|")}
           and (!lanes or lanes = 0)
+          and (!lanes:backward or !lanes:forward)
           and lane_markings != no
     """
     override val commitMessage = "Add road lanes"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,8 @@
     <string name="about_summary_authors">"© 2016–2021 Tobias Zwick and contributors"</string>
     <string name="about_title_repository">"Source Repository"</string>
     <string name="about_summary_repository">"on GitHub"</string>
-    <string name="about_title_faq">"Frequently Asked Questions"</string>
-    <string name="about_summary_faq">"Please read these FAQ first if you have issues."</string>
+    <string name="about_title_faq">"FAQ"</string>
+    <string name="about_summary_faq">"Please read these first."</string>
     <string name="about_title_report_error">"Report error"</string>
     <string name="about_title_feedback">"Give Feedback"</string>
     <string name="about_title_license">"License"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@
     <string name="about_summary_authors">"© 2016–2021 Tobias Zwick and contributors"</string>
     <string name="about_title_repository">"Source Repository"</string>
     <string name="about_summary_repository">"on GitHub"</string>
+    <string name="about_title_faq">"Frequently Asked Questions"</string>
+    <string name="about_summary_faq">"please read this FAQ first if you have issues"</string>
     <string name="about_title_report_error">"Report error"</string>
     <string name="about_title_feedback">"Give Feedback"</string>
     <string name="about_title_license">"License"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,6 @@
     <string name="about_title_repository">"Source Repository"</string>
     <string name="about_summary_repository">"on GitHub"</string>
     <string name="about_title_faq">"FAQ"</string>
-    <string name="about_summary_faq">"Please read these first."</string>
     <string name="about_title_report_error">"Report error"</string>
     <string name="about_title_feedback">"Give Feedback"</string>
     <string name="about_title_license">"License"</string>

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -36,6 +36,12 @@
         android:widgetLayout="@layout/widget_image_open_in_browser"/>
 
     <Preference
+        android:key="faq"
+        android:title="@string/about_title_faq"
+        android:summary="@string/about_summary_faq"
+        android:widgetLayout="@layout/widget_image_open_in_browser"/>
+
+    <Preference
         android:key="privacy"
         android:title="@string/about_title_privacy_statement"
         android:summary="@string/about_summary_privacy_statement"

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -37,7 +37,6 @@
     <Preference
         android:key="faq"
         android:title="@string/about_title_faq"
-        android:summary="@string/about_summary_faq"
         android:widgetLayout="@layout/widget_image_open_in_browser"/>
 
     <Preference

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -32,6 +32,7 @@
     <Preference
         android:key="repository"
         android:title="@string/about_title_repository"
+        android:summary="@string/about_summary_repository"
         android:widgetLayout="@layout/widget_image_open_in_browser"/>
 
     <Preference

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -32,7 +32,6 @@
     <Preference
         android:key="repository"
         android:title="@string/about_title_repository"
-        android:summary="@string/about_summary_repository"
         android:widgetLayout="@layout/widget_image_open_in_browser"/>
 
     <Preference


### PR DESCRIPTION
As mentioned in https://github.com/streetcomplete/StreetComplete/issues/2976#issuecomment-873084127, it is worth to include link to _Frequently Asked Questions_ in the StreetComplete menu, some people (myself included) would read the [FAQ](https://wiki.openstreetmap.org/wiki/StreetComplete/FAQ) and learn something new, even when they're not having problems (and especially when they are).

Closes https://github.com/streetcomplete/StreetComplete/issues/2976