### PR TITLE
Fix location pin showing after location is lost

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
@@ -111,6 +111,7 @@ open class LocationAwareMapFragment : MapFragment() {
     fun stopPositionTracking() {
         locationMapComponent?.isVisible = false
         locationManager.removeUpdates()
+        isCompassMode = false
         displayedLocation = null
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
@@ -111,6 +111,7 @@ open class LocationAwareMapFragment : MapFragment() {
     fun stopPositionTracking() {
         locationMapComponent?.isVisible = false
         locationManager.removeUpdates()
+        displayedLocation = null
     }
 
     protected open fun shouldCenterCurrentPosition(): Boolean {


### PR DESCRIPTION
Steps to reproduce:

- Turn on location services and get a location fix
- Turn off location services
- Scroll so your location is off screen

Before: Location pin points back to last known location
Now: Location pin does not appear

(Also described in https://github.com/streetcomplete/StreetComplete/issues/3147#issuecomment-895581863)