### PR TITLE
Auto-mirror arrow for RTL languages

### DIFF
--- a/app/src/main/res/drawable/ic_chevron_right_24dp.xml
+++ b/app/src/main/res/drawable/ic_chevron_right_24dp.xml
@@ -1,4 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:autoMirrored="true"
         android:width="24dp"
         android:height="24dp"
         android:viewportWidth="24.0"


### PR DESCRIPTION
Fixes #3181. ~~Draft because I have not tested this yet (it's pretty late here).~~ Tested and confirmed as not working. I will need to try some more to fix this.

Note that the "right" in the drawable name is now misleading, as it is a left arrow on RTL languages now. What to do?