### PR TITLE
Define achievements inside quest types

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.data.osm.osmquests
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
 open class TestQuestType : OsmElementQuestType<String> {
@@ -16,5 +16,5 @@ open class TestQuestType : OsmElementQuestType<String> {
     override val commitMessage = ""
     override fun getApplicableElements(mapData: MapDataWithGeometry) = emptyList<Element>()
     override val wikiLink: String? = null
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = emptyList<QuestTypeAchievement>()
 }

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
@@ -3,16 +3,18 @@ package de.westnordost.streetcomplete.data.osm.osmquests
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
 open class TestQuestType : OsmElementQuestType<String> {
 
     override fun getTitle(tags: Map<String, String>) = 0
-    override fun isApplicableTo(element: Element):Boolean? = null
+    override fun isApplicableTo(element: Element): Boolean? = null
     override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {}
     override val icon = 0
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
     override val commitMessage = ""
     override fun getApplicableElements(mapData: MapDataWithGeometry) = emptyList<Element>()
     override val wikiLink: String? = null
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -50,9 +50,9 @@ class ElementEditsUploader @Inject constructor(
             mapDataController.updateAll(updates)
 
             if (edit.action is IsRevertAction) {
-                statisticsUpdater.subtractOne(edit.questType, edit.position)
+                statisticsUpdater.subtractOne(questTypeName, edit.position)
             } else {
-                statisticsUpdater.addOne(edit.questType, edit.position)
+                statisticsUpdater.addOne(questTypeName, edit.position)
             }
 
         } catch (e: ConflictException) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -50,9 +50,9 @@ class ElementEditsUploader @Inject constructor(
             mapDataController.updateAll(updates)
 
             if (edit.action is IsRevertAction) {
-                statisticsUpdater.subtractOne(questTypeName, edit.position)
+                statisticsUpdater.subtractOne(edit.questType, edit.position)
             } else {
-                statisticsUpdater.addOne(questTypeName, edit.position)
+                statisticsUpdater.addOne(edit.questType, edit.position)
             }
 
         } catch (e: ConflictException) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.data.osmnotes.notequests
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.QuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.quests.note_discussion.NoteAnswer
 import de.westnordost.streetcomplete.quests.note_discussion.NoteDiscussionForm
 
@@ -10,7 +10,7 @@ object OsmNoteQuestType : QuestType<NoteAnswer> {
     override val icon = R.drawable.ic_quest_notes
     override val title = R.string.quest_noteDiscussion_title
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = emptyList<QuestTypeAchievement>()
 
     override fun createForm() = NoteDiscussionForm()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestType.kt
@@ -2,12 +2,15 @@ package de.westnordost.streetcomplete.data.osmnotes.notequests
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.QuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.note_discussion.NoteAnswer
 import de.westnordost.streetcomplete.quests.note_discussion.NoteDiscussionForm
 
 object OsmNoteQuestType : QuestType<NoteAnswer> {
     override val icon = R.drawable.ic_quest_notes
     override val title = R.string.quest_noteDiscussion_title
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun createForm() = NoteDiscussionForm()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.data.quest
 
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
 interface QuestType<T> {
@@ -25,5 +25,5 @@ interface QuestType<T> {
     val dayNightVisibility: DayNightCycle get() = DayNightCycle.DAY_AND_NIGHT
 
     /** towards which achievements the quest should count */
-    val questTypeAchievements: List<QuestTypeAchievements>
+    val questTypeAchievements: List<QuestTypeAchievement>
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.quest
 
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
 interface QuestType<T> {
@@ -22,4 +23,7 @@ interface QuestType<T> {
 
     /** if the quest should only be shown during day-light or night-time hours */
     val dayNightVisibility: DayNightCycle get() = DayNightCycle.DAY_AND_NIGHT
+
+    /** towards which achievements the quest should count */
+    val questTypeAchievements: List<QuestTypeAchievements> get() = listOf()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestType.kt
@@ -25,5 +25,5 @@ interface QuestType<T> {
     val dayNightVisibility: DayNightCycle get() = DayNightCycle.DAY_AND_NIGHT
 
     /** towards which achievements the quest should count */
-    val questTypeAchievements: List<QuestTypeAchievements> get() = listOf()
+    val questTypeAchievements: List<QuestTypeAchievements>
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.countryboundaries.getIds
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.user.achievements.AchievementGiver
 import de.westnordost.streetcomplete.ktx.toLocalDate
 import java.time.Instant
@@ -22,18 +23,18 @@ class StatisticsUpdater @Inject constructor(
     private val countryBoundaries: FutureTask<CountryBoundaries>,
     @Named("QuestAliases") private val questAliases: List<Pair<String, String>>
 ) {
-    fun addOne(questType: String, position: LatLon) {
+    fun addOne(questType: QuestType<*>, position: LatLon) {
         updateDaysActive()
 
-        questStatisticsDao.addOne(questType)
+        questStatisticsDao.addOne(questType::class.simpleName!!)
         getRealCountryCode(position)?.let { countryStatisticsDao.addOne(it) }
 
         achievementGiver.updateQuestTypeAchievements(questType)
     }
 
-    fun subtractOne(questType: String, position: LatLon) {
+    fun subtractOne(questType: QuestType<*>, position: LatLon) {
         updateDaysActive()
-        questStatisticsDao.subtractOne(questType)
+        questStatisticsDao.subtractOne(questType::class.simpleName!!)
         getRealCountryCode(position)?.let { countryStatisticsDao.subtractOne(it) }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.countryboundaries.getIds
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
-import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.user.achievements.AchievementGiver
 import de.westnordost.streetcomplete.ktx.toLocalDate
 import java.time.Instant
@@ -23,18 +22,18 @@ class StatisticsUpdater @Inject constructor(
     private val countryBoundaries: FutureTask<CountryBoundaries>,
     @Named("QuestAliases") private val questAliases: List<Pair<String, String>>
 ) {
-    fun addOne(questType: QuestType<*>, position: LatLon) {
+    fun addOne(questType: String, position: LatLon) {
         updateDaysActive()
 
-        questStatisticsDao.addOne(questType::class.simpleName!!)
+        questStatisticsDao.addOne(questType)
         getRealCountryCode(position)?.let { countryStatisticsDao.addOne(it) }
 
         achievementGiver.updateQuestTypeAchievements(questType)
     }
 
-    fun subtractOne(questType: QuestType<*>, position: LatLon) {
+    fun subtractOne(questType: String, position: LatLon) {
         updateDaysActive()
-        questStatisticsDao.subtractOne(questType::class.simpleName!!)
+        questStatisticsDao.subtractOne(questType)
         getRealCountryCode(position)?.let { countryStatisticsDao.subtractOne(it) }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/Achievement.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/Achievement.kt
@@ -24,6 +24,6 @@ data class Achievement(
 
 sealed class AchievementCondition
 
-data class SolvedQuestsOfTypes(val questTypes: List<String>) : AchievementCondition()
+object SolvedQuestsOfTypes : AchievementCondition()
 object TotalSolvedQuests : AchievementCondition()
 object DaysActive : AchievementCondition()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -29,7 +29,7 @@ class AchievementGiver @Inject constructor(
     fun updateQuestTypeAchievements(questType: QuestType<*>) {
         return updateAchievements(allAchievements.filter { achievement ->
             when (achievement.condition) {
-                is SolvedQuestsOfTypes -> questType.questTypeAchievements.any { it.id == achievement.id }
+                is SolvedQuestsOfTypes -> questType.questTypeAchievements.has(achievement.id)
                 is TotalSolvedQuests -> true
                 else -> false
             }
@@ -103,7 +103,9 @@ class AchievementGiver @Inject constructor(
 
     private fun getAchievementQuestTypes(achievementId: String): List<String> {
         return questTypeRegistry
-            .filter { questType -> questType.questTypeAchievements.any { it.id == achievementId } }
+            .filter { it.questTypeAchievements.has(achievementId) }
             .map { it::class.simpleName!! }
     }
 }
+
+private fun List<QuestTypeAchievement>.has(achievementId: String) = any { it.id == achievementId }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -82,18 +82,19 @@ class AchievementGiver @Inject constructor(
 
     private fun getAchievedLevel(achievement: Achievement): Int {
         val func = achievement.pointsNeededToAdvanceFunction
+        val achievedPoints = getAchievedPoints(achievement)
         var level = 0
         var threshold = 0
         do {
             threshold += func(level)
             level++
             if (achievement.maxLevel != -1 && level > achievement.maxLevel) break
-        } while (isAchieved(threshold, achievement))
+        } while (threshold <= achievedPoints)
         return level - 1
     }
 
-    private fun isAchieved(threshold: Int, achievement: Achievement): Boolean {
-        return threshold <= when (achievement.condition) {
+    private fun getAchievedPoints(achievement: Achievement): Int {
+        return when (achievement.condition) {
             is SolvedQuestsOfTypes -> questStatisticsDao.getAmount(getAchievementQuestTypes(achievement.id))
             is TotalSolvedQuests -> questStatisticsDao.getTotalAmount()
             is DaysActive -> userStore.daysActive

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
 import de.westnordost.streetcomplete.data.notifications.NewUserAchievementsDao
+import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.user.QuestStatisticsDao
 import de.westnordost.streetcomplete.data.user.UserStore
 import javax.inject.Inject
@@ -23,10 +24,10 @@ class AchievementGiver @Inject constructor(
     }
 
     /** Look at and grant only the achievements that have anything to do with the given quest type */
-    fun updateQuestTypeAchievements(questType: String) {
-        return updateAchievements(allAchievements.filter {
-            when (it.condition) {
-                is SolvedQuestsOfTypes -> it.condition.questTypes.contains(questType)
+    fun updateQuestTypeAchievements(questType: QuestType<*>) {
+        return updateAchievements(allAchievements.filter { achievement ->
+            when (achievement.condition) {
+                is SolvedQuestsOfTypes -> questType.questTypeAchievements.any { it.id == achievement.id }
                 is TotalSolvedQuests -> true
                 else -> false
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -29,7 +29,7 @@ class AchievementGiver @Inject constructor(
         val questType = questTypeRegistry.getByName(questTypeName)!!
         return updateAchievements(allAchievements.filter {
             when (it.condition) {
-                is SolvedQuestsOfTypes -> questType.questTypeAchievements.has(it.id)
+                is SolvedQuestsOfTypes -> questType.questTypeAchievements.anyHasId(it.id)
                 is TotalSolvedQuests -> true
                 else -> false
             }
@@ -103,9 +103,9 @@ class AchievementGiver @Inject constructor(
 
     private fun getAchievementQuestTypes(achievementId: String): List<String> {
         return questTypeRegistry
-            .filter { it.questTypeAchievements.has(achievementId) }
+            .filter { it.questTypeAchievements.anyHasId(achievementId) }
             .map { it::class.simpleName!! }
     }
 }
 
-private fun List<QuestTypeAchievement>.has(achievementId: String) = any { it.id == achievementId }
+private fun List<QuestTypeAchievement>.anyHasId(achievementId: String) = any { it.id == achievementId }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -92,7 +92,7 @@ class AchievementGiver @Inject constructor(
 
     private fun isAchieved(threshold: Int, condition: AchievementCondition): Boolean {
         return threshold <= when (condition) {
-            is SolvedQuestsOfTypes -> questStatisticsDao.getAmount(condition.questTypes)
+            is SolvedQuestsOfTypes -> questStatisticsDao.getAmount(condition.questTypes) // TODO: how to get quest types for this achievement
             is TotalSolvedQuests -> questStatisticsDao.getTotalAmount()
             is DaysActive -> userStore.daysActive
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiver.kt
@@ -1,7 +1,6 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
 import de.westnordost.streetcomplete.data.notifications.NewUserAchievementsDao
-import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.user.QuestStatisticsDao
 import de.westnordost.streetcomplete.data.user.UserStore
@@ -26,10 +25,11 @@ class AchievementGiver @Inject constructor(
     }
 
     /** Look at and grant only the achievements that have anything to do with the given quest type */
-    fun updateQuestTypeAchievements(questType: QuestType<*>) {
-        return updateAchievements(allAchievements.filter { achievement ->
-            when (achievement.condition) {
-                is SolvedQuestsOfTypes -> questType.questTypeAchievements.has(achievement.id)
+    fun updateQuestTypeAchievements(questTypeName: String) {
+        val questType = questTypeRegistry.getByName(questTypeName)!!
+        return updateAchievements(allAchievements.filter {
+            when (it.condition) {
+                is SolvedQuestsOfTypes -> questType.questTypeAchievements.has(it.id)
                 is TotalSolvedQuests -> true
                 else -> false
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
@@ -3,6 +3,111 @@ package de.westnordost.streetcomplete.data.user.achievements
 import dagger.Module
 import dagger.Provides
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.accepts_cash.AddAcceptsCash
+import de.westnordost.streetcomplete.quests.address.AddAddressStreet
+import de.westnordost.streetcomplete.quests.address.AddHousenumber
+import de.westnordost.streetcomplete.quests.atm_operator.AddAtmOperator
+import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
+import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierType
+import de.westnordost.streetcomplete.quests.barrier_type.AddStileType
+import de.westnordost.streetcomplete.quests.bench_backrest.AddBenchBackrest
+import de.westnordost.streetcomplete.quests.bike_parking_capacity.AddBikeParkingCapacity
+import de.westnordost.streetcomplete.quests.bike_parking_cover.AddBikeParkingCover
+import de.westnordost.streetcomplete.quests.bike_parking_type.AddBikeParkingType
+import de.westnordost.streetcomplete.quests.board_type.AddBoardType
+import de.westnordost.streetcomplete.quests.bollard_type.AddBollardType
+import de.westnordost.streetcomplete.quests.bridge_structure.AddBridgeStructure
+import de.westnordost.streetcomplete.quests.building_levels.AddBuildingLevels
+import de.westnordost.streetcomplete.quests.building_type.AddBuildingType
+import de.westnordost.streetcomplete.quests.building_underground.AddIsBuildingUnderground
+import de.westnordost.streetcomplete.quests.bus_stop_bench.AddBenchStatusOnBusStop
+import de.westnordost.streetcomplete.quests.bus_stop_bin.AddBinStatusOnBusStop
+import de.westnordost.streetcomplete.quests.bus_stop_lit.AddBusStopLit
+import de.westnordost.streetcomplete.quests.bus_stop_name.AddBusStopName
+import de.westnordost.streetcomplete.quests.bus_stop_ref.AddBusStopRef
+import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter
+import de.westnordost.streetcomplete.quests.car_wash_type.AddCarWashType
+import de.westnordost.streetcomplete.quests.charging_station_capacity.AddChargingStationCapacity
+import de.westnordost.streetcomplete.quests.charging_station_operator.AddChargingStationOperator
+import de.westnordost.streetcomplete.quests.clothing_bin_operator.AddClothingBinOperator
+import de.westnordost.streetcomplete.quests.construction.MarkCompletedBuildingConstruction
+import de.westnordost.streetcomplete.quests.construction.MarkCompletedHighwayConstruction
+import de.westnordost.streetcomplete.quests.crossing.AddCrossing
+import de.westnordost.streetcomplete.quests.crossing_island.AddCrossingIsland
+import de.westnordost.streetcomplete.quests.crossing_type.AddCrossingType
+import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
+import de.westnordost.streetcomplete.quests.diet_type.AddKosher
+import de.westnordost.streetcomplete.quests.diet_type.AddVegan
+import de.westnordost.streetcomplete.quests.diet_type.AddVegetarian
+import de.westnordost.streetcomplete.quests.drinking_water.AddDrinkingWater
+import de.westnordost.streetcomplete.quests.existence.CheckExistence
+import de.westnordost.streetcomplete.quests.ferry.AddFerryAccessMotorVehicle
+import de.westnordost.streetcomplete.quests.ferry.AddFerryAccessPedestrian
+import de.westnordost.streetcomplete.quests.foot.AddProhibitedForPedestrians
+import de.westnordost.streetcomplete.quests.general_fee.AddGeneralFee
+import de.westnordost.streetcomplete.quests.handrail.AddHandrail
+import de.westnordost.streetcomplete.quests.internet_access.AddInternetAccess
+import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
+import de.westnordost.streetcomplete.quests.lanes.AddLanes
+import de.westnordost.streetcomplete.quests.max_height.AddMaxHeight
+import de.westnordost.streetcomplete.quests.max_speed.AddMaxSpeed
+import de.westnordost.streetcomplete.quests.max_weight.AddMaxWeight
+import de.westnordost.streetcomplete.quests.motorcycle_parking_capacity.AddMotorcycleParkingCapacity
+import de.westnordost.streetcomplete.quests.motorcycle_parking_cover.AddMotorcycleParkingCover
+import de.westnordost.streetcomplete.quests.oneway.AddOneway
+import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
+import de.westnordost.streetcomplete.quests.parking_access.AddBikeParkingAccess
+import de.westnordost.streetcomplete.quests.parking_access.AddParkingAccess
+import de.westnordost.streetcomplete.quests.parking_fee.AddBikeParkingFee
+import de.westnordost.streetcomplete.quests.parking_fee.AddParkingFee
+import de.westnordost.streetcomplete.quests.parking_type.AddParkingType
+import de.westnordost.streetcomplete.quests.pitch_lit.AddPitchLit
+import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
+import de.westnordost.streetcomplete.quests.playground_access.AddPlaygroundAccess
+import de.westnordost.streetcomplete.quests.police_type.AddPoliceType
+import de.westnordost.streetcomplete.quests.postbox_collection_times.AddPostboxCollectionTimes
+import de.westnordost.streetcomplete.quests.postbox_ref.AddPostboxRef
+import de.westnordost.streetcomplete.quests.postbox_royal_cypher.AddPostboxRoyalCypher
+import de.westnordost.streetcomplete.quests.powerpoles_material.AddPowerPolesMaterial
+import de.westnordost.streetcomplete.quests.railway_crossing.AddRailwayCrossingBarrier
+import de.westnordost.streetcomplete.quests.recycling.AddRecyclingType
+import de.westnordost.streetcomplete.quests.recycling_glass.DetermineRecyclingGlass
+import de.westnordost.streetcomplete.quests.recycling_material.AddRecyclingContainerMaterials
+import de.westnordost.streetcomplete.quests.religion.AddReligionToPlaceOfWorship
+import de.westnordost.streetcomplete.quests.religion.AddReligionToWaysideShrine
+import de.westnordost.streetcomplete.quests.road_name.AddRoadName
+import de.westnordost.streetcomplete.quests.roof_shape.AddRoofShape
+import de.westnordost.streetcomplete.quests.segregated.AddCyclewaySegregation
+import de.westnordost.streetcomplete.quests.self_service.AddSelfServiceLaundry
+import de.westnordost.streetcomplete.quests.shop_type.CheckShopType
+import de.westnordost.streetcomplete.quests.shop_type.SpecifyShopType
+import de.westnordost.streetcomplete.quests.sidewalk.AddSidewalk
+import de.westnordost.streetcomplete.quests.sport.AddSport
+import de.westnordost.streetcomplete.quests.step_count.AddStepCount
+import de.westnordost.streetcomplete.quests.steps_incline.AddStepsIncline
+import de.westnordost.streetcomplete.quests.steps_ramp.AddStepsRamp
+import de.westnordost.streetcomplete.quests.summit_register.AddSummitRegister
+import de.westnordost.streetcomplete.quests.surface.AddCyclewayPartSurface
+import de.westnordost.streetcomplete.quests.surface.AddFootwayPartSurface
+import de.westnordost.streetcomplete.quests.surface.AddPathSurface
+import de.westnordost.streetcomplete.quests.surface.AddPitchSurface
+import de.westnordost.streetcomplete.quests.surface.AddRoadSurface
+import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingBusStop
+import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingCrosswalk
+import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingKerb
+import de.westnordost.streetcomplete.quests.toilet_availability.AddToiletAvailability
+import de.westnordost.streetcomplete.quests.toilets_fee.AddToiletsFee
+import de.westnordost.streetcomplete.quests.tourism_information.AddInformationToTourism
+import de.westnordost.streetcomplete.quests.tracktype.AddTracktype
+import de.westnordost.streetcomplete.quests.traffic_signals_button.AddTrafficSignalsButton
+import de.westnordost.streetcomplete.quests.traffic_signals_sound.AddTrafficSignalsSound
+import de.westnordost.streetcomplete.quests.traffic_signals_vibrate.AddTrafficSignalsVibration
+import de.westnordost.streetcomplete.quests.way_lit.AddWayLit
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessBusiness
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessOutside
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessPublicTransport
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessToilets
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessToiletsPart
 import javax.inject.Named
 
 @Module
@@ -14,13 +119,13 @@ object AchievementsModule {
 
     // list of quest synonyms (this alternate name is mentioned to aid searching for this code)
     private val questAliases = listOf(
-        "AddAccessibleForPedestrians"        to "AddProhibitedForPedestrians",
-        "AddWheelChairAccessPublicTransport" to "AddWheelchairAccessPublicTransport",
-        "AddWheelChairAccessToilets"         to "AddWheelchairAccessToilets",
-        "AddSidewalks"                       to "AddSidewalk",
-        "DetailRoadSurface"                  to "AddRoadSurface",
-        "AddTrafficSignalsBlindFeatures"     to "AddTrafficSignalsVibration",
-        "AddSuspectedOneway"                 to "AddOneway"
+        "AddAccessibleForPedestrians"        to AddProhibitedForPedestrians::class.simpleName!!,
+        "AddWheelChairAccessPublicTransport" to AddWheelchairAccessPublicTransport::class.simpleName!!,
+        "AddWheelChairAccessToilets"         to AddWheelchairAccessToilets::class.simpleName!!,
+        "AddSidewalks"                       to AddSidewalk::class.simpleName!!,
+        "DetailRoadSurface"                  to AddRoadSurface::class.simpleName!!,
+        "AddTrafficSignalsBlindFeatures"     to AddTrafficSignalsVibration::class.simpleName!!,
+        "AddSuspectedOneway"                 to AddOneway::class.simpleName!!,
     )
 
     private val links = listOf(
@@ -413,13 +518,13 @@ object AchievementsModule {
             R.string.achievement_rare_title,
             R.string.achievement_rare_solved_X,
             SolvedQuestsOfTypes(listOf(
-                "AddSummitRegister", // 1
-                "AddWheelchairAccessToiletsPart", // 38
-                "AddWheelchairAccessOutside", // 154
-                "AddFerryAccessPedestrian", // 66
-                "AddFerryAccessMotorVehicle", // 103
-                "AddInformationToTourism", // 137
-                "AddBoardType" // 188
+                AddSummitRegister::class.simpleName!!, // 1
+                AddWheelchairAccessToiletsPart::class.simpleName!!, // 38
+                AddWheelchairAccessOutside::class.simpleName!!, // 154
+                AddFerryAccessPedestrian::class.simpleName!!, // 66
+                AddFerryAccessMotorVehicle::class.simpleName!!, // 103
+                AddInformationToTourism::class.simpleName!!, // 137
+                AddBoardType::class.simpleName!!, // 188
             )),
             // levels: 3, 9, 18, 30, 45, 63, ...
             { lvl -> (lvl + 1)*3 },
@@ -433,27 +538,27 @@ object AchievementsModule {
             R.string.achievement_car_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddRoadName",
-                    "AddOneway",
-                    "MarkCompletedHighwayConstruction",
-                    "AddTracktype",
-                    "AddRoadSurface",
-                    "AddMaxSpeed",
-                    "AddMaxHeight",
-                    "AddMaxWeight",
-                    "AddRailwayCrossingBarrier",
-                    "AddParkingAccess",
-                    "AddParkingFee",
-                    "AddParkingType",
-                    "AddMotorcycleParkingCapacity",
-                    "AddMotorcycleParkingCover",
-                    "AddFerryAccessMotorVehicle",
-                    "AddCarWashType",
-                    "AddChargingStationOperator",
-                    "AddChargingStationCapacity",
-                    "AddLanes",
-                    "AddBarrierType",
-                    "AddBollardType",
+                    AddRoadName::class.simpleName!!,
+                    AddOneway::class.simpleName!!,
+                    MarkCompletedHighwayConstruction::class.simpleName!!,
+                    AddTracktype::class.simpleName!!,
+                    AddRoadSurface::class.simpleName!!,
+                    AddMaxSpeed::class.simpleName!!,
+                    AddMaxHeight::class.simpleName!!,
+                    AddMaxWeight::class.simpleName!!,
+                    AddRailwayCrossingBarrier::class.simpleName!!,
+                    AddParkingAccess::class.simpleName!!,
+                    AddParkingFee::class.simpleName!!,
+                    AddParkingType::class.simpleName!!,
+                    AddMotorcycleParkingCapacity::class.simpleName!!,
+                    AddMotorcycleParkingCover::class.simpleName!!,
+                    AddFerryAccessMotorVehicle::class.simpleName!!,
+                    AddCarWashType::class.simpleName!!,
+                    AddChargingStationOperator::class.simpleName!!,
+                    AddChargingStationCapacity::class.simpleName!!,
+                    AddLanes::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
+                    AddBollardType::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -476,8 +581,8 @@ object AchievementsModule {
             R.string.achievement_veg_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddVegetarian",
-                    "AddVegan"
+                    AddVegetarian::class.simpleName!!,
+                    AddVegan::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -494,28 +599,28 @@ object AchievementsModule {
             R.string.achievement_pedestrian_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddRoadName",
-                    "AddWayLit",
-                    "AddHandrail",
-                    "AddStepsIncline",
-                    "AddStepCount",
-                    "AddStepsRamp",
-                    "AddFootwayPartSurface",
-                    "AddBenchBackrest",
-                    "AddTrafficSignalsButton",
-                    "AddFerryAccessPedestrian",
-                    "AddPathSurface",
-                    "AddCrossingType",
-                    "AddProhibitedForPedestrians",
-                    "AddSidewalk",
-                    "AddBusStopName",
-                    "AddBusStopRef",
-                    "AddBusStopShelter",
-                    "AddBenchStatusOnBusStop",
-                    "AddBusStopLit",
-                    "AddCrossingIsland",
-                    "AddBarrierType",
-                    "AddCrossing"
+                    AddRoadName::class.simpleName!!,
+                    AddWayLit::class.simpleName!!,
+                    AddHandrail::class.simpleName!!,
+                    AddStepsIncline::class.simpleName!!,
+                    AddStepCount::class.simpleName!!,
+                    AddStepsRamp::class.simpleName!!,
+                    AddFootwayPartSurface::class.simpleName!!,
+                    AddBenchBackrest::class.simpleName!!,
+                    AddTrafficSignalsButton::class.simpleName!!,
+                    AddFerryAccessPedestrian::class.simpleName!!,
+                    AddPathSurface::class.simpleName!!,
+                    AddCrossingType::class.simpleName!!,
+                    AddProhibitedForPedestrians::class.simpleName!!,
+                    AddSidewalk::class.simpleName!!,
+                    AddBusStopName::class.simpleName!!,
+                    AddBusStopRef::class.simpleName!!,
+                    AddBusStopShelter::class.simpleName!!,
+                    AddBenchStatusOnBusStop::class.simpleName!!,
+                    AddBusStopLit::class.simpleName!!,
+                    AddCrossingIsland::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
+                    AddCrossing::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -532,13 +637,13 @@ object AchievementsModule {
             R.string.achievement_building_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddIsBuildingUnderground",
-                    "AddBuildingType",
-                    "AddBuildingLevels",
-                    "MarkCompletedBuildingConstruction",
-                    "AddPowerPolesMaterial",
-                    "AddBridgeStructure",
-                    "AddRoofShape"
+                    AddIsBuildingUnderground::class.simpleName!!,
+                    AddBuildingType::class.simpleName!!,
+                    AddBuildingLevels::class.simpleName!!,
+                    MarkCompletedBuildingConstruction::class.simpleName!!,
+                    AddPowerPolesMaterial::class.simpleName!!,
+                    AddBridgeStructure::class.simpleName!!,
+                    AddRoofShape::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -556,12 +661,12 @@ object AchievementsModule {
             R.string.achievement_postman_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddHousenumber",
-                    "AddRoadName",
-                    "AddAddressStreet",
-                    "AddPostboxRef",
-                    "AddPostboxCollectionTimes",
-                    "AddPostboxRoyalCypher"
+                    AddHousenumber::class.simpleName!!,
+                    AddRoadName::class.simpleName!!,
+                    AddAddressStreet::class.simpleName!!,
+                    AddPostboxRef::class.simpleName!!,
+                    AddPostboxCollectionTimes::class.simpleName!!,
+                    AddPostboxRoyalCypher::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -581,14 +686,14 @@ object AchievementsModule {
             R.string.achievement_blind_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddTactilePavingCrosswalk",
-                    "AddTrafficSignalsSound",
-                    "AddTrafficSignalsVibration",
-                    "AddTactilePavingBusStop",
-                    "AddCrossingIsland",
-                    "AddKerbHeight",
-                    "AddTactilePavingKerb",
-                    "AddBarrierType"
+                    AddTactilePavingCrosswalk::class.simpleName!!,
+                    AddTrafficSignalsSound::class.simpleName!!,
+                    AddTrafficSignalsVibration::class.simpleName!!,
+                    AddTactilePavingBusStop::class.simpleName!!,
+                    AddCrossingIsland::class.simpleName!!,
+                    AddKerbHeight::class.simpleName!!,
+                    AddTactilePavingKerb::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -606,17 +711,17 @@ object AchievementsModule {
             R.string.achievement_wheelchair_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddWheelchairAccessBusiness",
-                    "AddWheelchairAccessOutside",
-                    "AddWheelchairAccessPublicTransport",
-                    "AddWheelchairAccessToilets",
-                    "AddWheelchairAccessToiletsPart",
-                    "AddFootwayPartSurface",
-                    "AddPathSurface",
-                    "AddStepsRamp",
-                    "AddHandrail",
-                    "AddKerbHeight",
-                    "AddBarrierType"
+                    AddWheelchairAccessBusiness::class.simpleName!!,
+                    AddWheelchairAccessOutside::class.simpleName!!,
+                    AddWheelchairAccessPublicTransport::class.simpleName!!,
+                    AddWheelchairAccessToilets::class.simpleName!!,
+                    AddWheelchairAccessToiletsPart::class.simpleName!!,
+                    AddFootwayPartSurface::class.simpleName!!,
+                    AddPathSurface::class.simpleName!!,
+                    AddStepsRamp::class.simpleName!!,
+                    AddHandrail::class.simpleName!!,
+                    AddKerbHeight::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -634,18 +739,18 @@ object AchievementsModule {
             R.string.achievement_bicyclist_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "AddCycleway",
-                    "AddCyclewayPartSurface",
-                    "AddBikeParkingCapacity",
-                    "AddBikeParkingCover",
-                    "AddBikeParkingType",
-                    "AddBikeParkingAccess",
-                    "AddBikeParkingFee",
-                    "AddCyclewaySegregation",
-                    "AddPathSurface",
-                    "AddStepsRamp",
-                    "AddKerbHeight",
-                    "AddBarrierType"
+                    AddCycleway::class.simpleName!!,
+                    AddCyclewayPartSurface::class.simpleName!!,
+                    AddBikeParkingCapacity::class.simpleName!!,
+                    AddBikeParkingCover::class.simpleName!!,
+                    AddBikeParkingType::class.simpleName!!,
+                    AddBikeParkingAccess::class.simpleName!!,
+                    AddBikeParkingFee::class.simpleName!!,
+                    AddCyclewaySegregation::class.simpleName!!,
+                    AddPathSurface::class.simpleName!!,
+                    AddStepsRamp::class.simpleName!!,
+                    AddKerbHeight::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -663,33 +768,33 @@ object AchievementsModule {
             R.string.achievement_citizen_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "CheckExistence",
-                    "CheckShopType",
-                    "SpecifyShopType",
-                    "AddSelfServiceLaundry",
-                    "AddToiletAvailability",
-                    "AddToiletsFee",
-                    "AddPlaceName",
-                    "DetermineRecyclingGlass",
-                    "AddRecyclingContainerMaterials",
-                    "AddClothingBinOperator",
-                    "AddBinStatusOnBusStop",
-                    "AddBabyChangingTable",
-                    "AddOpeningHours",
-                    "AddAtmOperator",
-                    "AddPlaygroundAccess",
-                    "AddReligionToPlaceOfWorship",
-                    "AddRecyclingType",
-                    "AddAcceptsCash",
-                    "AddVegetarian",
-                    "AddVegan",
-                    "AddKosher",
-                    "AddPoliceType",
+                    CheckExistence::class.simpleName!!,
+                    CheckShopType::class.simpleName!!,
+                    SpecifyShopType::class.simpleName!!,
+                    AddSelfServiceLaundry::class.simpleName!!,
+                    AddToiletAvailability::class.simpleName!!,
+                    AddToiletsFee::class.simpleName!!,
+                    AddPlaceName::class.simpleName!!,
+                    DetermineRecyclingGlass::class.simpleName!!,
+                    AddRecyclingContainerMaterials::class.simpleName!!,
+                    AddClothingBinOperator::class.simpleName!!,
+                    AddBinStatusOnBusStop::class.simpleName!!,
+                    AddBabyChangingTable::class.simpleName!!,
+                    AddOpeningHours::class.simpleName!!,
+                    AddAtmOperator::class.simpleName!!,
+                    AddPlaygroundAccess::class.simpleName!!,
+                    AddReligionToPlaceOfWorship::class.simpleName!!,
+                    AddRecyclingType::class.simpleName!!,
+                    AddAcceptsCash::class.simpleName!!,
+                    AddVegetarian::class.simpleName!!,
+                    AddVegan::class.simpleName!!,
+                    AddKosher::class.simpleName!!,
+                    AddPoliceType::class.simpleName!!,
                     // tourist related
-                    "AddInformationToTourism",
-                    "AddBoardType",
-                    "AddInternetAccess",
-                    "AddGeneralFee"
+                    AddInformationToTourism::class.simpleName!!,
+                    AddBoardType::class.simpleName!!,
+                    AddInternetAccess::class.simpleName!!,
+                    AddGeneralFee::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
@@ -709,24 +814,24 @@ object AchievementsModule {
             R.string.achievement_outdoors_solved_X,
             SolvedQuestsOfTypes(
                 listOf(
-                    "CheckExistence",
-                    "AddSport",
-                    "AddPitchSurface",
-                    "AddPitchLit",
-                    "AddSummitRegister",
-                    "AddReligionToWaysideShrine",
-                    "AddDrinkingWater",
+                    CheckExistence::class.simpleName!!,
+                    AddSport::class.simpleName!!,
+                    AddPitchSurface::class.simpleName!!,
+                    AddPitchLit::class.simpleName!!,
+                    AddSummitRegister::class.simpleName!!,
+                    AddReligionToWaysideShrine::class.simpleName!!,
+                    AddDrinkingWater::class.simpleName!!,
                     // from pedestrian
-                    "AddPathSurface",
-                    "AddCyclewaySegregation",
-                    "AddCyclewayPartSurface",
-                    "AddFootwayPartSurface",
-                    "AddBenchBackrest",
-                    "AddBarrierType",
-                    "AddStileType",
+                    AddPathSurface::class.simpleName!!,
+                    AddCyclewaySegregation::class.simpleName!!,
+                    AddCyclewayPartSurface::class.simpleName!!,
+                    AddFootwayPartSurface::class.simpleName!!,
+                    AddBenchBackrest::class.simpleName!!,
+                    AddBarrierType::class.simpleName!!,
+                    AddStileType::class.simpleName!!,
                     // information boards
-                    "AddInformationToTourism",
-                    "AddBoardType"
+                    AddInformationToTourism::class.simpleName!!,
+                    AddBoardType::class.simpleName!!,
                 )
             ),
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
@@ -590,9 +590,9 @@ object AchievementsModule {
     private fun links(vararg linksKeys: String = emptyArray()): List<Link> =
         linksKeys.map { linksById.getValue(it) }
 
-    // Quests not mentioned in any achievements:
+    // Achievement suggestions:
 
     // maybe "emergency"
-    // AddFireHydrantType AddIsDefibrillatorIndoor
+    // AddFireHydrantType AddIsDefibrillatorIndoor AddBollardType
     //
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
@@ -3,112 +3,28 @@ package de.westnordost.streetcomplete.data.user.achievements
 import dagger.Module
 import dagger.Provides
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.accepts_cash.AddAcceptsCash
-import de.westnordost.streetcomplete.quests.address.AddAddressStreet
-import de.westnordost.streetcomplete.quests.address.AddHousenumber
-import de.westnordost.streetcomplete.quests.atm_operator.AddAtmOperator
-import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
-import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierType
-import de.westnordost.streetcomplete.quests.barrier_type.AddStileType
-import de.westnordost.streetcomplete.quests.bench_backrest.AddBenchBackrest
-import de.westnordost.streetcomplete.quests.bike_parking_capacity.AddBikeParkingCapacity
-import de.westnordost.streetcomplete.quests.bike_parking_cover.AddBikeParkingCover
-import de.westnordost.streetcomplete.quests.bike_parking_type.AddBikeParkingType
-import de.westnordost.streetcomplete.quests.board_type.AddBoardType
-import de.westnordost.streetcomplete.quests.bollard_type.AddBollardType
-import de.westnordost.streetcomplete.quests.bridge_structure.AddBridgeStructure
-import de.westnordost.streetcomplete.quests.building_levels.AddBuildingLevels
-import de.westnordost.streetcomplete.quests.building_type.AddBuildingType
-import de.westnordost.streetcomplete.quests.building_underground.AddIsBuildingUnderground
-import de.westnordost.streetcomplete.quests.bus_stop_bench.AddBenchStatusOnBusStop
-import de.westnordost.streetcomplete.quests.bus_stop_bin.AddBinStatusOnBusStop
-import de.westnordost.streetcomplete.quests.bus_stop_lit.AddBusStopLit
-import de.westnordost.streetcomplete.quests.bus_stop_name.AddBusStopName
-import de.westnordost.streetcomplete.quests.bus_stop_ref.AddBusStopRef
-import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter
-import de.westnordost.streetcomplete.quests.car_wash_type.AddCarWashType
-import de.westnordost.streetcomplete.quests.charging_station_capacity.AddChargingStationCapacity
-import de.westnordost.streetcomplete.quests.charging_station_operator.AddChargingStationOperator
-import de.westnordost.streetcomplete.quests.clothing_bin_operator.AddClothingBinOperator
-import de.westnordost.streetcomplete.quests.construction.MarkCompletedBuildingConstruction
-import de.westnordost.streetcomplete.quests.construction.MarkCompletedHighwayConstruction
-import de.westnordost.streetcomplete.quests.crossing.AddCrossing
-import de.westnordost.streetcomplete.quests.crossing_island.AddCrossingIsland
-import de.westnordost.streetcomplete.quests.crossing_type.AddCrossingType
-import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
-import de.westnordost.streetcomplete.quests.diet_type.AddKosher
-import de.westnordost.streetcomplete.quests.diet_type.AddVegan
-import de.westnordost.streetcomplete.quests.diet_type.AddVegetarian
-import de.westnordost.streetcomplete.quests.drinking_water.AddDrinkingWater
-import de.westnordost.streetcomplete.quests.existence.CheckExistence
-import de.westnordost.streetcomplete.quests.ferry.AddFerryAccessMotorVehicle
-import de.westnordost.streetcomplete.quests.ferry.AddFerryAccessPedestrian
 import de.westnordost.streetcomplete.quests.foot.AddProhibitedForPedestrians
-import de.westnordost.streetcomplete.quests.general_fee.AddGeneralFee
-import de.westnordost.streetcomplete.quests.handrail.AddHandrail
-import de.westnordost.streetcomplete.quests.internet_access.AddInternetAccess
-import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
-import de.westnordost.streetcomplete.quests.lanes.AddLanes
-import de.westnordost.streetcomplete.quests.max_height.AddMaxHeight
-import de.westnordost.streetcomplete.quests.max_speed.AddMaxSpeed
-import de.westnordost.streetcomplete.quests.max_weight.AddMaxWeight
-import de.westnordost.streetcomplete.quests.motorcycle_parking_capacity.AddMotorcycleParkingCapacity
-import de.westnordost.streetcomplete.quests.motorcycle_parking_cover.AddMotorcycleParkingCover
 import de.westnordost.streetcomplete.quests.oneway.AddOneway
-import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
-import de.westnordost.streetcomplete.quests.parking_access.AddBikeParkingAccess
-import de.westnordost.streetcomplete.quests.parking_access.AddParkingAccess
-import de.westnordost.streetcomplete.quests.parking_fee.AddBikeParkingFee
-import de.westnordost.streetcomplete.quests.parking_fee.AddParkingFee
-import de.westnordost.streetcomplete.quests.parking_type.AddParkingType
-import de.westnordost.streetcomplete.quests.pitch_lit.AddPitchLit
-import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
-import de.westnordost.streetcomplete.quests.playground_access.AddPlaygroundAccess
-import de.westnordost.streetcomplete.quests.police_type.AddPoliceType
-import de.westnordost.streetcomplete.quests.postbox_collection_times.AddPostboxCollectionTimes
-import de.westnordost.streetcomplete.quests.postbox_ref.AddPostboxRef
-import de.westnordost.streetcomplete.quests.postbox_royal_cypher.AddPostboxRoyalCypher
-import de.westnordost.streetcomplete.quests.powerpoles_material.AddPowerPolesMaterial
-import de.westnordost.streetcomplete.quests.railway_crossing.AddRailwayCrossingBarrier
-import de.westnordost.streetcomplete.quests.recycling.AddRecyclingType
-import de.westnordost.streetcomplete.quests.recycling_glass.DetermineRecyclingGlass
-import de.westnordost.streetcomplete.quests.recycling_material.AddRecyclingContainerMaterials
-import de.westnordost.streetcomplete.quests.religion.AddReligionToPlaceOfWorship
-import de.westnordost.streetcomplete.quests.religion.AddReligionToWaysideShrine
-import de.westnordost.streetcomplete.quests.road_name.AddRoadName
-import de.westnordost.streetcomplete.quests.roof_shape.AddRoofShape
-import de.westnordost.streetcomplete.quests.segregated.AddCyclewaySegregation
-import de.westnordost.streetcomplete.quests.self_service.AddSelfServiceLaundry
-import de.westnordost.streetcomplete.quests.shop_type.CheckShopType
-import de.westnordost.streetcomplete.quests.shop_type.SpecifyShopType
 import de.westnordost.streetcomplete.quests.sidewalk.AddSidewalk
-import de.westnordost.streetcomplete.quests.sport.AddSport
-import de.westnordost.streetcomplete.quests.step_count.AddStepCount
-import de.westnordost.streetcomplete.quests.steps_incline.AddStepsIncline
-import de.westnordost.streetcomplete.quests.steps_ramp.AddStepsRamp
-import de.westnordost.streetcomplete.quests.summit_register.AddSummitRegister
-import de.westnordost.streetcomplete.quests.surface.AddCyclewayPartSurface
-import de.westnordost.streetcomplete.quests.surface.AddFootwayPartSurface
-import de.westnordost.streetcomplete.quests.surface.AddPathSurface
-import de.westnordost.streetcomplete.quests.surface.AddPitchSurface
 import de.westnordost.streetcomplete.quests.surface.AddRoadSurface
-import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingBusStop
-import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingCrosswalk
-import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingKerb
-import de.westnordost.streetcomplete.quests.toilet_availability.AddToiletAvailability
-import de.westnordost.streetcomplete.quests.toilets_fee.AddToiletsFee
-import de.westnordost.streetcomplete.quests.tourism_information.AddInformationToTourism
-import de.westnordost.streetcomplete.quests.tracktype.AddTracktype
-import de.westnordost.streetcomplete.quests.traffic_signals_button.AddTrafficSignalsButton
-import de.westnordost.streetcomplete.quests.traffic_signals_sound.AddTrafficSignalsSound
 import de.westnordost.streetcomplete.quests.traffic_signals_vibrate.AddTrafficSignalsVibration
-import de.westnordost.streetcomplete.quests.way_lit.AddWayLit
-import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessBusiness
-import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessOutside
 import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessPublicTransport
 import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessToilets
-import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessToiletsPart
 import javax.inject.Named
+
+enum class QuestTypeAchievements(val id: String) {
+    RARE("rare"),
+    CAR("car"),
+    VEG("veg"),
+    PEDESTRIAN("pedestrian"),
+    BUILDING("building"),
+    POSTMAN("postman"),
+    BLIND("blind"),
+    WHEELCHAIR("wheelchair"),
+    BICYCLIST("bicyclist"),
+    CITIZEN("citizen"),
+    OUTDOORS("outdoors"),
+}
 
 @Module
 object AchievementsModule {
@@ -513,54 +429,22 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "rare",
+            QuestTypeAchievements.RARE.id,
             R.drawable.ic_achievement_rare,
             R.string.achievement_rare_title,
             R.string.achievement_rare_solved_X,
-            SolvedQuestsOfTypes(listOf(
-                AddSummitRegister::class.simpleName!!, // 1
-                AddWheelchairAccessToiletsPart::class.simpleName!!, // 38
-                AddWheelchairAccessOutside::class.simpleName!!, // 154
-                AddFerryAccessPedestrian::class.simpleName!!, // 66
-                AddFerryAccessMotorVehicle::class.simpleName!!, // 103
-                AddInformationToTourism::class.simpleName!!, // 137
-                AddBoardType::class.simpleName!!, // 188
-            )),
+            SolvedQuestsOfTypes,
             // levels: 3, 9, 18, 30, 45, 63, ...
             { lvl -> (lvl + 1)*3 },
             mapOf()
         ),
 
         Achievement(
-            "car",
+            QuestTypeAchievements.CAR.id,
             R.drawable.ic_achievement_car,
             R.string.achievement_car_title,
             R.string.achievement_car_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddRoadName::class.simpleName!!,
-                    AddOneway::class.simpleName!!,
-                    MarkCompletedHighwayConstruction::class.simpleName!!,
-                    AddTracktype::class.simpleName!!,
-                    AddRoadSurface::class.simpleName!!,
-                    AddMaxSpeed::class.simpleName!!,
-                    AddMaxHeight::class.simpleName!!,
-                    AddMaxWeight::class.simpleName!!,
-                    AddRailwayCrossingBarrier::class.simpleName!!,
-                    AddParkingAccess::class.simpleName!!,
-                    AddParkingFee::class.simpleName!!,
-                    AddParkingType::class.simpleName!!,
-                    AddMotorcycleParkingCapacity::class.simpleName!!,
-                    AddMotorcycleParkingCover::class.simpleName!!,
-                    AddFerryAccessMotorVehicle::class.simpleName!!,
-                    AddCarWashType::class.simpleName!!,
-                    AddChargingStationOperator::class.simpleName!!,
-                    AddChargingStationCapacity::class.simpleName!!,
-                    AddLanes::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                    AddBollardType::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -575,16 +459,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "veg",
+            QuestTypeAchievements.VEG.id,
             R.drawable.ic_achievement_veg,
             R.string.achievement_veg_title,
             R.string.achievement_veg_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddVegetarian::class.simpleName!!,
-                    AddVegan::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -593,36 +472,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "pedestrian",
+            QuestTypeAchievements.PEDESTRIAN.id,
             R.drawable.ic_achievement_pedestrian,
             R.string.achievement_pedestrian_title,
             R.string.achievement_pedestrian_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddRoadName::class.simpleName!!,
-                    AddWayLit::class.simpleName!!,
-                    AddHandrail::class.simpleName!!,
-                    AddStepsIncline::class.simpleName!!,
-                    AddStepCount::class.simpleName!!,
-                    AddStepsRamp::class.simpleName!!,
-                    AddFootwayPartSurface::class.simpleName!!,
-                    AddBenchBackrest::class.simpleName!!,
-                    AddTrafficSignalsButton::class.simpleName!!,
-                    AddFerryAccessPedestrian::class.simpleName!!,
-                    AddPathSurface::class.simpleName!!,
-                    AddCrossingType::class.simpleName!!,
-                    AddProhibitedForPedestrians::class.simpleName!!,
-                    AddSidewalk::class.simpleName!!,
-                    AddBusStopName::class.simpleName!!,
-                    AddBusStopRef::class.simpleName!!,
-                    AddBusStopShelter::class.simpleName!!,
-                    AddBenchStatusOnBusStop::class.simpleName!!,
-                    AddBusStopLit::class.simpleName!!,
-                    AddCrossingIsland::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                    AddCrossing::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -631,21 +485,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "building",
+            QuestTypeAchievements.BUILDING.id,
             R.drawable.ic_achievement_building,
             R.string.achievement_building_title,
             R.string.achievement_building_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddIsBuildingUnderground::class.simpleName!!,
-                    AddBuildingType::class.simpleName!!,
-                    AddBuildingLevels::class.simpleName!!,
-                    MarkCompletedBuildingConstruction::class.simpleName!!,
-                    AddPowerPolesMaterial::class.simpleName!!,
-                    AddBridgeStructure::class.simpleName!!,
-                    AddRoofShape::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -655,20 +499,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "postman",
+            QuestTypeAchievements.POSTMAN.id,
             R.drawable.ic_achievement_postman,
             R.string.achievement_postman_title,
             R.string.achievement_postman_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddHousenumber::class.simpleName!!,
-                    AddRoadName::class.simpleName!!,
-                    AddAddressStreet::class.simpleName!!,
-                    AddPostboxRef::class.simpleName!!,
-                    AddPostboxCollectionTimes::class.simpleName!!,
-                    AddPostboxRoyalCypher::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -680,22 +515,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "blind",
+            QuestTypeAchievements.BLIND.id,
             R.drawable.ic_achievement_blind,
             R.string.achievement_blind_title,
             R.string.achievement_blind_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddTactilePavingCrosswalk::class.simpleName!!,
-                    AddTrafficSignalsSound::class.simpleName!!,
-                    AddTrafficSignalsVibration::class.simpleName!!,
-                    AddTactilePavingBusStop::class.simpleName!!,
-                    AddCrossingIsland::class.simpleName!!,
-                    AddKerbHeight::class.simpleName!!,
-                    AddTactilePavingKerb::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -705,25 +529,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "wheelchair",
+            QuestTypeAchievements.WHEELCHAIR.id,
             R.drawable.ic_achievement_wheelchair,
             R.string.achievement_wheelchair_title,
             R.string.achievement_wheelchair_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddWheelchairAccessBusiness::class.simpleName!!,
-                    AddWheelchairAccessOutside::class.simpleName!!,
-                    AddWheelchairAccessPublicTransport::class.simpleName!!,
-                    AddWheelchairAccessToilets::class.simpleName!!,
-                    AddWheelchairAccessToiletsPart::class.simpleName!!,
-                    AddFootwayPartSurface::class.simpleName!!,
-                    AddPathSurface::class.simpleName!!,
-                    AddStepsRamp::class.simpleName!!,
-                    AddHandrail::class.simpleName!!,
-                    AddKerbHeight::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -733,26 +543,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "bicyclist",
+            QuestTypeAchievements.BICYCLIST.id,
             R.drawable.ic_achievement_bicyclist,
             R.string.achievement_bicyclist_title,
             R.string.achievement_bicyclist_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    AddCycleway::class.simpleName!!,
-                    AddCyclewayPartSurface::class.simpleName!!,
-                    AddBikeParkingCapacity::class.simpleName!!,
-                    AddBikeParkingCover::class.simpleName!!,
-                    AddBikeParkingType::class.simpleName!!,
-                    AddBikeParkingAccess::class.simpleName!!,
-                    AddBikeParkingFee::class.simpleName!!,
-                    AddCyclewaySegregation::class.simpleName!!,
-                    AddPathSurface::class.simpleName!!,
-                    AddStepsRamp::class.simpleName!!,
-                    AddKerbHeight::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -762,41 +557,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "citizen",
+            QuestTypeAchievements.CITIZEN.id,
             R.drawable.ic_achievement_citizen,
             R.string.achievement_citizen_title,
             R.string.achievement_citizen_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    CheckExistence::class.simpleName!!,
-                    CheckShopType::class.simpleName!!,
-                    SpecifyShopType::class.simpleName!!,
-                    AddSelfServiceLaundry::class.simpleName!!,
-                    AddToiletAvailability::class.simpleName!!,
-                    AddToiletsFee::class.simpleName!!,
-                    AddPlaceName::class.simpleName!!,
-                    DetermineRecyclingGlass::class.simpleName!!,
-                    AddRecyclingContainerMaterials::class.simpleName!!,
-                    AddClothingBinOperator::class.simpleName!!,
-                    AddBinStatusOnBusStop::class.simpleName!!,
-                    AddBabyChangingTable::class.simpleName!!,
-                    AddOpeningHours::class.simpleName!!,
-                    AddAtmOperator::class.simpleName!!,
-                    AddPlaygroundAccess::class.simpleName!!,
-                    AddReligionToPlaceOfWorship::class.simpleName!!,
-                    AddRecyclingType::class.simpleName!!,
-                    AddAcceptsCash::class.simpleName!!,
-                    AddVegetarian::class.simpleName!!,
-                    AddVegan::class.simpleName!!,
-                    AddKosher::class.simpleName!!,
-                    AddPoliceType::class.simpleName!!,
-                    // tourist related
-                    AddInformationToTourism::class.simpleName!!,
-                    AddBoardType::class.simpleName!!,
-                    AddInternetAccess::class.simpleName!!,
-                    AddGeneralFee::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(
@@ -808,32 +573,11 @@ object AchievementsModule {
         ),
 
         Achievement(
-            "outdoors",
+            QuestTypeAchievements.OUTDOORS.id,
             R.drawable.ic_achievement_outdoors,
             R.string.achievement_outdoors_title,
             R.string.achievement_outdoors_solved_X,
-            SolvedQuestsOfTypes(
-                listOf(
-                    CheckExistence::class.simpleName!!,
-                    AddSport::class.simpleName!!,
-                    AddPitchSurface::class.simpleName!!,
-                    AddPitchLit::class.simpleName!!,
-                    AddSummitRegister::class.simpleName!!,
-                    AddReligionToWaysideShrine::class.simpleName!!,
-                    AddDrinkingWater::class.simpleName!!,
-                    // from pedestrian
-                    AddPathSurface::class.simpleName!!,
-                    AddCyclewaySegregation::class.simpleName!!,
-                    AddCyclewayPartSurface::class.simpleName!!,
-                    AddFootwayPartSurface::class.simpleName!!,
-                    AddBenchBackrest::class.simpleName!!,
-                    AddBarrierType::class.simpleName!!,
-                    AddStileType::class.simpleName!!,
-                    // information boards
-                    AddInformationToTourism::class.simpleName!!,
-                    AddBoardType::class.simpleName!!,
-                )
-            ),
+            SolvedQuestsOfTypes,
             // levels: 10, 30, 60, 100, 150, 210, 280, 360, 450, 550, 660, 780, 910, 1050, ...
             { lvl -> (lvl + 1)*10 },
             mapOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsModule.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAcces
 import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessToilets
 import javax.inject.Named
 
-enum class QuestTypeAchievements(val id: String) {
+enum class QuestTypeAchievement(val id: String) {
     RARE("rare"),
     CAR("car"),
     VEG("veg"),
@@ -429,7 +429,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.RARE.id,
+            QuestTypeAchievement.RARE.id,
             R.drawable.ic_achievement_rare,
             R.string.achievement_rare_title,
             R.string.achievement_rare_solved_X,
@@ -440,7 +440,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.CAR.id,
+            QuestTypeAchievement.CAR.id,
             R.drawable.ic_achievement_car,
             R.string.achievement_car_title,
             R.string.achievement_car_solved_X,
@@ -459,7 +459,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.VEG.id,
+            QuestTypeAchievement.VEG.id,
             R.drawable.ic_achievement_veg,
             R.string.achievement_veg_title,
             R.string.achievement_veg_solved_X,
@@ -472,7 +472,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.PEDESTRIAN.id,
+            QuestTypeAchievement.PEDESTRIAN.id,
             R.drawable.ic_achievement_pedestrian,
             R.string.achievement_pedestrian_title,
             R.string.achievement_pedestrian_solved_X,
@@ -485,7 +485,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.BUILDING.id,
+            QuestTypeAchievement.BUILDING.id,
             R.drawable.ic_achievement_building,
             R.string.achievement_building_title,
             R.string.achievement_building_solved_X,
@@ -499,7 +499,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.POSTMAN.id,
+            QuestTypeAchievement.POSTMAN.id,
             R.drawable.ic_achievement_postman,
             R.string.achievement_postman_title,
             R.string.achievement_postman_solved_X,
@@ -515,7 +515,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.BLIND.id,
+            QuestTypeAchievement.BLIND.id,
             R.drawable.ic_achievement_blind,
             R.string.achievement_blind_title,
             R.string.achievement_blind_solved_X,
@@ -529,7 +529,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.WHEELCHAIR.id,
+            QuestTypeAchievement.WHEELCHAIR.id,
             R.drawable.ic_achievement_wheelchair,
             R.string.achievement_wheelchair_title,
             R.string.achievement_wheelchair_solved_X,
@@ -543,7 +543,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.BICYCLIST.id,
+            QuestTypeAchievement.BICYCLIST.id,
             R.drawable.ic_achievement_bicyclist,
             R.string.achievement_bicyclist_title,
             R.string.achievement_bicyclist_solved_X,
@@ -557,7 +557,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.CITIZEN.id,
+            QuestTypeAchievement.CITIZEN.id,
             R.drawable.ic_achievement_citizen,
             R.string.achievement_citizen_title,
             R.string.achievement_citizen_solved_X,
@@ -573,7 +573,7 @@ object AchievementsModule {
         ),
 
         Achievement(
-            QuestTypeAchievements.OUTDOORS.id,
+            QuestTypeAchievement.OUTDOORS.id,
             R.drawable.ic_achievement_outdoors,
             R.string.achievement_outdoors_title,
             R.string.achievement_outdoors_solved_X,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -57,7 +57,7 @@ class AddAcceptsCash(
 
     override val enabledInCountries = NoCountriesExcept("SE")
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (hasFeatureName(tags)) R.string.quest_accepts_cash_type_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -55,6 +56,8 @@ class AddAcceptsCash(
     override val isReplaceShopEnabled = true
 
     override val enabledInCountries = NoCountriesExcept("SE")
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (hasFeatureName(tags)) R.string.quest_accepts_cash_type_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.Relation
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 
 class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
@@ -32,7 +32,7 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
     // In Japan, housenumbers usually have block numbers, not streets
     override val enabledInCountries = AllCountriesExcept("JP")
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
+    override val questTypeAchievements = listOf(POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_street_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.Relation
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 
 class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
@@ -30,6 +31,8 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
     override val wikiLink = "Key:addr"
     // In Japan, housenumbers usually have block numbers, not streets
     override val enabledInCountries = AllCountriesExcept("JP")
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_street_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.isArea
 import de.westnordost.streetcomplete.util.LatLonRaster
 import de.westnordost.streetcomplete.util.isCompletelyInside
@@ -28,6 +29,8 @@ class AddHousenumber :  OsmElementQuestType<HousenumberAnswer> {
             "IT", // https://lists.openstreetmap.org/pipermail/talk-it/2018-July/063712.html
             "FR"  // https://github.com/streetcomplete/StreetComplete/issues/2427 https://t.me/osmfr/26320
     )
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 import de.westnordost.streetcomplete.ktx.isArea
 import de.westnordost.streetcomplete.util.LatLonRaster
 import de.westnordost.streetcomplete.util.isCompletelyInside
@@ -30,7 +30,7 @@ class AddHousenumber :  OsmElementQuestType<HousenumberAnswer> {
             "FR"  // https://github.com/streetcomplete/StreetComplete/issues/2427 https://t.me/osmfr/26320
     )
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
+    override val questTypeAchievements = listOf(POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.atm_operator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddAtmOperator : OsmFilterQuestType<String>() {
 
@@ -13,7 +13,7 @@ class AddAtmOperator : OsmFilterQuestType<String>() {
     override val icon = R.drawable.ic_quest_money
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_atm_operator_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.atm_operator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddAtmOperator : OsmFilterQuestType<String>() {
 
@@ -11,6 +12,8 @@ class AddAtmOperator : OsmFilterQuestType<String>() {
     override val wikiLink = "Tag:amenity=atm"
     override val icon = R.drawable.ic_quest_money
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_atm_operator_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.baby_changing_table
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -27,7 +27,7 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val isReplaceShopEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.baby_changing_table
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -25,6 +26,8 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_baby
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val isReplaceShopEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -3,7 +3,12 @@ package de.westnordost.streetcomplete.quests.barrier_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddBarrierType : OsmFilterQuestType<BarrierType>() {
 
@@ -23,14 +28,7 @@ class AddBarrierType : OsmFilterQuestType<BarrierType>() {
     override val icon = R.drawable.ic_quest_barrier
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.CAR,
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.BLIND,
-        QuestTypeAchievements.WHEELCHAIR,
-        QuestTypeAchievements.BICYCLIST,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(CAR, PEDESTRIAN, BLIND, WHEELCHAIR, BICYCLIST, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_barrier_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.barrier_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBarrierType : OsmFilterQuestType<BarrierType>() {
 
@@ -21,6 +22,15 @@ class AddBarrierType : OsmFilterQuestType<BarrierType>() {
     override val wikiLink = "Key:barrier"
     override val icon = R.drawable.ic_quest_barrier
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.CAR,
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.BLIND,
+        QuestTypeAchievements.WHEELCHAIR,
+        QuestTypeAchievements.BICYCLIST,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_barrier_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddStileType : OsmElementQuestType<BarrierType> {
 
@@ -36,6 +37,8 @@ class AddStileType : OsmElementQuestType<BarrierType> {
     override val wikiLink = "Key:stile"
     override val icon = R.drawable.ic_quest_cow
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_stile_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddStileType : OsmElementQuestType<BarrierType> {
 
@@ -38,7 +38,7 @@ class AddStileType : OsmElementQuestType<BarrierType> {
     override val icon = R.drawable.ic_quest_cow
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_stile_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -3,7 +3,8 @@ package de.westnordost.streetcomplete.quests.bench_backrest
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.bench_backrest.BenchBackrestAnswer.*
 
 class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
@@ -20,10 +21,7 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
     override val icon = R.drawable.ic_quest_bench_poi
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bench_backrest_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.bench_backrest
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.bench_backrest.BenchBackrestAnswer.*
 
 class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
@@ -18,6 +19,11 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
     override val wikiLink = "Tag:amenity=bench"
     override val icon = R.drawable.ic_quest_bench_poi
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bench_backrest_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
 
@@ -24,6 +25,8 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_capacity
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bikeParkingCapacity_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
 
@@ -26,7 +26,7 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
     override val icon = R.drawable.ic_quest_bicycle_parking_capacity
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bikeParkingCapacity_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_cover
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -21,7 +21,7 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_bicycle_parking_cover
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) =
         R.string.quest_bicycleParkingCoveredStatus_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_cover
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -19,6 +20,8 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_cover
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) =
         R.string.quest_bicycleParkingCoveredStatus_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
 
@@ -18,7 +18,7 @@ class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
     override val icon = R.drawable.ic_quest_bicycle_parking
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
 
@@ -16,6 +17,8 @@ class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
     override val wikiLink = "Key:bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -3,7 +3,9 @@ package de.westnordost.streetcomplete.quests.board_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddBoardType : OsmFilterQuestType<BoardType>() {
 
@@ -17,11 +19,7 @@ class AddBoardType : OsmFilterQuestType<BoardType>() {
     override val icon = R.drawable.ic_quest_board_type
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.CITIZEN,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(RARE, CITIZEN, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_board_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.board_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBoardType : OsmFilterQuestType<BoardType>() {
 
@@ -15,6 +16,12 @@ class AddBoardType : OsmFilterQuestType<BoardType>() {
     override val wikiLink = "Key:board_type"
     override val icon = R.drawable.ic_quest_board_type
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.CITIZEN,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_board_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBollardType : OsmElementQuestType<BollardType> {
 
@@ -25,6 +26,8 @@ class AddBollardType : OsmElementQuestType<BollardType> {
     override val wikiLink = "Key:bollard"
     override val icon = R.drawable.ic_quest_no_cars
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bollard_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddBollardType : OsmElementQuestType<BollardType> {
 
@@ -27,7 +27,7 @@ class AddBollardType : OsmElementQuestType<BollardType> {
     override val icon = R.drawable.ic_quest_no_cars
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bollard_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bridge_structure
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
 
@@ -12,7 +12,7 @@ class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
     override val wikiLink = "Key:bridge:structure"
     override val icon = R.drawable.ic_quest_bridge
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bridge_structure_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.bridge_structure
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
 
@@ -10,6 +11,8 @@ class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
     override val commitMessage = "Add bridge structures"
     override val wikiLink = "Key:bridge:structure"
     override val icon = R.drawable.ic_quest_bridge
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bridge_structure_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.building_levels
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
 
@@ -15,7 +15,7 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
     override val wikiLink = "Key:building:levels"
     override val icon = R.drawable.ic_quest_building_levels
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("building:part"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.building_levels
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
 
@@ -13,6 +14,8 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
     override val commitMessage = "Add building and roof levels"
     override val wikiLink = "Key:building:levels"
     override val icon = R.drawable.ic_quest_building_levels
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("building:part"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.building_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBuildingType : OsmFilterQuestType<BuildingType>() {
 
@@ -33,7 +33,7 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
     override val wikiLink = "Key:building"
     override val icon = R.drawable.ic_quest_building
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_buildingType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.building_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBuildingType : OsmFilterQuestType<BuildingType>() {
 
@@ -31,6 +32,8 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
     override val commitMessage = "Add building types"
     override val wikiLink = "Key:building"
     override val icon = R.drawable.ic_quest_building
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_buildingType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.building_underground
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
 class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
@@ -11,6 +12,8 @@ class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Determine whether building is fully underground"
     override val wikiLink = "Key:location"
     override val icon = R.drawable.ic_quest_building_underground
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.building_underground
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
 class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
@@ -13,7 +13,7 @@ class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:location"
     override val icon = R.drawable.ic_quest_building_underground
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -25,6 +26,8 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether a bus stop has a bench"
     override val wikiLink = "Key:bench"
     override val icon = R.drawable.ic_quest_bench_public_transport
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -27,7 +27,7 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:bench"
     override val icon = R.drawable.ic_quest_bench_public_transport
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -27,7 +27,7 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:bin"
     override val icon = R.drawable.ic_quest_bin_public_transport
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -25,6 +26,8 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether a bus stop has a bin"
     override val wikiLink = "Key:bin"
     override val icon = R.drawable.ic_quest_bin_public_transport
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.DayNightCycle.ONLY_NIGHT
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -31,6 +32,8 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_bus_stop_lit
     override val dayNightVisibility = ONLY_NIGHT
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.DayNightCycle.ONLY_NIGHT
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -33,7 +33,7 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_bus_stop_lit
     override val dayNightVisibility = ONLY_NIGHT
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
 
@@ -23,7 +23,7 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["tram"] == "yes")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
 
@@ -21,6 +22,8 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
     override val commitMessage = "Determine bus/tram stop names"
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["tram"] == "yes")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
 
@@ -23,7 +23,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["tram"] == "yes")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
 
@@ -21,6 +22,8 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
     override val commitMessage = "Determine bus/tram stop ref"
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["tram"] == "yes")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.BusStopShelterAnswer.*
@@ -26,6 +27,8 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
     override val commitMessage = "Add bus stop shelter"
     override val wikiLink = "Key:shelter"
     override val icon = R.drawable.ic_quest_bus_stop_shelter
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.BusStopShelterAnswer.*
@@ -28,7 +28,7 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
     override val wikiLink = "Key:shelter"
     override val icon = R.drawable.ic_quest_bus_stop_shelter
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsAnyKey("name", "ref")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.camera_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 
 class AddCameraType : OsmFilterQuestType<CameraType>() {
@@ -18,7 +18,7 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
     override val wikiLink = "Tag:surveillance:type"
     override val icon = R.drawable.ic_quest_surveillance_camera
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camera_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -18,7 +18,7 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
     override val wikiLink = "Tag:surveillance:type"
     override val icon = R.drawable.ic_quest_surveillance_camera
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camera_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.camera_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 
 class AddCameraType : OsmFilterQuestType<CameraType>() {
@@ -16,6 +17,8 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
     override val commitMessage = "Add camera type"
     override val wikiLink = "Tag:surveillance:type"
     override val icon = R.drawable.ic_quest_surveillance_camera
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camera_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.car_wash_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.*
 
@@ -12,6 +13,8 @@ class AddCarWashType : OsmFilterQuestType<List<CarWashType>>() {
     override val commitMessage = "Add car wash type"
     override val wikiLink = "Tag:amenity=car_wash"
     override val icon = R.drawable.ic_quest_car_wash
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_carWashType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.car_wash_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.*
 
@@ -14,7 +14,7 @@ class AddCarWashType : OsmFilterQuestType<List<CarWashType>>() {
     override val wikiLink = "Tag:amenity=car_wash"
     override val icon = R.drawable.ic_quest_car_wash
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_carWashType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -22,7 +22,7 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>() {
     override val icon = R.drawable.ic_quest_car_charger_capacity
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsAnyKey("name", "brand", "operator", "ref"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -20,6 +21,8 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>() {
     override val wikiLink = "Tag:amenity=charging_station"
     override val icon = R.drawable.ic_quest_car_charger_capacity
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsAnyKey("name", "brand", "operator", "ref"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.charging_station_operator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddChargingStationOperator : OsmFilterQuestType<String>() {
 
@@ -17,7 +17,7 @@ class AddChargingStationOperator : OsmFilterQuestType<String>() {
     override val icon = R.drawable.ic_quest_car_charger
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>): Int = R.string.quest_charging_station_operator_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.charging_station_operator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddChargingStationOperator : OsmFilterQuestType<String>() {
 
@@ -15,6 +16,8 @@ class AddChargingStationOperator : OsmFilterQuestType<String>() {
     override val wikiLink = "Tag:amenity=charging_station"
     override val icon = R.drawable.ic_quest_car_charger
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>): Int = R.string.quest_charging_station_operator_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddClothingBinOperator : OsmElementQuestType<String> {
 
@@ -24,7 +24,7 @@ class AddClothingBinOperator : OsmElementQuestType<String> {
     override val icon = R.drawable.ic_quest_recycling_clothes
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
         mapData.nodes.filter { filter.matches(it) && it.tags.hasNoOtherRecyclingTags() }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddClothingBinOperator : OsmElementQuestType<String> {
 
@@ -22,6 +23,8 @@ class AddClothingBinOperator : OsmElementQuestType<String> {
     override val wikiLink = "Tag:amenity=recycling"
     override val icon = R.drawable.ic_quest_recycling_clothes
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
         mapData.nodes.filter { filter.matches(it) && it.tags.hasNoOtherRecyclingTags() }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import java.time.LocalDate
 
 class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
@@ -17,6 +18,8 @@ class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructi
     override val commitMessage = "Determine whether construction is now completed"
     override val wikiLink = "Tag:building=construction"
     override val icon = R.drawable.ic_quest_building_construction
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_construction_building_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
@@ -5,8 +5,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
-import java.time.LocalDate
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
 
@@ -19,7 +18,7 @@ class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructi
     override val wikiLink = "Tag:building=construction"
     override val icon = R.drawable.ic_quest_building_construction
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_construction_building_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import java.time.LocalDate
 
 class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
@@ -19,6 +20,8 @@ class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructio
     override val wikiLink = "Tag:highway=construction"
     override val icon = R.drawable.ic_quest_road_construction
     override val hasMarkersAtEnds = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val isRoad = ALL_ROADS.contains(tags["construction"])

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
@@ -6,8 +6,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
-import java.time.LocalDate
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
 
@@ -21,7 +20,7 @@ class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructio
     override val icon = R.drawable.ic_quest_road_construction
     override val hasMarkersAtEnds = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val isRoad = ALL_ROADS.contains(tags["construction"])

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeightForm
 import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight
 import de.westnordost.streetcomplete.util.isRightOf
@@ -35,6 +36,8 @@ class AddCrossing : OsmElementQuestType<KerbHeight> {
     override val commitMessage = "Add whether there is a crossing"
     override val wikiLink = "Tag:highway=crossing"
     override val icon = R.drawable.ic_quest_pedestrian
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_crossing_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeightForm
 import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight
 import de.westnordost.streetcomplete.util.isRightOf
@@ -37,7 +37,7 @@ class AddCrossing : OsmElementQuestType<KerbHeight> {
     override val wikiLink = "Tag:highway=crossing"
     override val icon = R.drawable.ic_quest_pedestrian
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_crossing_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -31,6 +32,11 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
     override val commitMessage = "Add whether pedestrian crossing has an island"
     override val wikiLink = "Key:crossing:island"
     override val icon = R.drawable.ic_quest_pedestrian_crossing_island
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.BLIND,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_pedestrian_crossing_island
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -6,7 +6,8 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -33,10 +34,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
     override val wikiLink = "Key:crossing:island"
     override val icon = R.drawable.ic_quest_pedestrian_crossing_island
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.BLIND,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_pedestrian_crossing_island
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddCrossingType : OsmFilterQuestType<CrossingType>() {
 
@@ -32,7 +32,7 @@ class AddCrossingType : OsmFilterQuestType<CrossingType>() {
     override val wikiLink = "Key:crossing"
     override val icon = R.drawable.ic_quest_pedestrian_crossing
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_crossing_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddCrossingType : OsmFilterQuestType<CrossingType>() {
 
@@ -30,6 +31,8 @@ class AddCrossingType : OsmFilterQuestType<CrossingType>() {
     override val commitMessage = "Add crossing type"
     override val wikiLink = "Key:crossing"
     override val icon = R.drawable.ic_quest_pedestrian_crossing
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_crossing_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -12,6 +12,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 import de.westnordost.streetcomplete.quests.cycleway.Cycleway.*
 import de.westnordost.streetcomplete.util.isNearAndAligned
@@ -51,6 +52,8 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
     )
 
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) : Int =
         if (createCyclewaySides(tags, false) != null)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 import de.westnordost.streetcomplete.quests.cycleway.Cycleway.*
 import de.westnordost.streetcomplete.util.isNearAndAligned
@@ -53,7 +53,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
 
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) : Int =
         if (createCyclewaySides(tags, false) != null)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.defibrillator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -19,7 +19,7 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:indoor"
     override val icon = R.drawable.ic_quest_defibrillator
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = emptyList<QuestTypeAchievement>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_is_defibrillator_inside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.defibrillator
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -17,6 +18,8 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether defibrillator is inside building"
     override val wikiLink = "Key:indoor"
     override val icon = R.drawable.ic_quest_defibrillator
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_is_defibrillator_inside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddKosher : OsmFilterQuestType<DietAvailability>() {
 
@@ -25,7 +25,7 @@ class AddKosher : OsmFilterQuestType<DietAvailability>() {
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside_regional_warning
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_kosher_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddKosher : OsmFilterQuestType<DietAvailability>() {
 
@@ -23,6 +24,8 @@ class AddKosher : OsmFilterQuestType<DietAvailability>() {
     override val icon = R.drawable.ic_quest_kosher
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside_regional_warning
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_kosher_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.VEG
 
 class AddVegan : OsmFilterQuestType<DietAvailability>() {
 
@@ -29,10 +30,7 @@ class AddVegan : OsmFilterQuestType<DietAvailability>() {
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.VEG,
-        QuestTypeAchievements.CITIZEN,
-    )
+    override val questTypeAchievements = listOf(VEG, CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegan_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddVegan : OsmFilterQuestType<DietAvailability>() {
 
@@ -27,6 +28,11 @@ class AddVegan : OsmFilterQuestType<DietAvailability>() {
     override val icon = R.drawable.ic_quest_restaurant_vegan
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.VEG,
+        QuestTypeAchievements.CITIZEN,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegan_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
 
@@ -24,6 +25,11 @@ class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
     override val icon = R.drawable.ic_quest_restaurant_vegetarian
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.VEG,
+        QuestTypeAchievements.CITIZEN,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegetarian_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.VEG
 
 class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
 
@@ -26,10 +27,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailability>() {
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.VEG,
-        QuestTypeAchievements.CITIZEN,
-    )
+    override val questTypeAchievements = listOf(VEG, CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegetarian_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.drinking_water
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
@@ -20,6 +21,8 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
     override val wikiLink = "Key:drinking_water"
     override val icon = R.drawable.ic_quest_drinking_water
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_drinking_water_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.drinking_water
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
@@ -22,7 +22,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
     override val icon = R.drawable.ic_quest_drinking_water
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_drinking_water_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -9,7 +9,8 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -82,10 +83,7 @@ class CheckExistence(
     override val wikiLink: String? = null
     override val icon = R.drawable.ic_quest_check
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.CITIZEN,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(CITIZEN, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsAnyKey("name", "brand", "ref", "operator"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -80,6 +81,11 @@ class CheckExistence(
     override val commitMessage = "Check if element still exists"
     override val wikiLink: String? = null
     override val icon = R.drawable.ic_quest_check
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.CITIZEN,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsAnyKey("name", "brand", "ref", "operator"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.ferry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -13,6 +14,11 @@ class AddFerryAccessMotorVehicle : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:route=ferry"
     override val icon = R.drawable.ic_quest_ferry
     override val hasMarkersAtEnds = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.CAR,
+    )
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
@@ -3,7 +3,8 @@ package de.westnordost.streetcomplete.quests.ferry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -15,10 +16,7 @@ class AddFerryAccessMotorVehicle : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_ferry
     override val hasMarkersAtEnds = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.CAR,
-    )
+    override val questTypeAchievements = listOf(RARE, CAR)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.ferry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -13,6 +14,11 @@ class AddFerryAccessPedestrian : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:route=ferry"
     override val icon = R.drawable.ic_quest_ferry_pedestrian
     override val hasMarkersAtEnds = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.PEDESTRIAN,
+    )
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
@@ -3,7 +3,8 @@ package de.westnordost.streetcomplete.quests.ferry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -15,10 +16,7 @@ class AddFerryAccessPedestrian : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_ferry_pedestrian
     override val hasMarkersAtEnds = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.PEDESTRIAN,
-    )
+    override val questTypeAchievements = listOf(RARE, PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.fire_hydrant
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 
 class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
 
@@ -13,7 +13,7 @@ class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
     override val icon = R.drawable.ic_quest_fire_hydrant
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = emptyList<QuestTypeAchievement>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_fireHydrant_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.fire_hydrant
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
 
@@ -11,6 +12,8 @@ class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = R.drawable.ic_quest_fire_hydrant
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_fireHydrant_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.*
 
 class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansAnswer>() {
@@ -38,6 +39,8 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
     override val wikiLink = "Key:foot"
     override val icon = R.drawable.ic_quest_no_pedestrians
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accessible_for_pedestrians_title_prohibited
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.*
 
 class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansAnswer>() {
@@ -40,7 +40,7 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
     override val icon = R.drawable.ic_quest_no_pedestrians
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accessible_for_pedestrians_title_prohibited
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.general_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -18,6 +19,8 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add fee info"
     override val wikiLink = "Key:fee"
     override val icon = R.drawable.ic_quest_fee
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_generalFee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.general_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -20,7 +20,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:fee"
     override val icon = R.drawable.ic_quest_fee
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_generalFee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -28,10 +29,7 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_steps_handrail
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.WHEELCHAIR,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -26,6 +27,11 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:handrail"
     override val icon = R.drawable.ic_quest_steps_handrail
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.WHEELCHAIR,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
 
@@ -27,6 +28,8 @@ class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
     override val wikiLink = "Key:internet_access"
     override val icon = R.drawable.ic_quest_wifi
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_internet_access_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
 
@@ -29,7 +29,7 @@ class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
     override val icon = R.drawable.ic_quest_wifi
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_internet_access_name_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddKerbHeight : OsmElementQuestType<KerbHeight> {
 
@@ -21,6 +22,12 @@ class AddKerbHeight : OsmElementQuestType<KerbHeight> {
     override val commitMessage = "Add kerb height info"
     override val wikiLink = "Key:kerb"
     override val icon = R.drawable.ic_quest_kerb_type
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.BLIND,
+        QuestTypeAchievements.WHEELCHAIR,
+        QuestTypeAchievements.BICYCLIST,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_kerb_height_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
@@ -8,7 +8,9 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddKerbHeight : OsmElementQuestType<KerbHeight> {
 
@@ -23,11 +25,7 @@ class AddKerbHeight : OsmElementQuestType<KerbHeight> {
     override val wikiLink = "Key:kerb"
     override val icon = R.drawable.ic_quest_kerb_type
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.BLIND,
-        QuestTypeAchievements.WHEELCHAIR,
-        QuestTypeAchievements.BICYCLIST,
-    )
+    override val questTypeAchievements = listOf(BLIND, WHEELCHAIR, BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_kerb_height_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddLanes : OsmFilterQuestType<LanesAnswer>() {
 
@@ -26,6 +27,8 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
     override val wikiLink = "Key:lanes"
     override val icon = R.drawable.ic_quest_street_lanes
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_lanes_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddLanes : OsmFilterQuestType<LanesAnswer>() {
 
@@ -28,7 +28,7 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
     override val icon = R.drawable.ic_quest_street_lanes
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_lanes_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -24,7 +24,7 @@ class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
     override val icon = R.drawable.ic_quest_leaf
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val forests = mapData

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.util.measuredMultiPolygonArea
 
 class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
@@ -24,7 +24,7 @@ class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
     override val icon = R.drawable.ic_quest_leaf
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val forests = mapData

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.util.measuredMultiPolygonArea
 
 class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
@@ -22,6 +23,8 @@ class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
     override val wikiLink = "Key:leaf_type"
     override val icon = R.drawable.ic_quest_leaf
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val forests = mapData

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.meta.ALL_ROADS
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.util.intersects
 
@@ -55,6 +56,8 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
     override val wikiLink = "Key:maxheight"
     override val icon = R.drawable.ic_quest_max_height
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val isParkingEntrance = tags["amenity"] == "parking_entrance"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.meta.ALL_ROADS
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.util.intersects
 
@@ -57,7 +57,7 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
     override val icon = R.drawable.ic_quest_max_height
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val isParkingEntrance = tags["amenity"] == "parking_entrance"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
 
@@ -29,6 +30,8 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
     // see #813: US has different rules for each different state which need to be respected
     override val enabledInCountries = AllCountriesExcept("US")
     override val defaultDisabledMessage = R.string.default_disabled_msg_maxspeed
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
 
@@ -31,7 +31,7 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
     override val enabledInCountries = AllCountriesExcept("US")
     override val defaultDisabledMessage = R.string.default_disabled_msg_maxspeed
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.max_weight
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.*
 
 class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
@@ -11,6 +12,8 @@ class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
     override val wikiLink = "Key:maxweight"
     override val icon = R.drawable.ic_quest_max_weight
     override val hasMarkersAtEnds = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override val elementFilter = """
         ways with highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.max_weight
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.*
 
 class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
@@ -13,7 +13,7 @@ class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
     override val icon = R.drawable.ic_quest_max_weight
     override val hasMarkersAtEnds = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override val elementFilter = """
         ways with highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
 
@@ -16,6 +17,8 @@ class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
     override val wikiLink = "Tag:amenity=motorcycle_parking"
     override val icon = R.drawable.ic_quest_motorcycle_parking_capacity
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_motorcycleParkingCapacity_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
 
@@ -18,7 +18,7 @@ class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
     override val icon = R.drawable.ic_quest_motorcycle_parking_capacity
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_motorcycleParkingCapacity_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.motorcycle_parking_cover
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -18,6 +19,8 @@ class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:amenity=motorcycle_parking"
     override val icon = R.drawable.ic_quest_motorcycle_parking_cover
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_motorcycleParkingCoveredStatus_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.motorcycle_parking_cover
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -20,7 +20,7 @@ class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_motorcycle_parking_cover
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_motorcycleParkingCoveredStatus_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.quests.cycleway.createCyclewaySides
 import de.westnordost.streetcomplete.quests.cycleway.estimatedWidth
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.*
 import de.westnordost.streetcomplete.quests.parking_lanes.*
 
@@ -35,7 +35,7 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_oneway2_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.quests.cycleway.createCyclewaySides
 import de.westnordost.streetcomplete.quests.cycleway.estimatedWidth
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.*
 import de.westnordost.streetcomplete.quests.parking_lanes.*
 
@@ -33,6 +34,8 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
     override val icon = R.drawable.ic_quest_oneway
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_oneway2_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegment
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegmentsApi
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.WayTrafficFlowDao
@@ -38,6 +39,8 @@ class AddSuspectedOneway(
     override val icon = R.drawable.ic_quest_oneway
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_oneway_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -40,7 +40,7 @@ class AddSuspectedOneway(
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_oneway_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegment
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegmentsApi
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.WayTrafficFlowDao
@@ -40,7 +40,7 @@ class AddSuspectedOneway(
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_oneway_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupported
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
@@ -98,7 +98,7 @@ class AddOpeningHours (
     override val icon = R.drawable.ic_quest_opening_hours
     override val isReplaceShopEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasProperName = hasProperName(tags)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.quests.opening_hours.parser.isSupported
 import de.westnordost.streetcomplete.quests.opening_hours.parser.toOpeningHoursRules
@@ -96,6 +97,8 @@ class AddOpeningHours (
     override val wikiLink = "Key:opening_hours"
     override val icon = R.drawable.ic_quest_opening_hours
     override val isReplaceShopEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasProperName = hasProperName(tags)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -16,7 +16,7 @@ class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
     override val wikiLink = "Tag:landuse=orchard"
     override val icon = R.drawable.ic_quest_apple
 
-    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_orchard_produce_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.orchard_produce
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
 
@@ -14,6 +15,8 @@ class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
     override val commitMessage = "Add orchard produces"
     override val wikiLink = "Tag:landuse=orchard"
     override val icon = R.drawable.ic_quest_apple
+
+    override val questTypeAchievements = emptyList<QuestTypeAchievements>()
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_orchard_produce_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.orchard_produce
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
 
@@ -16,7 +16,7 @@ class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
     override val wikiLink = "Tag:landuse=orchard"
     override val icon = R.drawable.ic_quest_apple
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_orchard_produce_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
@@ -17,6 +18,8 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     override val commitMessage = "Add type of bike parking access"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_access
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
@@ -19,7 +19,7 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_access
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
@@ -27,7 +27,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_access
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parking_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
@@ -25,6 +26,8 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     override val commitMessage = "Add type of parking access"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_access
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parking_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingFee : OsmFilterQuestType<FeeAnswer>() {
 
@@ -25,7 +25,7 @@ class AddBikeParkingFee : OsmFilterQuestType<FeeAnswer>() {
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_fee
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
+    override val questTypeAchievements = listOf(BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_fee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddBikeParkingFee : OsmFilterQuestType<FeeAnswer>() {
 
@@ -23,6 +24,8 @@ class AddBikeParkingFee : OsmFilterQuestType<FeeAnswer>() {
     override val commitMessage = "Add whether there is a bike parking fee"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_fee
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_parking_fee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddParkingFee : OsmFilterQuestType<FeeAnswer>() {
 
@@ -17,6 +18,8 @@ class AddParkingFee : OsmFilterQuestType<FeeAnswer>() {
     override val commitMessage = "Add whether there is a parking fee"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_fee
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parking_fee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingFee : OsmFilterQuestType<FeeAnswer>() {
 
@@ -19,7 +19,7 @@ class AddParkingFee : OsmFilterQuestType<FeeAnswer>() {
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_fee
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parking_fee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddParkingType : OsmFilterQuestType<ParkingType>() {
 
@@ -14,6 +15,8 @@ class AddParkingType : OsmFilterQuestType<ParkingType>() {
     override val commitMessage = "Add parking type"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parkingType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.parking_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingType : OsmFilterQuestType<ParkingType>() {
 
@@ -16,7 +16,7 @@ class AddParkingType : OsmFilterQuestType<ParkingType>() {
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_parkingType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -23,6 +24,8 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether pitch is lit"
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_pitch_lantern
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["leisure"] == "track")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -25,7 +25,7 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_pitch_lantern
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["leisure"] == "track")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import java.util.concurrent.FutureTask
 
@@ -100,7 +100,7 @@ class AddPlaceName(
     override val icon = R.drawable.ic_quest_label
     override val isReplaceShopEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_placeName_title_name
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import java.util.concurrent.FutureTask
 
@@ -98,6 +99,8 @@ class AddPlaceName(
     override val wikiLink = "Key:name"
     override val icon = R.drawable.ic_quest_label
     override val isReplaceShopEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_placeName_title_name
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.playground_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
 class AddPlaygroundAccess : OsmFilterQuestType<Boolean>() {
@@ -11,6 +12,8 @@ class AddPlaygroundAccess : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add playground access"
     override val wikiLink = "Tag:leisure=playground"
     override val icon = R.drawable.ic_quest_playground
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_playground_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.playground_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
 class AddPlaygroundAccess : OsmFilterQuestType<Boolean>() {
@@ -13,7 +13,7 @@ class AddPlaygroundAccess : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:leisure=playground"
     override val icon = R.drawable.ic_quest_playground
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_playground_access_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddPoliceType : OsmFilterQuestType<PoliceType>() {
 
@@ -18,7 +18,7 @@ class AddPoliceType : OsmFilterQuestType<PoliceType>() {
     override val icon = R.drawable.ic_quest_police
     override val enabledInCountries = NoCountriesExcept("IT")
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_policeType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddPoliceType : OsmFilterQuestType<PoliceType>() {
 
@@ -16,6 +17,8 @@ class AddPoliceType : OsmFilterQuestType<PoliceType>() {
     override val wikiLink = "Tag:amenity=police"
     override val icon = R.drawable.ic_quest_police
     override val enabledInCountries = NoCountriesExcept("IT")
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_policeType_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -47,7 +47,7 @@ class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
             // apparently mostly not in Latin America and in Arabic world and unknown in Africa
     )
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
+    override val questTypeAchievements = listOf(POSTMAN)
 
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
         arrayOfNotNull(getNameOrBrandOrOperatorOrRef(tags))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 import de.westnordost.streetcomplete.quests.getNameOrBrandOrOperatorOrRef
@@ -45,6 +46,8 @@ class AddPostboxCollectionTimes : OsmFilterQuestType<CollectionTimesAnswer>() {
             "TJ", "KG", "KZ", "MN", "GE"
             // apparently mostly not in Latin America and in Arabic world and unknown in Africa
     )
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
 
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
         arrayOfNotNull(getNameOrBrandOrOperatorOrRef(tags))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 
@@ -20,6 +21,8 @@ class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
     override val enabledInCountries = NoCountriesExcept(
             "FR", "GB", "GG", "IM", "JE", "MT", "IE", "SG", "CZ", "SK", "CH", "US"
     )
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
 
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
         arrayOfNotNull(tags["name"] ?: tags["brand"] ?: tags["operator"])

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
 
@@ -22,7 +22,7 @@ class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
             "FR", "GB", "GG", "IM", "JE", "MT", "IE", "SG", "CZ", "SK", "CH", "US"
     )
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
+    override val questTypeAchievements = listOf(POSTMAN)
 
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
         arrayOfNotNull(tags["name"] ?: tags["brand"] ?: tags["operator"])

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
 
@@ -22,6 +23,8 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
         // territories with agency postal services provided by the British Post Office
         "KW", "BH", "MA"
     )
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_postboxRoyalCypher_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 
 class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
 
@@ -24,7 +24,7 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
         "KW", "BH", "MA"
     )
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.POSTMAN)
+    override val questTypeAchievements = listOf(POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_postboxRoyalCypher_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.powerpoles_material
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
 
@@ -14,6 +15,8 @@ class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
     override val commitMessage = "Add power poles material type"
     override val wikiLink = "Tag:power=pole"
     override val icon = R.drawable.ic_quest_power
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_powerPolesMaterial_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.powerpoles_material
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
 
@@ -16,7 +16,7 @@ class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
     override val wikiLink = "Tag:power=pole"
     override val icon = R.drawable.ic_quest_power
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_powerPolesMaterial_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
 
@@ -27,7 +27,7 @@ class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
     override val wikiLink = "Key:crossing:barrier"
     override val icon = R.drawable.ic_quest_railway
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_railway_crossing_barrier_title2
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
 
@@ -25,6 +26,8 @@ class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
     override val commitMessage = "Add type of barrier for railway crossing"
     override val wikiLink = "Key:crossing:barrier"
     override val icon = R.drawable.ic_quest_railway
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_railway_crossing_barrier_title2
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.recycling
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.quests.recycling.RecyclingType.*
 
 
@@ -15,7 +15,7 @@ class AddRecyclingType : OsmFilterQuestType<RecyclingType>() {
     override val icon = R.drawable.ic_quest_recycling
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_recycling_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.recycling
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.recycling.RecyclingType.*
 
 
@@ -13,6 +14,8 @@ class AddRecyclingType : OsmFilterQuestType<RecyclingType>() {
     override val wikiLink = "Key:recycling_type"
     override val icon = R.drawable.ic_quest_recycling
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_recycling_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.quests.recycling_glass.RecyclingGlass.*
 
 class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
@@ -20,7 +20,7 @@ class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
     override val enabledInCountries = AllCountriesExcept("CZ")
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_recycling_glass_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.recycling_glass.RecyclingGlass.*
 
 class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
@@ -18,6 +19,8 @@ class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
     // see isUsuallyAnyGlassRecycleableInContainers.yml
     override val enabledInCountries = AllCountriesExcept("CZ")
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_recycling_glass_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.util.LatLonRaster
 import de.westnordost.streetcomplete.util.distanceTo
 import de.westnordost.streetcomplete.util.enclosingBoundingBox
@@ -31,7 +31,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
     override val icon = R.drawable.ic_quest_recycling_container
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val bbox = mapData.boundingBox ?: return emptyList()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -12,6 +12,7 @@ import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.util.LatLonRaster
 import de.westnordost.streetcomplete.util.distanceTo
 import de.westnordost.streetcomplete.util.enclosingBoundingBox
@@ -29,6 +30,8 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
     override val wikiLink = "Key:recycling"
     override val icon = R.drawable.ic_quest_recycling_container
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val bbox = mapData.boundingBox ?: return emptyList()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.religion
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
 
@@ -20,7 +20,7 @@ class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.religion
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
 
@@ -18,6 +19,8 @@ class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
     override val commitMessage = "Add religion for place of worship"
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.religion
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
 
@@ -15,6 +16,8 @@ class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
     override val commitMessage = "Add religion for wayside shrine"
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_religion_for_wayside_shrine_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.religion
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
 
@@ -17,7 +17,7 @@ class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_religion_for_wayside_shrine_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -7,7 +7,9 @@ import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.POSTMAN
 import de.westnordost.streetcomplete.quests.LocalizedName
 
 class AddRoadName : OsmElementQuestType<RoadNameAnswer> {
@@ -33,11 +35,7 @@ class AddRoadName : OsmElementQuestType<RoadNameAnswer> {
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.CAR,
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.POSTMAN,
-    )
+    override val questTypeAchievements = listOf(CAR, PEDESTRIAN, POSTMAN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["highway"] == "pedestrian")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.LocalizedName
 
 class AddRoadName : OsmElementQuestType<RoadNameAnswer> {
@@ -31,6 +32,12 @@ class AddRoadName : OsmElementQuestType<RoadNameAnswer> {
     override val icon = R.drawable.ic_quest_street_name
     override val hasMarkersAtEnds = true
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.CAR,
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.POSTMAN,
+    )
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["highway"] == "pedestrian")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.meta.CountryInfos
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType<RoofShape> {
 
@@ -20,6 +21,8 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
     override val wikiLink = "Key:roof:shape"
     override val icon = R.drawable.ic_quest_roof_shape
     override val defaultDisabledMessage = R.string.default_disabled_msg_roofShape
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_roofShape_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.meta.CountryInfos
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType<RoofShape> {
 
@@ -22,7 +22,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
     override val icon = R.drawable.ic_quest_roof_shape
     override val defaultDisabledMessage = R.string.default_disabled_msg_roofShape
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BUILDING)
+    override val questTypeAchievements = listOf(BUILDING)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_roofShape_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -5,7 +5,8 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
@@ -27,10 +28,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:segregated"
     override val icon = R.drawable.ic_quest_path_segregation
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.BICYCLIST,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(BICYCLIST, OUTDOORS)
 
     override val isSplitWayEnabled = true
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
@@ -25,6 +26,11 @@ class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add segregated status for combined footway with cycleway"
     override val wikiLink = "Key:segregated"
     override val icon = R.drawable.ic_quest_path_segregation
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.BICYCLIST,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override val isSplitWayEnabled = true
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.self_service
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -13,6 +14,8 @@ class AddSelfServiceLaundry : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:shop=laundry"
     override val icon = R.drawable.ic_quest_laundry
     override val isReplaceShopEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_laundrySelfService_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.self_service
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -15,7 +15,7 @@ class AddSelfServiceLaundry : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_laundry
     override val isReplaceShopEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_laundrySelfService_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
 
@@ -30,6 +31,8 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
     override val commitMessage = "Check if vacant shop is still vacant"
     override val wikiLink = "Key:disused:"
     override val icon = R.drawable.ic_quest_check_shop
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_shop_vacant_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
 
@@ -32,7 +32,7 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
     override val wikiLink = "Key:disused:"
     override val icon = R.drawable.ic_quest_check_shop
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_shop_vacant_type_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.deleteCheckDates
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.containsAny
 import java.time.LocalDate
 
@@ -28,6 +29,8 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
     override val wikiLink = "Key:shop"
     override val icon = R.drawable.ic_quest_check_shop
     override val isReplaceShopEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = when {
         hasProperName(tags)  -> R.string.quest_shop_type_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -4,9 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.deleteCheckDates
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.containsAny
-import java.time.LocalDate
 
 class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
@@ -30,7 +29,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
     override val icon = R.drawable.ic_quest_check_shop
     override val isReplaceShopEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = when {
         hasProperName(tags)  -> R.string.quest_shop_type_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.util.isNearAndAligned
 
 class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
@@ -55,6 +56,8 @@ class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
     override val wikiLink = "Key:sidewalk"
     override val icon = R.drawable.ic_quest_sidewalk
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_sidewalk_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.util.isNearAndAligned
 
 class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
@@ -57,7 +57,7 @@ class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
     override val icon = R.drawable.ic_quest_sidewalk
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_sidewalk_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.sport
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddSport : OsmFilterQuestType<List<Sport>>() {
 
@@ -24,7 +24,7 @@ class AddSport : OsmFilterQuestType<List<Sport>>() {
     override val wikiLink = "Key:sport"
     override val icon = R.drawable.ic_quest_sport
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_sport_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.sport
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddSport : OsmFilterQuestType<List<Sport>>() {
 
@@ -22,6 +23,8 @@ class AddSport : OsmFilterQuestType<List<Sport>>() {
     override val commitMessage = "Add pitches sport"
     override val wikiLink = "Key:sport"
     override val icon = R.drawable.ic_quest_sport
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_sport_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.step_count
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddStepCount : OsmFilterQuestType<Int>() {
 
@@ -20,6 +21,8 @@ class AddStepCount : OsmFilterQuestType<Int>() {
     override val isSplitWayEnabled = true
     // because the user needs to start counting at the start of the steps
     override val hasMarkersAtEnds = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_step_count_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.step_count
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddStepCount : OsmFilterQuestType<Int>() {
 
@@ -22,7 +22,7 @@ class AddStepCount : OsmFilterQuestType<Int>() {
     // because the user needs to start counting at the start of the steps
     override val hasMarkersAtEnds = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_step_count_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.steps_incline
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.quests.steps_incline.StepsIncline.*
 
 class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
@@ -19,6 +20,8 @@ class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
     override val wikiLink = "Key:incline"
     override val icon = R.drawable.ic_quest_steps
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_incline_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.steps_incline
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.steps_incline.StepsIncline.*
 
 class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
@@ -21,7 +21,7 @@ class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
     override val icon = R.drawable.ic_quest_steps
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_incline_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -4,7 +4,9 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
@@ -28,11 +30,7 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
     override val icon = R.drawable.ic_quest_steps_ramp
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.WHEELCHAIR,
-        QuestTypeAchievements.BICYCLIST,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, WHEELCHAIR, BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_ramp_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
@@ -26,6 +27,12 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
     override val wikiLink = "Key:ramp"
     override val icon = R.drawable.ic_quest_steps_ramp
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.WHEELCHAIR,
+        QuestTypeAchievements.BICYCLIST,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_ramp_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -9,7 +9,8 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 import de.westnordost.streetcomplete.util.distanceToArcs
@@ -37,10 +38,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
         "US", "AR", "PE"
     )
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(RARE, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_summit_register_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 import de.westnordost.streetcomplete.util.distanceToArcs
@@ -34,6 +35,11 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
 
         //Americas
         "US", "AR", "PE"
+    )
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.OUTDOORS,
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_summit_register_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -31,10 +32,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val icon = R.drawable.ic_quest_bicycleway_surface
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.BICYCLIST,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(BICYCLIST, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_cyclewayPartSurface_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -29,6 +30,11 @@ class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_bicycleway_surface
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.BICYCLIST,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_cyclewayPartSurface_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -4,7 +4,9 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -30,11 +32,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val icon = R.drawable.ic_quest_footway_surface
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.WHEELCHAIR,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, WHEELCHAIR, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_footwayPartSurface_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -28,6 +29,12 @@ class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_footway_surface
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.WHEELCHAIR,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_footwayPartSurface_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -5,7 +5,10 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddPathSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -33,12 +36,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val icon = R.drawable.ic_quest_way_surface
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.PEDESTRIAN,
-        QuestTypeAchievements.WHEELCHAIR,
-        QuestTypeAchievements.BICYCLIST,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(PEDESTRIAN, WHEELCHAIR, BICYCLIST, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = when {
         tags["area"] == "yes"          -> R.string.quest_streetSurface_square_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddPathSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -31,6 +32,13 @@ class AddPathSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_way_surface
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.PEDESTRIAN,
+        QuestTypeAchievements.WHEELCHAIR,
+        QuestTypeAchievements.BICYCLIST,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>) = when {
         tags["area"] == "yes"          -> R.string.quest_streetSurface_square_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 
 class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
@@ -43,7 +43,7 @@ class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_pitch_surface
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
+    override val questTypeAchievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.get("leisure") == "track")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 
 class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
@@ -41,6 +42,8 @@ class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val commitMessage = "Add pitch surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_pitch_surface
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.get("leisure") == "track")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -31,7 +31,7 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val icon = R.drawable.ic_quest_street_surface
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
@@ -29,6 +30,8 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_street_surface
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
@@ -29,7 +29,7 @@ class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_blind_bus
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
+    override val questTypeAchievements = listOf(BLIND)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
@@ -27,6 +28,8 @@ class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_blind_bus
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
@@ -36,6 +37,8 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_blind_pedestrian_crossing
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tactilePaving_title_crosswalk
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
@@ -38,7 +38,7 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
     override val icon = R.drawable.ic_quest_blind_pedestrian_crossing
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
+    override val questTypeAchievements = listOf(BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tactilePaving_title_crosswalk
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.kerb_height.couldBeAKerb
 import de.westnordost.streetcomplete.quests.kerb_height.findAllKerbNodes
@@ -28,7 +28,7 @@ class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
     override val icon = R.drawable.ic_quest_kerb_tactile_paving
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
+    override val questTypeAchievements = listOf(BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tactile_paving_kerb_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.kerb_height.couldBeAKerb
 import de.westnordost.streetcomplete.quests.kerb_height.findAllKerbNodes
@@ -26,6 +27,8 @@ class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_kerb_tactile_paving
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tactile_paving_kerb_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.toilet_availability
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -21,6 +22,8 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add toilet availability"
     override val wikiLink = "Key:toilets"
     override val icon = R.drawable.ic_quest_toilets
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["highway"] == "rest_area" || tags["highway"] == "services")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.toilet_availability
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -23,7 +23,7 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:toilets"
     override val icon = R.drawable.ic_quest_toilets
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["highway"] == "rest_area" || tags["highway"] == "services")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.toilets_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -20,7 +20,7 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_toilet_fee
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
+    override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_toiletsFee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.toilets_fee
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -18,6 +19,8 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:fee"
     override val icon = R.drawable.ic_quest_toilet_fee
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CITIZEN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_toiletsFee_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.tourism_information
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
 
@@ -11,6 +12,12 @@ class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
     override val wikiLink = "Tag:tourism=information"
     override val icon = R.drawable.ic_quest_information
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.CITIZEN,
+        QuestTypeAchievements.OUTDOORS,
+    )
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -3,7 +3,9 @@ package de.westnordost.streetcomplete.quests.tourism_information
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 
 class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
 
@@ -13,11 +15,7 @@ class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
     override val icon = R.drawable.ic_quest_information
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.CITIZEN,
-        QuestTypeAchievements.OUTDOORS,
-    )
+    override val questTypeAchievements = listOf(RARE, CITIZEN, OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>): Int =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddTracktype : OsmFilterQuestType<Tracktype>() {
 
@@ -26,7 +26,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
     override val icon = R.drawable.ic_quest_tractor
     override val isSplitWayEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
+    override val questTypeAchievements = listOf(CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tracktype_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddTracktype : OsmFilterQuestType<Tracktype>() {
 
@@ -24,6 +25,8 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
     override val wikiLink = "Key:tracktype"
     override val icon = R.drawable.ic_quest_tractor
     override val isSplitWayEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.CAR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tracktype_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.traffic_signals_button
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -20,7 +20,7 @@ class AddTrafficSignalsButton : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Tag:highway=traffic_signals"
     override val icon = R.drawable.ic_quest_traffic_lights
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_button_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests.traffic_signals_button
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -18,6 +19,8 @@ class AddTrafficSignalsButton : OsmFilterQuestType<Boolean>() {
     override val commitMessage = "Add whether traffic signals have a button for pedestrians"
     override val wikiLink = "Tag:highway=traffic_signals"
     override val icon = R.drawable.ic_quest_traffic_lights
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_button_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -31,7 +31,7 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
     override val wikiLink = "Key:$SOUND_SIGNALS"
     override val icon = R.drawable.ic_quest_blind_traffic_lights_sound
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
+    override val questTypeAchievements = listOf(BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_sound_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -29,6 +30,8 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
     override val commitMessage = "Add whether traffic signals have sound signals"
     override val wikiLink = "Key:$SOUND_SIGNALS"
     override val icon = R.drawable.ic_quest_blind_traffic_lights_sound
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_sound_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
@@ -30,7 +30,7 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
     override val wikiLink = "Key:$VIBRATING_BUTTON"
     override val icon = R.drawable.ic_quest_blind_traffic_lights
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
+    override val questTypeAchievements = listOf(BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_vibrate_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
@@ -28,6 +29,8 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
     override val commitMessage = "Add whether traffic signals have tactile indication that it's safe to cross"
     override val wikiLink = "Key:$VIBRATING_BUTTON"
     override val icon = R.drawable.ic_quest_blind_traffic_lights
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.BLIND)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_traffic_signals_vibrate_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.DayNightCycle.ONLY_NIGHT
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddWayLit : OsmFilterQuestType<WayLit>() {
 
@@ -48,7 +48,7 @@ class AddWayLit : OsmFilterQuestType<WayLit>() {
     override val isSplitWayEnabled = true
     override val dayNightVisibility = ONLY_NIGHT
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
+    override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val type = tags["highway"]

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.DayNightCycle.ONLY_NIGHT
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddWayLit : OsmFilterQuestType<WayLit>() {
 
@@ -46,6 +47,8 @@ class AddWayLit : OsmFilterQuestType<WayLit>() {
     override val icon = R.drawable.ic_quest_lantern
     override val isSplitWayEnabled = true
     override val dayNightVisibility = ONLY_NIGHT
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val type = tags["highway"]

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -4,7 +4,7 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import java.util.concurrent.FutureTask
 
@@ -90,7 +90,7 @@ class AddWheelchairAccessBusiness(
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
+    override val questTypeAchievements = listOf(WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (hasFeatureName(tags))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -4,6 +4,7 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import java.util.concurrent.FutureTask
 
@@ -88,6 +89,8 @@ class AddWheelchairAccessBusiness(
     override val icon = R.drawable.ic_quest_wheelchair_shop
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (hasFeatureName(tags))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -16,10 +17,7 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.WHEELCHAIR,
-    )
+    override val questTypeAchievements = listOf(RARE, WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_wheelchairAccess_outside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -14,6 +15,11 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
     override val commitMessage = "Add wheelchair access to outside places"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.WHEELCHAIR,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_wheelchairAccess_outside_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -18,6 +19,8 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>(
     override val commitMessage = "Add wheelchair access to public transport platforms"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_wheelchair
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -20,7 +20,7 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>(
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_wheelchair
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
+    override val questTypeAchievements = listOf(WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>): Int {
         val hasName = tags.containsKey("name")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -22,7 +22,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isDeleteElementEnabled = true
 
-    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
+    override val questTypeAchievements = listOf(WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -20,6 +21,8 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isDeleteElementEnabled = true
+
+    override val questTypeAchievements = listOf(QuestTypeAchievements.WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags.containsKey("name"))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -4,6 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
 
 class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -20,6 +21,11 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
+
+    override val questTypeAchievements = listOf(
+        QuestTypeAchievements.RARE,
+        QuestTypeAchievements.WHEELCHAIR,
+    )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_wheelchairAccess_toiletsPart_title
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -4,7 +4,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievements
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -22,10 +23,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
     override val isReplaceShopEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
-    override val questTypeAchievements = listOf(
-        QuestTypeAchievements.RARE,
-        QuestTypeAchievements.WHEELCHAIR,
-    )
+    override val questTypeAchievements = listOf(RARE, WHEELCHAIR)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_wheelchairAccess_toiletsPart_title
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
 open class TestQuestTypeA : OsmElementQuestType<String> {
@@ -17,6 +18,7 @@ open class TestQuestTypeA : OsmElementQuestType<String> {
     override fun getApplicableElements(mapData: MapDataWithGeometry) = mapData.filter { isApplicableTo(it) == true }
     override val wikiLink: String? = null
     override val icon = 0
+    override val questTypeAchievements = emptyList<QuestTypeAchievement>()
 }
 
 class TestQuestTypeB : TestQuestTypeA()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiverTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiverTest.kt
@@ -1,9 +1,12 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
-import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.data.notifications.NewUserAchievementsDao
+import de.westnordost.streetcomplete.data.quest.QuestType
+import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.user.QuestStatisticsDao
 import de.westnordost.streetcomplete.data.user.UserStore
+import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
+import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
 import org.junit.Before
@@ -19,6 +22,7 @@ class AchievementGiverTest {
     private lateinit var questStatisticsDao: QuestStatisticsDao
     private lateinit var userStore: UserStore
     private var allAchievements: MutableList<Achievement> = mutableListOf()
+    private lateinit var questTypeRegistry: QuestTypeRegistry
     private lateinit var achievementGiver: AchievementGiver
 
     @Before fun setUp() {
@@ -28,11 +32,12 @@ class AchievementGiverTest {
         userLinksDao = mock()
         questStatisticsDao = mock()
         userStore = mock()
+        initQuestTypeRegistry()
 
         allAchievements.clear()
 
         achievementGiver = AchievementGiver(userAchievementsDao, newUserAchievementsDao,
-            userLinksDao, questStatisticsDao, allAchievements, userStore)
+            userLinksDao, questStatisticsDao, allAchievements, questTypeRegistry, userStore)
     }
 
 
@@ -56,14 +61,14 @@ class AchievementGiverTest {
     }
 
     @Test fun `unlocks QuestType achievement`() {
-        on(questStatisticsDao.getAmount(listOf("a", "b"))).thenReturn(1)
+        on(questStatisticsDao.getAmount(listOf("ThisQuest", "OtherQuest"))).thenReturn(1)
 
-        allAchievements.addAll(listOf(achievement("questsAbc", SolvedQuestsOfTypes(listOf("a","b")))))
+        allAchievements.addAll(listOf(achievement("mixedAchievement", SolvedQuestsOfTypes)))
 
         achievementGiver.updateAllAchievements()
 
-        verify(userAchievementsDao).put("questsAbc", 1)
-        verify(newUserAchievementsDao).push("questsAbc" to 1)
+        verify(userAchievementsDao).put("mixedAchievement", 1)
+        verify(newUserAchievementsDao).push("mixedAchievement" to 1)
     }
 
     @Test fun `unlocks multiple locked levels of an achievement and grants those links`() {
@@ -133,9 +138,9 @@ class AchievementGiverTest {
 
         allAchievements.addAll(listOf(
             achievement("daysActive", DaysActive),
-            achievement("otherAchievement", SolvedQuestsOfTypes(listOf("OtherQuest"))),
-            achievement("thisAchievement", SolvedQuestsOfTypes(listOf("ThisQuest"))),
-            achievement("mixedAchievement", SolvedQuestsOfTypes(listOf("ThisQuest", "OtherQuest"))),
+            achievement("otherAchievement", SolvedQuestsOfTypes),
+            achievement("thisAchievement", SolvedQuestsOfTypes),
+            achievement("mixedAchievement", SolvedQuestsOfTypes),
             achievement("allQuests", TotalSolvedQuests)
         ))
 
@@ -156,7 +161,7 @@ class AchievementGiverTest {
         allAchievements.addAll(listOf(
             achievement("daysActive", DaysActive),
             achievement("daysActive2", DaysActive),
-            achievement("otherAchievement", SolvedQuestsOfTypes(listOf("ThisQuest", "OtherQuest"))),
+            achievement("mixedAchievement", SolvedQuestsOfTypes),
             achievement("allQuests", TotalSolvedQuests)
         ))
 
@@ -179,4 +184,37 @@ class AchievementGiverTest {
 
     private fun links(vararg ids: String): List<Link> =
         ids.map { id -> Link(id, "url", "title", LinkCategory.INTRO, null, null) }
+
+    private fun questTypeAchievements(achievementIds: List<String>): List<QuestTypeAchievement> =
+        achievementIds.map {
+            val questTypeAchievement: QuestTypeAchievement = mock()
+            on(questTypeAchievement.id).thenReturn(it)
+            questTypeAchievement
+        }
+
+    private fun initQuestTypeRegistry() {
+        questTypeRegistry = mock()
+
+        class ThisQuest : QuestType<Int> {
+            override val icon = 0
+            override val title = 0
+            override fun createForm(): AbstractQuestAnswerFragment<Int> = mock()
+            override val questTypeAchievements =
+                questTypeAchievements(listOf("thisAchievement", "mixedAchievement"))
+        }
+
+        class OtherQuest : QuestType<Int> {
+            override val icon = 0
+            override val title = 0
+            override fun createForm(): AbstractQuestAnswerFragment<Int> = mock()
+            override val questTypeAchievements =
+                questTypeAchievements(listOf("otherAchievement", "mixedAchievement"))
+        }
+
+        val thisQuest = ThisQuest()
+        val otherQuest = OtherQuest()
+        on(questTypeRegistry.iterator()).thenReturn(listOf(thisQuest, otherQuest).listIterator())
+        on(questTypeRegistry.getByName("ThisQuest")).thenReturn(thisQuest)
+        on(questTypeRegistry.getByName("OtherQuest")).thenReturn(otherQuest)
+    }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiverTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementGiverTest.kt
@@ -193,8 +193,6 @@ class AchievementGiverTest {
         }
 
     private fun initQuestTypeRegistry() {
-        questTypeRegistry = mock()
-
         class ThisQuest : QuestType<Int> {
             override val icon = 0
             override val title = 0
@@ -211,10 +209,6 @@ class AchievementGiverTest {
                 questTypeAchievements(listOf("otherAchievement", "mixedAchievement"))
         }
 
-        val thisQuest = ThisQuest()
-        val otherQuest = OtherQuest()
-        on(questTypeRegistry.iterator()).thenReturn(listOf(thisQuest, otherQuest).listIterator())
-        on(questTypeRegistry.getByName("ThisQuest")).thenReturn(thisQuest)
-        on(questTypeRegistry.getByName("OtherQuest")).thenReturn(otherQuest)
+        questTypeRegistry = QuestTypeRegistry(listOf(ThisQuest(), OtherQuest()))
     }
 }


### PR DESCRIPTION
As suggested in https://github.com/streetcomplete/StreetComplete/pull/3311#issuecomment-924422806:

> Maybe the achievement stuff should be refactored so that it is defined in the quests themselves to which achievements they should count. Contributors keep forgetting to add it