### PR TITLE
Give users a "this crossing doesn't exist" option in the crossing-type quest.

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -363,8 +363,8 @@ class MainFragment : Fragment(R.layout.fragment_main),
         }
     }
 
-    override fun onComposeNote(questKey: QuestKey, questTitle: String) {
-        showInBottomSheet(LeaveNoteInsteadFragment.create(questKey, questTitle))
+    override fun onComposeNote(questKey: QuestKey, questTitle: String, initialMessage: String?) {
+        showInBottomSheet(LeaveNoteInsteadFragment.create(questKey, questTitle, initialMessage))
     }
 
     override fun onSplitWay(osmQuestKey: OsmQuestKey) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -103,7 +103,7 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
         fun onAnsweredQuest(questKey: QuestKey, answer: Any)
 
         /** Called when the user chose to leave a note instead  */
-        fun onComposeNote(questKey: QuestKey, questTitle: String)
+        fun onComposeNote(questKey: QuestKey, questTitle: String, initialMessage: String?)
 
         /** Called when the user chose to split the way  */
         fun onSplitWay(osmQuestKey: OsmQuestKey)
@@ -337,10 +337,10 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
         }
     }
 
-    protected fun composeNote() {
+    protected fun composeNote(initialMessage: String? = null) {
         if (answered++ == 0) {
             val questTitle = englishResources.getQuestTitle(questType, osmElement, featureDictionaryFuture)
-            listener?.onComposeNote(questKey, questTitle)
+            listener?.onComposeNote(questKey, questTitle, initialMessage)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
@@ -18,18 +18,21 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment(), IsShowingQuestDet
     interface Listener {
         fun onCreatedNoteInstead(questKey: QuestKey, questTitle: String, note: String, imagePaths: List<String>)
     }
+
     private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
 
     override val layoutResId = R.layout.fragment_quest_answer
 
     private lateinit var questTitle: String
     override lateinit var questKey: QuestKey
+    private var initialMessage: String? = null
 
     override fun onCreate(inState: Bundle?) {
         super.onCreate(inState)
         val args = requireArguments()
         questTitle = args.getString(ARG_QUEST_TITLE)!!
         questKey = Json.decodeFromString(args.getString(ARG_QUEST_KEY)!!)
+        initialMessage = args.getString(ARG_INITIAL_MESSAGE)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -37,6 +40,7 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment(), IsShowingQuestDet
 
         titleLabel.text = getString(R.string.map_btn_create_note)
         descriptionLabel.text = null
+        initialMessage?.let { noteInput.setText(it) }
     }
 
     override fun onComposedNote(text: String, imagePaths: List<String>) {
@@ -46,12 +50,14 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment(), IsShowingQuestDet
     companion object {
         private const val ARG_QUEST_TITLE = "questTitle"
         private const val ARG_QUEST_KEY = "questKey"
+        private const val ARG_INITIAL_MESSAGE = "initialMessage"
 
-        fun create(questKey: QuestKey, questTitle: String): LeaveNoteInsteadFragment {
+        fun create(questKey: QuestKey, questTitle: String, initialMessage: String?): LeaveNoteInsteadFragment {
             val f = LeaveNoteInsteadFragment()
             f.arguments = bundleOf(
                 ARG_QUEST_KEY to Json.encodeToString(questKey),
-                ARG_QUEST_TITLE to questTitle
+                ARG_QUEST_TITLE to questTitle,
+                ARG_INITIAL_MESSAGE to initialMessage
             )
             return f
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -5,6 +5,8 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.quests.OtherAnswer
+import de.westnordost.streetcomplete.quests.building_type.BuildingType
 
 class AddCrossingType : OsmFilterQuestType<CrossingType>() {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -5,8 +5,6 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.quests.OtherAnswer
-import de.westnordost.streetcomplete.quests.building_type.BuildingType
 
 class AddCrossingType : OsmFilterQuestType<CrossingType>() {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
@@ -2,7 +2,6 @@ package de.westnordost.streetcomplete.quests.crossing_type
 
 import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.quests.AImageListQuestAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.*
@@ -18,15 +17,19 @@ class AddCrossingTypeForm : AImageListQuestAnswerFragment<CrossingType, Crossing
 
     override val otherAnswers = listOf(
         OtherAnswer(R.string.quest_crossing_type_no_crossing) {
-            activity?.let { AlertDialog.Builder(it)
-                .setMessage(R.string.quest_crossing_type_explain_delete_crossing_note)
-                .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok) { _, _ ->
-                    composeNote("This crossing does not exist.")
-                }
-                .show()
+            activity?.let {
+                AlertDialog.Builder(it)
+                    .setMessage(R.string.quest_crossing_type_explain_delete_crossing_note)
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        // Notes should be in English or the local language. This default value
+                        // assumes that the app's language is the local language. Hopefully users
+                        // will notice the advisory text and fix it if that's wrong.
+                        composeNote(getString(R.string.quest_crossing_type_no_crossing_note_prefill))
+                    }
+                    .show()
             }
-                                                              },
+        },
     )
 
     override val itemsPerRow = 3

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
@@ -1,7 +1,10 @@
 package de.westnordost.streetcomplete.quests.crossing_type
 
+import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.quests.AImageListQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.*
 import de.westnordost.streetcomplete.view.image_select.Item
 
@@ -11,6 +14,19 @@ class AddCrossingTypeForm : AImageListQuestAnswerFragment<CrossingType, Crossing
         Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals_controlled),
         Item(MARKED, R.drawable.crossing_type_zebra, R.string.quest_crossing_type_marked),
         Item(UNMARKED, R.drawable.crossing_type_unmarked, R.string.quest_crossing_type_unmarked)
+    )
+
+    override val otherAnswers = listOf(
+        OtherAnswer(R.string.quest_crossing_type_no_crossing) {
+            activity?.let { AlertDialog.Builder(it)
+                .setMessage(R.string.quest_crossing_type_explain_delete_crossing_note)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    composeNote("This crossing does not exist.")
+                }
+                .show()
+            }
+                                                              },
     )
 
     override val itemsPerRow = 3

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
@@ -137,7 +137,7 @@ class ShowQuestFormsActivity : AppCompatActivity(), AbstractQuestAnswerFragment.
             .show()
         popQuestForm()
     }
-    override fun onComposeNote(questKey: QuestKey, questTitle: String) {
+    override fun onComposeNote(questKey: QuestKey, questTitle: String, initialMessage: String?) {
         popQuestForm("Composing note")
     }
     override fun onSplitWay(osmQuestKey: OsmQuestKey) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,6 +375,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_crossing_type_unmarked">Crossing without road markings</string>
     <string name="quest_crossing_type_no_crossing">There is no crossing here.</string>
     <string name="quest_crossing_type_explain_delete_crossing_note">The crossing needs to be deleted in a more general map editor. Please leave a note explaining how the crossing has gone away.</string>
+    <string name="quest_crossing_type_no_crossing_note_prefill">This crossing does not exist.</string>
     <string name="compass_north_one_letter">N</string>
     <string name="action_undo">Undo</string>
     <string name="undo_last">Undo last edit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_crossing_type_signals_controlled">Crossing controlled by traffic lights</string>
     <string name="quest_crossing_type_marked">Marked crossing</string>
     <string name="quest_crossing_type_unmarked">Crossing without road markings</string>
+    <string name="quest_crossing_type_no_crossing">There is no crossing here.</string>
+    <string name="quest_crossing_type_explain_delete_crossing_note">The crossing needs to be deleted in a more general map editor. Please leave a note explaining how the crossing has gone away.</string>
     <string name="compass_north_one_letter">N</string>
     <string name="action_undo">Undo</string>
     <string name="undo_last">Undo last edit</string>


### PR DESCRIPTION
Fixes #3106

This just opens a note with a suggestion of what to write, but it's clearer than the status quo in saying a note is the right way to handle this problem.

When the only aspect of the crossing is a `highway=crossing` node, without a `footway=crossing` way, I think we could implement this without a note by removing the `highway=crossing` tag (and leaving the node), but conversation on the issue seemed unfavorable to being even that aggressive.