### PR TITLE
Filter `bicycle_parking=floor` from AddBikeParkingCapacity Quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -10,6 +10,7 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
     override val elementFilter = """
         nodes, ways with amenity = bicycle_parking
          and access !~ private|no
+         and bicycle_parking !~ floor
          and (
            !capacity
            or bicycle_parking ~ stands|wall_loops and capacity older today -4 years


### PR DESCRIPTION
This type of bicycle parking is just "An area designated for the parking of bicycles", so it does not have a well defined capacity and users should not be asked about it.

I don't have a development environment setup, so I can't test at the moment. I could get around to it eventually, but, if the premise of the change is approved, I don't think the implementation is sufficiently complex to require testing on my end.