### PR TITLE
make text more readable - set style on image descriptions used in some quests [ready]

### DIFF
--- a/app/src/main/res/layout/cell_labeled_icon_select_right.xml
+++ b/app/src/main/res/layout/cell_labeled_icon_select_right.xml
@@ -25,7 +25,7 @@
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/imageView"
         android:layout_centerVertical="true"
-        style="@style/ImageSelectDescription"
+        style="@style/DescriptionNextToImage"
         tools:text="@string/quest_segregated_mixed" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/cell_labeled_icon_select_with_description.xml
+++ b/app/src/main/res/layout/cell_labeled_icon_select_with_description.xml
@@ -30,12 +30,12 @@
             android:id="@+id/textView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            style="@style/ImageSelectTitle"
+            style="@style/TitleNextToImage"
             tools:text="@string/quest_buildingType_apartments" />
 
         <TextView
             android:id="@+id/descriptionView"
-            style="@style/ImageSelectDescription"
+            style="@style/DescriptionNextToImage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="@string/quest_buildingType_apartments_description" />

--- a/app/src/main/res/layout/cell_labeled_icon_select_with_description_group.xml
+++ b/app/src/main/res/layout/cell_labeled_icon_select_with_description_group.xml
@@ -36,12 +36,12 @@
                 android:id="@+id/textView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/ImageSelectTitle"
+                style="@style/TitleNextToImage"
                 tools:text="@string/quest_buildingType_residential" />
 
             <TextView
                 android:id="@+id/descriptionView"
-                style="@style/ImageSelectDescription"
+                style="@style/DescriptionNextToImage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:text="@string/quest_buildingType_residential_description" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -5,13 +5,15 @@
 
     <color name="attribution_text">#ccc</color>
 
-    <color name="hint_text">#aaa</color>
-
     <color name="inverted_background">#aaa</color>
     <color name="background">#000</color>
     <color name="background_transparent">#0000</color>
     <color name="text">#fff</color>
     <color name="monochrome_icon">#ccc</color>
+
+    <color name="hint_text">#aaa</color>
+    <color name="icon_selection_title_text">#fff</color>
+    <color name="icon_selection_description_text">#fff</color>
 
     <color name="quest_selection_frame">#bbFF5722</color>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -11,7 +11,7 @@
     <color name="text">#fff</color>
     <color name="monochrome_icon">#ccc</color>
 
-    <color name="hint_text">#aaa</color>
+    <color name="hint_text">#999</color>
     <color name="title_text_next_to_image">#fff</color>
     <color name="description_text_next_to_image">#fff</color>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -5,7 +5,7 @@
 
     <color name="attribution_text">#ccc</color>
 
-    <color name="hint_text">#999</color>
+    <color name="hint_text">#aaa</color>
 
     <color name="inverted_background">#aaa</color>
     <color name="background">#000</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,6 +12,7 @@
     <color name="monochrome_icon">#ccc</color>
 
     <color name="hint_text">#999</color>
+    <color name="title_text_below_image">#fff</color>
     <color name="title_text_next_to_image">#fff</color>
     <color name="description_text_next_to_image">#fff</color>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,7 +12,7 @@
     <color name="monochrome_icon">#ccc</color>
 
     <color name="hint_text">#999</color>
-    <color name="title_text_below_image">#fff</color>
+    <color name="label_text_below_image">#fff</color>
     <color name="title_text_next_to_image">#fff</color>
     <color name="description_text_next_to_image">#fff</color>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,8 +12,8 @@
     <color name="monochrome_icon">#ccc</color>
 
     <color name="hint_text">#aaa</color>
-    <color name="icon_selection_title_text">#fff</color>
-    <color name="icon_selection_description_text">#fff</color>
+    <color name="title_text_next_to_image">#fff</color>
+    <color name="description_text_next_to_image">#fff</color>
 
     <color name="quest_selection_frame">#bbFF5722</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,7 +27,7 @@
     <color name="indicator_dot_selected">@color/accent</color>
 
     <color name="hint_text">#666</color>
-    <color name="title_text_below_image">#000</color>
+    <color name="label_text_below_image">#000</color>
     <color name="title_text_next_to_image">#000</color>
     <color name="description_text_next_to_image">#000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,7 +26,7 @@
     <color name="indicator_dot">#888</color>
     <color name="indicator_dot_selected">@color/accent</color>
 
-    <color name="hint_text">#555</color>
+    <color name="hint_text">#666</color>
     <color name="title_text_next_to_image">#000</color>
     <color name="description_text_next_to_image">#000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,7 +26,7 @@
     <color name="indicator_dot">#888</color>
     <color name="indicator_dot_selected">@color/accent</color>
 
-    <color name="hint_text">#666</color>
+    <color name="hint_text">#555</color>
 
     <color name="disabled_text">#6666</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,6 +27,8 @@
     <color name="indicator_dot_selected">@color/accent</color>
 
     <color name="hint_text">#555</color>
+    <color name="icon_selection_title_text">#000</color>
+    <color name="icon_selection_description_text">#000</color>
 
     <color name="disabled_text">#6666</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,8 +27,8 @@
     <color name="indicator_dot_selected">@color/accent</color>
 
     <color name="hint_text">#555</color>
-    <color name="icon_selection_title_text">#000</color>
-    <color name="icon_selection_description_text">#000</color>
+    <color name="title_text_next_to_image">#000</color>
+    <color name="description_text_next_to_image">#000</color>
 
     <color name="disabled_text">#6666</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,6 +27,7 @@
     <color name="indicator_dot_selected">@color/accent</color>
 
     <color name="hint_text">#666</color>
+    <color name="title_text_below_image">#000</color>
     <color name="title_text_next_to_image">#000</color>
     <color name="description_text_next_to_image">#000</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -126,11 +126,13 @@
     <style name="ImageSelectTitle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/hint_text</item>
     </style>
 
     <style name="ImageSelectDescription">
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">normal</item>
+        <item name="android:textColor">@color/hint_text</item>
     </style>
 
     <!-- ++++++++++++++++++++++++++++++++++++++ Table ++++++++++++++++++++++++++++++++++++++++++ -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -126,13 +126,13 @@
     <style name="ImageSelectTitle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/hint_text</item>
+        <item name="android:textColor">@color/text</item>
     </style>
 
     <style name="ImageSelectDescription">
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">normal</item>
-        <item name="android:textColor">@color/hint_text</item>
+        <item name="android:textColor">@color/text</item>
     </style>
 
     <!-- ++++++++++++++++++++++++++++++++++++++ Table ++++++++++++++++++++++++++++++++++++++++++ -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -121,7 +121,7 @@
         <item name="android:textStyle">normal</item>
         <item name="android:textAlignment">center</item>
         <item name="android:gravity">center_horizontal</item>
-        <item name="android:textColor">@color/title_text_below_image</item>
+        <item name="android:textColor">@color/label_text_below_image</item>
     </style>
 
     <style name="TitleNextToImage">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -121,6 +121,7 @@
         <item name="android:textStyle">normal</item>
         <item name="android:textAlignment">center</item>
         <item name="android:gravity">center_horizontal</item>
+        <item name="android:textColor">@color/title_text_below_image</item>
     </style>
 
     <style name="TitleNextToImage">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -123,16 +123,16 @@
         <item name="android:gravity">center_horizontal</item>
     </style>
 
-    <style name="ImageSelectTitle">
+    <style name="TitleNextToImage">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/icon_selection_title_text</item>
+        <item name="android:textColor">@color/title_text_next_to_image</item>
     </style>
 
-    <style name="ImageSelectDescription">
+    <style name="DescriptionNextToImage">
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">normal</item>
-        <item name="android:textColor">@color/icon_selection_description_text</item>
+        <item name="android:textColor">@color/description_text_next_to_image</item>
     </style>
 
     <!-- ++++++++++++++++++++++++++++++++++++++ Table ++++++++++++++++++++++++++++++++++++++++++ -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -126,13 +126,13 @@
     <style name="ImageSelectTitle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/text</item>
+        <item name="android:textColor">@color/icon_selection_title_text</item>
     </style>
 
     <style name="ImageSelectDescription">
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">normal</item>
-        <item name="android:textColor">@color/text</item>
+        <item name="android:textColor">@color/icon_selection_description_text</item>
     </style>
 
     <!-- ++++++++++++++++++++++++++++++++++++++ Table ++++++++++++++++++++++++++++++++++++++++++ -->


### PR DESCRIPTION
changes ImageSelectTitle ImageSelectDescription - that a bit confusingly affects quest where user selects icon wth title + description - and photo-selecion quests are not affected

this starts explicitly setting colour on text visible during selection
why? because in some cases light gray currently used is not clearly visible and this allows to set it at least in some cases

TODO:
- check is it fine to set such colour manually or is it bad idea for some reason (that is why I will open a draft PR)
- fix it for night mode where this change degraded contrast
- before fixing for dark mode check where else hint_text is used and is it also affected by poor contrast in night mode right now