### PR TITLE
Use ActivityCompat.recreate().

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.app.ActivityCompat
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
@@ -130,7 +131,7 @@ class SettingsFragment : PreferenceFragmentCompat(), HasTitle,
             Prefs.THEME_SELECT -> {
                 val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
                 AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
-                activity?.recreate()
+                activity?.let { ActivityCompat.recreate(it) }
             }
             Prefs.RESURVEY_INTERVALS -> {
                 resurveyIntervalsUpdater.update()


### PR DESCRIPTION
Use [`ActivityCompat.recreate()`](https://developer.android.com/reference/androidx/core/app/ActivityCompat#recreate(android.app.Activity)) to backport the method's behavior to Android versions below P.