### PR TITLE
Change no-sidewalk tagging to =no

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -110,7 +110,7 @@ class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
                 answer.left && answer.right -> "both"
                 answer.left -> "left"
                 answer.right -> "right"
-                else -> "none"
+                else -> "no"
             }
         }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddSidewalkTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddSidewalkTest.kt
@@ -129,7 +129,7 @@ class AddSidewalkTest {
     @Test fun `apply no sidewalk answer`() {
         questType.verifyAnswer(
             SidewalkSides(left = false, right = false),
-            StringMapEntryAdd("sidewalk", "none")
+            StringMapEntryAdd("sidewalk", "no")
         )
     }
 


### PR DESCRIPTION
This PR changes the StreetComplete tagging for streets with no sidewalks to `sidewalk=no` instead of `sidewalk=none`.  This is consistent with the tagging used by both iD and JOSM.