### PR TITLE
Count a node as a kerb even if it has a kerb= tag.

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/KerbUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/KerbUtil.kt
@@ -37,7 +37,7 @@ private val allowedKeysOnKerbNode = setOf(
     "sloped_curb",
     "tactile_paving",
     "surface", "smoothness", "material",
-    "kerb:height", "height",
+    "kerb", "kerb:height", "height",
     // access/eligibility-related
     "wheelchair", "bicycle", "foot", "stroller",
     // misc / meta info

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerbTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerbTest.kt
@@ -1,0 +1,22 @@
+package de.westnordost.streetcomplete.quests.tactile_paving
+
+import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
+import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.way
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AddTactilePavingKerbTest {
+    private val questType = AddTactilePavingKerb()
+
+    @Test fun `applicable to kerb with height`() {
+        val node = node(id = 1, tags = mapOf("barrier" to "kerb", "kerb" to "lowered"))
+        val mapData = TestMapDataWithGeometry(listOf(node, way(nodes = listOf(1, 2, 3), tags = mapOf(
+            "highway" to "footway",
+            "footway" to "sidewalk"
+        ))))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+        assertNull(questType.isApplicableTo(node))
+    }
+}


### PR DESCRIPTION
Otherwise, if the AddKerbHeight quest is ordered before AddTactilePavingKerb, the latter will never apply.