### PR TITLE
Sort building levels recents by regular, then roof

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -31,7 +31,9 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     private val roofLevels get() = roofLevelsInput?.text?.toString().orEmpty().trim()
 
     private val lastPickedAnswers by lazy {
-        favs.get(javaClass.simpleName).map { it.toBuildingLevelAnswer() }
+        favs.get(javaClass.simpleName).map { it.toBuildingLevelAnswer() }.sortedWith(
+            compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels }
+        )
     }
 
     @Inject internal lateinit var favs: LastPickedValuesStore<String>


### PR DESCRIPTION
The new building levels recent values is great. However, I've found that the vast majority of the buildings in the areas I map are 5 values: 1/0, 1/1, 2/0, 2/1, and -- probably to the surprise of no one -- 3/0. With that in mind, a stabler sort order would be much easier for me to scan and find the entry I'm looking for than the current FIFO queue.

~~I haven't tried this yet, going to do it this morning.~~ Tried it, works as intended.