### PR TITLE
#2643 language switch

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/FragmentContainerActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/FragmentContainerActivity.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.fragment.app.commit
+import de.westnordost.streetcomplete.util.LocaleContextWrapper
 
 /** An activity that contains one full-screen ("main") fragment */
 open class FragmentContainerActivity(
@@ -43,6 +44,10 @@ open class FragmentContainerActivity(
             supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         }
         supportFragmentManager.registerFragmentLifecycleCallbacks(fragmentLifecycleCallbacks, false)
+    }
+
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LocaleContextWrapper.wrap(newBase,"am"))
     }
 
     fun pushMainFragment(fragment: Fragment) {

--- a/app/src/main/java/de/westnordost/streetcomplete/FragmentContainerActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/FragmentContainerActivity.kt
@@ -47,7 +47,7 @@ open class FragmentContainerActivity(
     }
 
     override fun attachBaseContext(newBase: Context?) {
-        super.attachBaseContext(LocaleContextWrapper.wrap(newBase,"am"))
+        super.attachBaseContext(LocaleContextWrapper.wrap(newBase))
     }
 
     fun pushMainFragment(fragment: Fragment) {

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.kt
@@ -46,6 +46,7 @@ import de.westnordost.streetcomplete.map.MainFragment
 import de.westnordost.streetcomplete.notifications.NotificationsContainerFragment
 import de.westnordost.streetcomplete.tutorial.TutorialFragment
 import de.westnordost.streetcomplete.util.CrashReportExceptionHandler
+import de.westnordost.streetcomplete.util.LocaleContextWrapper
 import de.westnordost.streetcomplete.util.parseGeoUri
 import de.westnordost.streetcomplete.view.dialogs.RequestLoginDialog
 import kotlinx.coroutines.launch
@@ -113,6 +114,10 @@ class MainActivity : AppCompatActivity(),
             }
         }
         handleGeoUri()
+    }
+
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LocaleContextWrapper.wrap(newBase,"am"))
     }
 
     private fun handleGeoUri() {

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun attachBaseContext(newBase: Context?) {
-        super.attachBaseContext(LocaleContextWrapper.wrap(newBase,"am"))
+        super.attachBaseContext(LocaleContextWrapper.wrap(newBase))
     }
 
     private fun handleGeoUri() {

--- a/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
@@ -14,6 +14,7 @@ object Prefs {
     const val UNGLUE_HINT_TIMES_SHOWN = "unglueHint.shown"
     const val THEME_SELECT = "theme.select"
     const val THEME_BACKGROUND = "theme.background_type"
+    const val LANGUAGE_SELECT = "language.select"
 
     const val RESURVEY_INTERVALS = "quests.resurveyIntervals"
 

--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.about
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -15,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.BuildConfig
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.tryStartActivity
+import de.westnordost.streetcomplete.util.LocaleContextWrapper
 import de.westnordost.streetcomplete.util.sendEmail
 import de.westnordost.streetcomplete.view.ListAdapter
 import kotlinx.android.synthetic.main.cell_labeled_icon_select_right.view.*
@@ -31,6 +33,8 @@ class AboutFragment : PreferenceFragmentCompat() {
     private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = LocaleContextWrapper.wrap(context, "am");
+
         addPreferencesFromResource(R.xml.about)
 
         findPreference<Preference>("version")?.summary = getString(R.string.about_summary_current_version, "v" + BuildConfig.VERSION_NAME)
@@ -63,7 +67,7 @@ class AboutFragment : PreferenceFragmentCompat() {
 
         findPreference<Preference>("translate")?.summary = resources.getString(
             R.string.about_description_translate,
-            Locale.getDefault().displayLanguage,
+            context.resources.configuration.locale.getDisplayLanguage(context.resources.configuration.locale),
             resources.getInteger(R.integer.translation_completeness)
         )
         findPreference<Preference>("translate")?.setOnPreferenceClickListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -33,7 +33,7 @@ class AboutFragment : PreferenceFragmentCompat() {
     private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        val context = LocaleContextWrapper.wrap(context, "am");
+        val context = LocaleContextWrapper.wrap(context);
 
         addPreferencesFromResource(R.xml.about)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.settings
 
 import android.content.Intent
 import android.content.SharedPreferences
+import android.icu.util.ULocale.getDisplayLanguage
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.widget.TextView
@@ -10,6 +11,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -92,12 +94,78 @@ class SettingsFragment : PreferenceFragmentCompat(), HasTitle,
             true
         }
 
+        buildLanguageSelector()
+
         findPreference<Preference>("debug")?.isVisible = BuildConfig.DEBUG
 
         findPreference<Preference>("debug.quests")?.setOnPreferenceClickListener {
             startActivity(Intent(context, ShowQuestFormsActivity::class.java))
             true
         }
+    }
+
+    private fun buildLanguageSelector() {
+        // FIXME: externalize to YML?
+        val entryValues = arrayOf<CharSequence>("",
+                "am",
+                "ar",
+                "ast",
+                "bg",
+                "bs",
+                "ca",
+                "cs",
+                "da",
+                "de",
+                "el",
+                "en-AU",
+                "en-GB",
+                "en",
+                "es",
+                "eu",
+                "fa",
+                "fi",
+                "fr",
+                "gl",
+                "hr",
+                "hu",
+                "in",
+                "it",
+                "ja",
+                "ko",
+                "lt",
+                "ml",
+                "nl",
+                "nn",
+                "no",
+                "pl",
+                "pt-BR",
+                "pt",
+                "ro",
+                "ru",
+                "sk",
+                "sv",
+                "th",
+                "tr",
+                "uk",
+                "zh-CN",
+                "zh-HK",
+                "zh",
+                "zh-TW"
+        );
+
+        val entries = arrayOf<CharSequence>();
+
+        entryValues.forEach {
+            if (it == "") {
+                entries.plusElement(getString(R.string.language_system_default))
+            } else {
+                val locale = Locale(it.toString())
+                entries.plusElement(locale.getDisplayLanguage(locale))
+            }
+        }
+
+        findPreference<ListPreference>("language.select")?.setEntries(entries)
+        findPreference<ListPreference>("language.select")?.setEntryValues(entryValues)
     }
 
     override fun onStart() {

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -15,13 +15,9 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
+import de.westnordost.streetcomplete.*
 import de.westnordost.streetcomplete.ApplicationConstants.DELETE_OLD_DATA_AFTER
 import de.westnordost.streetcomplete.ApplicationConstants.REFRESH_DATA_AFTER
-import de.westnordost.streetcomplete.BuildConfig
-import de.westnordost.streetcomplete.HasTitle
-import de.westnordost.streetcomplete.Injector
-import de.westnordost.streetcomplete.Prefs
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 import de.westnordost.streetcomplete.data.osmnotes.NoteController
@@ -208,6 +204,10 @@ class SettingsFragment : PreferenceFragmentCompat(), HasTitle,
                 val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
                 AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
                 activity?.recreate()
+            }
+            Prefs.LANGUAGE_SELECT -> {
+                val intent = Intent(context?.applicationContext, MainActivity::class.java)
+                this.startActivity(intent)
             }
             Prefs.RESURVEY_INTERVALS -> {
                 resurveyIntervalsUpdater.update()

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -106,66 +106,70 @@ class SettingsFragment : PreferenceFragmentCompat(), HasTitle,
 
     private fun buildLanguageSelector() {
         // FIXME: externalize to YML?
-        val entryValues = arrayOf<CharSequence>("",
-                "am",
-                "ar",
-                "ast",
-                "bg",
-                "bs",
-                "ca",
-                "cs",
-                "da",
-                "de",
-                "el",
-                "en-AU",
-                "en-GB",
-                "en",
-                "es",
-                "eu",
-                "fa",
-                "fi",
-                "fr",
-                "gl",
-                "hr",
-                "hu",
-                "in",
-                "it",
-                "ja",
-                "ko",
-                "lt",
-                "ml",
-                "nl",
-                "nn",
-                "no",
-                "pl",
-                "pt-BR",
-                "pt",
-                "ro",
-                "ru",
-                "sk",
-                "sv",
-                "th",
-                "tr",
-                "uk",
-                "zh-CN",
-                "zh-HK",
-                "zh",
-                "zh-TW"
+        val entryValues = arrayOf<CharSequence>(
+            "",
+            "am",
+            "ar",
+            "ast",
+            "bg",
+            "bs",
+            "ca",
+            "cs",
+            "da",
+            "de",
+            "el",
+            "en-AU",
+            "en-GB",
+            "en",
+            "es",
+            "eu",
+            "fa",
+            "fi",
+            "fr",
+            "gl",
+            "hr",
+            "hu",
+            "in",
+            "it",
+            "ja",
+            "ko",
+            "lt",
+            "ml",
+            "nl",
+            "nn",
+            "no",
+            "pl",
+            "pt-BR",
+            "pt",
+            "ro",
+            "ru",
+            "sk",
+            "sv",
+            "th",
+            "tr",
+            "uk",
+            "zh-CN",
+            "zh-HK",
+            "zh",
+            "zh-TW"
         );
 
-        val entries = arrayOf<CharSequence>();
-
-        entryValues.forEach {
+        val entries = entryValues.map {
             if (it == "") {
-                entries.plusElement(getString(R.string.language_system_default))
+                getString(R.string.language_system_default)
             } else {
                 val locale = Locale(it.toString())
-                entries.plusElement(locale.getDisplayLanguage(locale))
+                val inTarget =  locale.getDisplayLanguage(locale)
+                if (inTarget != locale.displayLanguage) {
+                    inTarget + " / " + locale.displayLanguage
+                } else {
+                    inTarget
+                }
             }
         }
 
-        findPreference<ListPreference>("language.select")?.setEntries(entries)
-        findPreference<ListPreference>("language.select")?.setEntryValues(entryValues)
+        findPreference<ListPreference>("language.select")?.entries = entries.toTypedArray()
+        findPreference<ListPreference>("language.select")?.entryValues = entryValues
     }
 
     override fun onStart() {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/LocaleContextWrapper.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/LocaleContextWrapper.java
@@ -1,0 +1,66 @@
+package de.westnordost.streetcomplete.util;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.Configuration;
+import android.os.Build;
+
+import java.util.Locale;
+
+/**
+ * @source https://stackoverflow.com/a/40704077
+ */
+public class LocaleContextWrapper extends ContextWrapper {
+
+	public LocaleContextWrapper(Context base) {
+		super(base);
+	}
+
+	@SuppressWarnings("deprecation")
+	public static ContextWrapper wrap(Context context, String language) {
+		Configuration config = context.getResources().getConfiguration();
+		Locale sysLocale = null;
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+			sysLocale = getSystemLocale(config);
+		} else {
+			sysLocale = getSystemLocaleLegacy(config);
+		}
+		if (!language.equals("") && !sysLocale.getLanguage().equals(language)) {
+			Locale locale = new Locale(language);
+			Locale.setDefault(locale);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+				setSystemLocale(config, locale);
+			} else {
+				setSystemLocaleLegacy(config, locale);
+			}
+
+		}
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			context = context.createConfigurationContext(config);
+		} else {
+			context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+		}
+		return new LocaleContextWrapper(context);
+	}
+
+	@SuppressWarnings("deprecation")
+	public static Locale getSystemLocaleLegacy(Configuration config){
+		return config.locale;
+	}
+
+	@TargetApi(Build.VERSION_CODES.N)
+	public static Locale getSystemLocale(Configuration config){
+		return config.getLocales().get(0);
+	}
+
+	@SuppressWarnings("deprecation")
+	public static void setSystemLocaleLegacy(Configuration config, Locale locale){
+		config.locale = locale;
+	}
+
+	@TargetApi(Build.VERSION_CODES.N)
+	public static void setSystemLocale(Configuration config, Locale locale){
+		config.setLocale(locale);
+	}
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/util/LocaleContextWrapper.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/LocaleContextWrapper.java
@@ -3,10 +3,15 @@ package de.westnordost.streetcomplete.util;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Build;
 
+import androidx.preference.PreferenceManager;
+
 import java.util.Locale;
+
+import de.westnordost.streetcomplete.Prefs;
 
 /**
  * @source https://stackoverflow.com/a/40704077
@@ -18,7 +23,11 @@ public class LocaleContextWrapper extends ContextWrapper {
 	}
 
 	@SuppressWarnings("deprecation")
-	public static ContextWrapper wrap(Context context, String language) {
+	public static ContextWrapper wrap(Context context) {
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		String language = prefs.getString(Prefs.LANGUAGE_SELECT, "");
+
 		Configuration config = context.getResources().getConfiguration();
 		Locale sysLocale = null;
 		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1064,6 +1064,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_camera_type_dome">Dome</string>
     <string name="quest_camera_type_fixed">Fixed</string>
     <string name="quest_camera_type_panning">Panning</string>
-    <string name="pref_title_language_select">Select language (requires restart)</string>
+    <string name="pref_title_language_select">Select language</string>
     <string name="language_system_default">System default</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1064,4 +1064,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_camera_type_dome">Dome</string>
     <string name="quest_camera_type_fixed">Fixed</string>
     <string name="quest_camera_type_panning">Panning</string>
+    <string name="pref_title_language_select">Select language (requires restart)</string>
+    <string name="language_system_default">System default</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,6 +72,13 @@
             android:persistent="true"
             />
     -->
+        <ListPreference
+            android:key="language.select"
+            android:title="@string/pref_title_language_select"
+            android:summary="%s"
+            android:defaultValue=""
+            android:persistent="true"
+            />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This adds the possibility to switch the app language to any of those where a translation exists (fixes #2643).

Known issues also see #2643 

We might improve the way the available language list is build - currently it's hard coded (maybe a YAML file?) Or can we auto detect this? --> it would improve the workflow when adding new languages