### PR TITLE
Remove diet:vegan if vegetarian quest is answered with no

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -31,5 +31,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
 
     override fun applyAnswerTo(answer: DietAvailability, changes: StringMapChangesBuilder) {
         changes.updateWithCheckDate("diet:vegetarian", answer.osmValue)
+        if (answer.osmValue == "no")
+            changes.deleteIfExists("diet:vegan")
     }
 }


### PR DESCRIPTION
see #3249 
If a place has `diet:vegan != only` and the user answers the vegetarian quest with _no_, the vegan key is obsolete and thus can be removed.
Additionally this avoids the invalid combination of `diet:vegan=yes` and `diet:vegetarian=no`