### PR TITLE
[Exploration] Keep rotation center when note or form is open

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -609,9 +609,12 @@ class MainFragment : Fragment(R.layout.fragment_main),
                     tilt = if (isFlat) PI.toFloat() / 5f else 0f
                 }
             } else {
+                val pos = mapFragment.getCurrentCenter(mapOffsetWithOpenBottomSheet)!!
+                val offsetPos = mapFragment.getPostrotationPositionThatCentersPosition(pos, mapOffsetWithOpenBottomSheet)
                 mapFragment.updateCameraPosition(300) {
                     rotation = 0f
                     tilt = 0f
+                    position = offsetPos
                 }
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MapFragment.kt
@@ -364,8 +364,16 @@ open class MapFragment : Fragment(),
         }
     }
 
+    fun getCurrentCenter(padding: RectF): LatLon? {
+        return controller?.screenCenterToLatLon(padding)
+    }
+
     fun getPositionThatCentersPosition(pos: LatLon, offset: RectF): LatLon? {
         return controller?.getLatLonThatCentersLatLon(pos, offset)
+    }
+
+    fun getPostrotationPositionThatCentersPosition(pos: LatLon, offset: RectF): LatLon? {
+        return controller?.getLatLonThatCentersLatLonAfterRotation(pos, offset)
     }
 
     fun getDisplayedArea(): BoundingBox? = controller?.screenAreaToBoundingBox(RectF())

--- a/app/src/main/java/de/westnordost/streetcomplete/map/tangram/KtMapController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/tangram/KtMapController.kt
@@ -279,6 +279,27 @@ class KtMapController(private val c: MapController, contentResolver: ContentReso
         return position.translate(distanceAfterZoom, angle)
     }
 
+    fun getLatLonThatCentersLatLonAfterRotation(position: LatLon, padding: RectF, zoom: Float = cameraPosition.zoom): LatLon? {
+        val view = glViewHolder?.view ?: return null
+        val w = view.width
+        val h = view.height
+        if (w == 0 || h == 0) return null
+
+        val screenCenter = screenPositionToLatLon(PointF(w / 2f, h / 2f)) ?: return null
+        val offsetScreenCenter = screenPositionToLatLon(
+            PointF(
+                padding.left + (w - padding.left - padding.right) / 2,
+                padding.top + (h - padding.top - padding.bottom) / 2
+            )
+        ) ?: return null
+
+        val zoomDelta = zoom.toDouble() - cameraPosition.zoom
+        val distance = offsetScreenCenter.distanceTo(screenCenter)
+        val angle = 0.0
+        val distanceAfterZoom = distance * (2.0).pow(-zoomDelta)
+        return position.translate(-distanceAfterZoom, angle)
+    }
+
     /* -------------------------------------- Data Layers --------------------------------------- */
 
     fun addDataLayer(name: String, generateCentroid: Boolean = false): MapData =


### PR DESCRIPTION
This is a quite messy fix for #3101. I don't expect it to be merged as-is; the point is to find out whether @westnordost thinks it's reasonable to clean this up and merge it at all.