### PR TITLE
Disable AddProhibitedForPedestrians quest in Sweden

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -34,6 +34,8 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
     override val icon = R.drawable.ic_quest_no_pedestrians
     override val isSplitWayEnabled = true
 
+    override val enabledInCountries = AllCountriesExcept("SE")
+
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accessible_for_pedestrians_title_prohibited
 
     override fun createForm() = AddProhibitedForPedestriansForm()


### PR DESCRIPTION
After using StreetComplete for a while now and having already changed the Swedish translation to specify the AddProhibitedForPedestrians only applies to legal prohibitions, this quest still causes issues.

1. There's still `foot=no` being added in error, mostly by people not using the Swedish localisation (Having your phone or computer set to English is common among more tech-savvy people). It's not a worthwhile enterprise to try and contact those users nor is it possible to force them to use a localised version of the app.
2. Roads (in Sweden) where pedestrians are prohibited and which are not already covered by other regulations such as motorways are very uncommon.
3. The biggest issue is not actually adding `foot=no` in error, it's adding `foot=yes` if pedestrians are allowed. By default `foot=yes` is implied for all roads, streets, paths, etc. in Sweden, except motorways, expressways (`motorroad=yes`) and explicit cycleways. Unlike countries like the UK, there is no legal "right of way" that can be restricted and for which adding `foot=yes` is useful. 
