### PR TITLE
Add build debug apk github action

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,28 @@
+name: Build debug apk
+
+on:
+  [workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+    - name: Archive APK
+      uses: actions/upload-artifact@v2
+      with: 
+        name: debug-apk
+        path: app/build/outputs/apk/debug/app-debug.apk
+        retention-days: 1


### PR DESCRIPTION
This PR adds a zero-effort way to get a fresh apk to test your changes. 
This might be useful for testing small fixes without overhead of setting up dev environment and installing Android Studio.
Triggered manually only.
Result is an app debug apk with different app name and different icon which might be safely pushed to android device with `adb install` command.
Retention for the archived result file is a 1 day (no real reason to keep temp debug package, and full rebuild takes only ~8 min)