### PR TITLE
Move freezing into map fragment

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
@@ -24,6 +24,16 @@ open class LocationAwareMapFragment : MapFragment() {
     private lateinit var locationManager: FineLocationManager
 
     private var locationMapComponent: CurrentLocationMapComponent? = null
+    
+    var isFrozen = false
+        set(value) {
+            field = value
+            if (!value) {
+                endFocusQuest()
+                show3DBuildings = true
+                pinMode = QuestsMapFragment.PinMode.QUESTS
+            }
+        }   
 
     var displayedLocation: Location? = null
         private set
@@ -31,6 +41,7 @@ open class LocationAwareMapFragment : MapFragment() {
 
     /** Whether the view should automatically center on the GPS location */
     var isFollowingPosition = true
+        get() = field && !isFrozen
         set(value) {
             field = value
             centerCurrentPositionIfFollowing()
@@ -44,6 +55,7 @@ open class LocationAwareMapFragment : MapFragment() {
     // animation abruptly and slide out, rather than sliding in and out (the default interpolator)
     private val interpolator = DecelerateInterpolator()
     var isCompassMode: Boolean = false
+        get() = field && !isFrozen
         set(value) {
             if (field != value) {
                 field = value

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -837,11 +837,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
 
     private fun freezeMap() {
         val mapFragment = mapFragment ?: return
-
-        wasFollowingPosition = mapFragment.isFollowingPosition
-        wasCompassMode = mapFragment.isCompassMode
-        mapFragment.isFollowingPosition = false
-        mapFragment.isCompassMode = false
+        mapFragment.isFrozen = true
     }
 
     private fun resetFreezeMap() {
@@ -854,12 +850,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
 
     private fun unfreezeMap() {
         val mapFragment = mapFragment ?: return
-
-        mapFragment.isFollowingPosition = wasFollowingPosition
-        mapFragment.isCompassMode = wasCompassMode
-        mapFragment.endFocusQuest()
-        mapFragment.show3DBuildings = true
-        mapFragment.pinMode = QuestsMapFragment.PinMode.QUESTS
+        mapFragment.isFrozen = false
     }
 
     //endregion


### PR DESCRIPTION
Exploration for #3312. This might help prevent more bugs of this sort.

I did this on GitHub and haven't tested whether it compiles. There is certainly more to do (e.g., moving `resetFreezeMap` into the mapfragment and removing the now-redundant `[un]freezeMap` functions). Just opening to check what you think of this approach.