### PR TITLE
Fix typo in enGB strings.xml

### DIFF
--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -490,7 +490,7 @@ Partially means that a wheelchair can enter and use the toilet, but no handrail 
     <string name="pref_quests_reset">"Reset both quest enablement and order to the default?"</string>
     <string name="quest_buildingType_title2">"What was this building constructed as?"</string>
     <string name="quest_generic_item_invalid_value">"Please select a more specific value."</string>
-    <string name="quest_buildingType_answer_multiple_types">"It was multiple purposes"</string>
+    <string name="quest_buildingType_answer_multiple_types">"It has multiple purposes"</string>
     <string name="quest_buildingType_answer_multiple_types_description">"Simply select the main purpose of this building. E.g. if there is a shop on the ground floor with flats above it, it is still mainly flats."</string>
     <string name="quest_buildingType_answer_construction_site">"It is still being constructed"</string>
     <string name="quest_buildingType_residential">"Residential"</string>


### PR DESCRIPTION
Hi,

Just noticed this typo while using StreetComplete:

"It _was_ multiple purposes" which should be "It _has_ multiple purposes" just like "It has multiple house numbers".

This patch should fix it, but I'm a bit new to pull requests - hopefully this works.