### PR TITLE
Refactor CacheConfig init block

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
@@ -21,21 +21,15 @@ import javax.inject.Singleton
 
     val cache: Cache?
 
-    init {
-        val cacheDir = context.externalCacheDir
-        val tileCacheDir: File?
-        if (cacheDir != null) {
-            tileCacheDir = File(cacheDir, TILE_CACHE_DIR)
-            if (!tileCacheDir.exists()) tileCacheDir.mkdir()
-        } else {
-            tileCacheDir = null
+    init { 
+        val tileCacheDir: File? = context.externalCacheDir?.let { cacheDir ->
+            File(cacheDir, TILE_CACHE_DIR)
+                .also { if (!it.exists()) it.mkdir() }
+                .takeIf { it.exists() } // mkdir might fail
         }
-
-        cache = if (tileCacheDir?.exists() == true) {
+        cache = tileCacheDir?.let {
             val mbs = PreferenceManager.getDefaultSharedPreferences(context).getInt(Prefs.MAP_TILECACHE_IN_MB, 50)
-            Cache(tileCacheDir, mbs * 1000L * 1000L)
-        } else {
-            null
+            Cache(it, mbs * 1000L * 1000L)
         }
     }
 


### PR DESCRIPTION
Untested, I just did it in the GitHub interface when I was looking at the file for unrelated reasons. If you think it looks good, I'll test it.

It could be refactored to get rid of the init block entirely, and just chain the second `let` directly off the first, when assigning `cache`. I didn't find it much more readable that way, although it would semantically make clear that "all the stuff in this block is just about generating the value of `cache`."