### PR TITLE
Better hint that everyone should enable team mode

### DIFF
--- a/app/src/main/res/layout/dialog_team_mode.xml
+++ b/app/src/main/res/layout/dialog_team_mode.xml
@@ -25,7 +25,7 @@
 
         <TextView
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="center_vertical"
             android:labelFor="@id/teamSizeInput"
@@ -38,6 +38,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/dialog_horizontal_margin"
             android:ems="2"
+            android:layout_gravity="center"
             android:imeOptions="actionDone"
             android:importantForAutofill="no"
             android:inputType="numberSigned"

--- a/app/src/main/res/layout/dialog_team_mode.xml
+++ b/app/src/main/res/layout/dialog_team_mode.xml
@@ -29,7 +29,7 @@
             android:layout_weight="1"
             android:gravity="center_vertical"
             android:labelFor="@id/teamSizeInput"
-            android:text="@string/team_mode_team_size_label"
+            android:text="@string/team_mode_team_size_label2"
             android:textAppearance="@android:style/TextAppearance.Theme.Dialog" />
 
         <EditText

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -868,7 +868,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="team_mode">Team Mode</string>
     <string name="team_mode_exit">Exit Team Mode</string>
     <string name="team_mode_description">When mapping the same area together in a group, you can enter team mode to split up quests between all team members.</string>
-    <string name="team_mode_team_size_label2">How many people are mapping? Enter the same number on everyone's phone.</string>
+    <string name="team_mode_team_size_label2">How many people are mapping? Enter the same number on everyone\'s phone.</string>
     <string name="team_mode_team_size_hint">Team mode works for groups of 2 to 12 people.</string>
     <string name="team_mode_choose_color2">Next, each person must pick a different color. Choose yours:</string>
     <string name="team_mode_active">Team mode is active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -868,9 +868,9 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="team_mode">Team Mode</string>
     <string name="team_mode_exit">Exit Team Mode</string>
     <string name="team_mode_description">When mapping the same area together in a group, you can enter team mode to split up quests between all team members.</string>
-    <string name="team_mode_team_size_label">How many people are there?</string>
+    <string name="team_mode_team_size_label2">How many people are mapping? Enter the same number on everyone's phone.</string>
     <string name="team_mode_team_size_hint">Team mode works for groups of 2 to 12 people.</string>
-    <string name="team_mode_choose_color2">Now everybody in your group chooses a unique color on their phone:</string>
+    <string name="team_mode_choose_color2">Next, each person must pick a different color. Choose yours:</string>
     <string name="team_mode_active">Team mode is active</string>
     <string name="team_mode_deactivated">Team mode deactivated</string>
 


### PR DESCRIPTION
I suspect that people knew they all needed their phones out, but thought they could do things on one phone, because the second step instructions are addressed to "everybody".

This way introduces the "everyone does this" hint sooner, but the second step is directed only at one person; this should make it clear that each person does it individually.

Modified slightly from my suggestion in #3170; this is shorter.