### PR TITLE
Use smart item selection for building levels

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -114,14 +114,14 @@ abstract class AGroupedImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnsw
                         .setMessage(R.string.quest_generic_item_confirmation)
                         .setNegativeButton(R.string.quest_generic_confirmation_no, null)
                         .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ ->
-                            favs.add(javaClass.simpleName, itemValue, allowDuplicates = true)
+                            favs.add(javaClass.simpleName, itemValue)
                             onClickOk(itemValue)
                         }
                         .show()
                 }
             }
             else {
-                favs.add(javaClass.simpleName, itemValue, allowDuplicates = true)
+                favs.add(javaClass.simpleName, itemValue)
                 onClickOk(itemValue)
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -42,9 +42,8 @@ abstract class AGroupedImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnsw
 
     override fun onAttach(ctx: Context) {
         super.onAttach(ctx)
-        val stringToItem by lazy {
-            allItems.mapNotNull { it.items }.flatten().associateBy { it.value.toString() }
-        }
+        val validSuggestions = allItems.mapNotNull { it.items }.flatten()
+        val stringToItem = validSuggestions.associateBy { it.value.toString() }
         favs = LastPickedValuesStore(
             PreferenceManager.getDefaultSharedPreferences(ctx.applicationContext),
             key = javaClass.simpleName,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -16,7 +16,6 @@ import de.westnordost.streetcomplete.databinding.QuestGenericListBinding
 import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
 import de.westnordost.streetcomplete.view.image_select.GroupedImageSelectAdapter
 import kotlin.math.max
-import kotlin.math.min
 
 /**
  * Abstract class for quests with a grouped list of images and one to select.

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -35,7 +35,7 @@ abstract class AGroupedImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnsw
     protected abstract val allItems: List<GroupableDisplayItem<I>>
     protected abstract val topItems: List<GroupableDisplayItem<I>>
 
-    @Inject internal lateinit var favs: LastPickedValuesStore<I>
+    @Inject internal lateinit var favs: LastPickedValuesStore
 
     private val selectedItem get() = imageSelector.selectedItem
 
@@ -114,14 +114,14 @@ abstract class AGroupedImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnsw
                         .setMessage(R.string.quest_generic_item_confirmation)
                         .setNegativeButton(R.string.quest_generic_confirmation_no, null)
                         .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ ->
-                            favs.add(javaClass.simpleName, itemValue)
+                            favs.add(javaClass.simpleName, itemValue.toString())
                             onClickOk(itemValue)
                         }
                         .show()
                 }
             }
             else {
-                favs.add(javaClass.simpleName, itemValue)
+                favs.add(javaClass.simpleName, itemValue.toString())
                 onClickOk(itemValue)
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -9,8 +9,6 @@ import android.view.View
 import androidx.core.view.postDelayed
 import androidx.preference.PreferenceManager
 
-import javax.inject.Inject
-
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.QuestGenericListBinding
 import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
@@ -11,7 +11,6 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.QuestGenericListBinding
 import de.westnordost.streetcomplete.view.image_select.DisplayItem
 import de.westnordost.streetcomplete.view.image_select.ImageSelectAdapter
-import java.util.*
 import kotlin.collections.ArrayList
 
 /**

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
@@ -34,7 +34,7 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
 
     protected lateinit var imageSelector: ImageSelectAdapter<I>
 
-    private lateinit var favs: LastPickedValuesStore<I>
+    private lateinit var favs: LastPickedValuesStore
 
     protected open val itemsPerRow = 4
     /** return -1 for any number. Default: 1  */
@@ -89,7 +89,7 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
     override fun onClickOk() {
         val values = imageSelector.selectedItems
         if (values.isNotEmpty()) {
-            favs.add(javaClass.simpleName, values)
+            favs.add(javaClass.simpleName, values.map { it.toString() })
             onClickOk(values)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
@@ -51,7 +51,7 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
 
     override fun onAttach(ctx: Context) {
         super.onAttach(ctx)
-        val stringToItem by lazy { items.associateBy { it.value.toString() } }
+        val stringToItem = items.associateBy { it.value.toString() }
         favs = LastPickedValuesStore(
             PreferenceManager.getDefaultSharedPreferences(ctx.applicationContext),
             key = javaClass.simpleName,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -49,7 +49,17 @@ fun <T> LastPickedValuesStore<T>.getWeighted(
     itemPool: List<GroupableDisplayItem<T>>
 ): List<GroupableDisplayItem<T>> {
     val stringToItem = itemPool.associateBy { it.value.toString() }
-    val lastPickedItems = get(key).map { stringToItem.get(it) }
+    return getWeighted(key, count, historyCount, defaultItems, stringToItem::get)
+}
+
+fun <T, I> LastPickedValuesStore<T>.getWeighted(
+    key: String,
+    count: Int,
+    historyCount: Int,
+    defaultItems: List<I>,
+    deserialize: (String) -> I?
+): List<I> {
+    val lastPickedItems = get(key).map(deserialize)
     val counts = lastPickedItems.countUniqueNonNull(historyCount, count)
     val topRecent = counts.keys.sortedByDescending { counts.get(it) }
     val latest = lastPickedItems.take(1).filterNotNull()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -11,16 +11,16 @@ import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
 import kotlin.math.min
 
 /** T must be a string or enum - something that distinctly converts toString. */
-class LastPickedValuesStore<T> @Inject constructor(private val prefs: SharedPreferences) {
+class LastPickedValuesStore @Inject constructor(private val prefs: SharedPreferences) {
 
-    fun add(key: String, newValues: Iterable<T>) {
-        val lastValues = newValues.asSequence().map { it.toString() } + get(key)
+    fun add(key: String, newValues: Iterable<String>) {
+        val lastValues = newValues.asSequence() + get(key)
         prefs.edit {
             putString(getKey(key), lastValues.take(MAX_ENTRIES).joinToString(","))
         }
     }
 
-    fun add(key: String, value: T) = add(key, listOf(value))
+    fun add(key: String, value: String) = add(key, listOf(value))
 
     fun get(key: String): Sequence<String> =
         prefs.getString(getKey(key), null)?.splitToSequence(",") ?: sequenceOf()
@@ -39,7 +39,7 @@ private const val MAX_ENTRIES = 100
  *
  * impl: null represents items not in the item pool
  */
-fun <T> LastPickedValuesStore<T>.getWeighted(
+fun <T> LastPickedValuesStore.getWeighted(
     key: String,
     count: Int,
     historyCount: Int,
@@ -70,7 +70,7 @@ private fun <T : Any> Sequence<T?>.countUniqueNonNull(minItems: Int, target: Int
 private fun <T> Sequence<T>.takeAtLeastWhile(count: Int, predicate: (T) -> Boolean): Sequence<T> =
     withIndex().takeWhile{ (i, t) -> i < count || predicate(t) }.map { it.value }
 
-fun <T> LastPickedValuesStore<T>.moveLastPickedDisplayItemsToFront(
+fun <T> LastPickedValuesStore.moveLastPickedDisplayItemsToFront(
     key: String,
     defaultItems: List<DisplayItem<T>>,
     itemPool: List<DisplayItem<T>>

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -6,7 +6,6 @@ import androidx.core.content.edit
 import javax.inject.Inject
 
 import de.westnordost.streetcomplete.Prefs
-import kotlin.math.min
 
 class LastPickedValuesStore<T : Any> @Inject constructor(private val prefs: SharedPreferences) {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -3,8 +3,6 @@ package de.westnordost.streetcomplete.quests
 import android.content.SharedPreferences
 import androidx.core.content.edit
 
-import javax.inject.Inject
-
 import de.westnordost.streetcomplete.Prefs
 
 class LastPickedValuesStore<T : Any>(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -6,51 +6,40 @@ import androidx.core.content.edit
 import javax.inject.Inject
 
 import de.westnordost.streetcomplete.Prefs
-import de.westnordost.streetcomplete.view.image_select.DisplayItem
-import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
 import kotlin.math.min
 
-/** T must be a string or enum - something that distinctly converts toString. */
-class LastPickedValuesStore @Inject constructor(private val prefs: SharedPreferences) {
+class LastPickedValuesStore<T : Any> @Inject constructor(private val prefs: SharedPreferences) {
 
-    fun add(key: String, newValues: Iterable<String>) {
-        val lastValues = newValues.asSequence() + get(key)
+    fun add(factory: Factory<T>, newValues: Iterable<T>) {
+        val lastValues = newValues.asSequence().map(factory::serialize) + getRaw(factory.key)
         prefs.edit {
-            putString(getKey(key), lastValues.take(MAX_ENTRIES).joinToString(","))
+            putString(getKey(factory.key), lastValues.take(MAX_ENTRIES).joinToString(","))
         }
     }
 
-    fun add(key: String, value: String) = add(key, listOf(value))
+    fun add(factory: Factory<T>, value: T) = add(factory, listOf(value))
 
-    fun get(key: String): Sequence<String> =
+    fun get(factory: Factory<T>): Sequence<T?> = getRaw(factory.key).map(factory::deserialize)
+
+    private fun getRaw(key: String): Sequence<String> =
         prefs.getString(getKey(key), null)?.splitToSequence(",") ?: sequenceOf()
 
     private fun getKey(key: String) = Prefs.LAST_PICKED_PREFIX + key
+
+    interface Factory<T : Any> {
+        val key: String
+        fun serialize(item: T): String
+        fun deserialize(value: String): T? // null = invalid value
+    }
 }
 
 private const val MAX_ENTRIES = 100
 
-/* Returns `count` unique items, sorted by how often they appear in the last `historyCount` answers.
- * If fewer than `count` unique items are found, look farther back in the history.
- * Only returns items in `itemPool` ("valid"), although other answers count towards `historyCount`.
- * If there are not enough unique items in the whole history, add unique `defaultItems` as needed.
- * Always include the most recent answer, if it is in `itemPool`, but still sorted normally. So, if
- * it is not one of the `count` most frequent items, it will replace the last of those.
- *
- * impl: null represents items not in the item pool
+/* In the first `historyCount` items, return the `count` most-common non-null items, in order.
+ * If the first item is not included (and is not null), it replaces the last of the common items.
+ * If fewer than `count` unique items are found, continue counting items until that many are found,
+ * or the end of the sequence is reached.
  */
-fun <T> LastPickedValuesStore.getWeighted(
-    key: String,
-    count: Int,
-    historyCount: Int,
-    defaultItems: List<GroupableDisplayItem<T>>,
-    itemPool: List<GroupableDisplayItem<T>>
-): List<GroupableDisplayItem<T>> {
-    val stringToItem = itemPool.associateBy { it.value.toString() }
-    val lastPickedItems = get(key).map { stringToItem.get(it) }
-    return lastPickedItems.mostCommonWithin(count, historyCount).padWith(defaultItems).toList()
-}
-
 fun <T : Any> Sequence<T?>.mostCommonWithin(count: Int, historyCount: Int): Sequence<T> {
     val counts = this.countUniqueNonNull(historyCount, count)
     val top = counts.keys.sortedByDescending { counts.get(it) }
@@ -70,15 +59,5 @@ private fun <T : Any> Sequence<T?>.countUniqueNonNull(minItems: Int, target: Int
 private fun <T> Sequence<T>.takeAtLeastWhile(count: Int, predicate: (T) -> Boolean): Sequence<T> =
     withIndex().takeWhile{ (i, t) -> i < count || predicate(t) }.map { it.value }
 
-fun <T> LastPickedValuesStore.moveLastPickedDisplayItemsToFront(
-    key: String,
-    defaultItems: List<DisplayItem<T>>,
-    itemPool: List<DisplayItem<T>>
-): List<DisplayItem<T>> {
-    val stringToItem = itemPool.associateBy { it.value.toString() }
-    val lastPickedItems = get(key).mapNotNull { stringToItem.get(it) }
-    return lastPickedItems.padWith(defaultItems).toList()
-}
-
-private fun <T> Sequence<T>.padWith(defaults: List<T>, count: Int = defaults.size) =
+fun <T> Sequence<T>.padWith(defaults: List<T>, count: Int = defaults.size) =
     (this + defaults).distinct().take(count)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -11,7 +11,7 @@ class LastPickedValuesStore<T : Any>(
     private val prefs: SharedPreferences,
     private val key: String,
     private val serialize: (T) -> String,
-    private val deserialize: (String) -> T? // null = invalid value
+    private val deserialize: (String) -> T? // null = unwanted value, see mostCommonWithin
 ) {
     fun add(newValues: Iterable<T>) {
         val lastValues = newValues.asSequence().map(serialize) + getRaw()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -13,17 +13,14 @@ import kotlin.math.min
 /** T must be a string or enum - something that distinctly converts toString. */
 class LastPickedValuesStore<T> @Inject constructor(private val prefs: SharedPreferences) {
 
-    fun add(key: String, newValues: Iterable<T>, max: Int = MAX_ENTRIES, allowDuplicates: Boolean = false) {
-        val values = newValues.asSequence().map { it.toString() } + get(key)
-        val lastValues = if (allowDuplicates) values else values.distinct()
+    fun add(key: String, newValues: Iterable<T>) {
+        val lastValues = newValues.asSequence().map { it.toString() } + get(key)
         prefs.edit {
-            putString(getKey(key), lastValues.take(max).joinToString(","))
+            putString(getKey(key), lastValues.take(MAX_ENTRIES).joinToString(","))
         }
     }
 
-    fun add(key: String, value: T, max: Int = MAX_ENTRIES, allowDuplicates: Boolean = false) {
-        add(key, listOf(value), max, allowDuplicates)
-    }
+    fun add(key: String, value: T) = add(key, listOf(value))
 
     fun get(key: String): Sequence<String> = prefs.getString(getKey(key), "")!!.splitToSequence(",")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -38,7 +38,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
             .toList()
     }
 
-    @Inject internal lateinit var favs: LastPickedValuesStore<String>
+    @Inject internal lateinit var favs: LastPickedValuesStore
 
     init {
         Injector.applicationComponent.inject(this)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -32,7 +32,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     private val roofLevels get() = binding.roofLevelsInput.text?.toString().orEmpty().trim()
 
     private val lastPickedAnswers by lazy {
-        favs.getWeighted(javaClass.simpleName, 5, 30, listOf()) { it.toBuildingLevelAnswer() }
+        favs.getWeighted(javaClass.simpleName, 5, 30) { it.toBuildingLevelAnswer() }
             .sortedWith(compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels })
             .toList()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -16,7 +16,7 @@ import de.westnordost.streetcomplete.databinding.QuestBuildingLevelsLastPickedBu
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.LastPickedValuesStore
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.getWeighted
+import de.westnordost.streetcomplete.quests.mostCommonWithin
 import de.westnordost.streetcomplete.util.TextChangedWatcher
 
 class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnswer>() {
@@ -32,7 +32,8 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     private val roofLevels get() = binding.roofLevelsInput.text?.toString().orEmpty().trim()
 
     private val lastPickedAnswers by lazy {
-        favs.getWeighted(javaClass.simpleName, 5, 30) { it.toBuildingLevelAnswer() }
+        favs.get(javaClass.simpleName).map { it.toBuildingLevelAnswer() }
+            .mostCommonWithin(5, 30)
             .sortedWith(compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels })
             .toList()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -16,6 +16,7 @@ import de.westnordost.streetcomplete.databinding.QuestBuildingLevelsLastPickedBu
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.LastPickedValuesStore
 import de.westnordost.streetcomplete.quests.AnswerItem
+import de.westnordost.streetcomplete.quests.getWeighted
 import de.westnordost.streetcomplete.util.TextChangedWatcher
 
 class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnswer>() {
@@ -31,9 +32,9 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     private val roofLevels get() = binding.roofLevelsInput.text?.toString().orEmpty().trim()
 
     private val lastPickedAnswers by lazy {
-        favs.get(javaClass.simpleName).map { it.toBuildingLevelAnswer() }.sortedWith(
-            compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels }
-        ).toList()
+        favs.getWeighted(javaClass.simpleName, 5, 30, listOf()) { it.toBuildingLevelAnswer() }
+            .sortedWith(compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels })
+            .toList()
     }
 
     @Inject internal lateinit var favs: LastPickedValuesStore<String>

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -65,7 +65,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     override fun onClickOk() {
         val roofLevelsNumber = if (roofLevels.isEmpty()) null else roofLevels.toInt()
         val answer = BuildingLevelsAnswer(levels.toInt(), roofLevelsNumber)
-        favs.add(javaClass.simpleName, answer.toSerializedString(), allowDuplicates = true)
+        favs.add(javaClass.simpleName, answer.toSerializedString())
         applyAnswer(answer)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -9,9 +9,6 @@ import android.view.ViewGroup
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 
-import javax.inject.Inject
-
-import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.QuestBuildingLevelsBinding
 import de.westnordost.streetcomplete.databinding.QuestBuildingLevelsLastPickedButtonBinding

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -65,7 +65,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     override fun onClickOk() {
         val roofLevelsNumber = if (roofLevels.isEmpty()) null else roofLevels.toInt()
         val answer = BuildingLevelsAnswer(levels.toInt(), roofLevelsNumber)
-        favs.add(javaClass.simpleName, answer.toSerializedString(), max = 5)
+        favs.add(javaClass.simpleName, answer.toSerializedString(), allowDuplicates = true)
         applyAnswer(answer)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
@@ -24,7 +24,7 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
 
     val listeners: MutableList<OnItemSelectionListener> = CopyOnWriteArrayList()
 
-    val selectedItems get() = _selectedIndices.map { i -> items[i].value!! }
+    val selectedItems get() = _selectedIndices.map { i -> items[i] }
 
     interface OnItemSelectionListener {
         fun onIndexSelected(index: Int)

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
@@ -5,70 +5,51 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.view.image_select.Item
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 
 
 class LastPickedValuesStoreTest {
 
-    private lateinit var favs: LastPickedValuesStore<Letter>
-    private val key: String = javaClass.simpleName
-
-    private val allItems = Letter.values().toList().toItems()
-    private val defaultItems = listOf(X, Y, Z).toItems()
-
-    @Before fun setUp() {
-        favs = mock()
-    }
-
     @Test fun `weighted sort returns the default items when there is no history`() {
-        on(favs.get(key)).thenReturn(sequenceOf())
-        val returnedItems = favs.getWeighted(key, 4, 99, defaultItems, allItems)
+        val allItems = Letter.values().toList().map { Item(it) }
+        val defaultItems = listOf(A, B, C).map { Item(it) }
+
+        val favs = mock<LastPickedValuesStore<Letter>>()
+        on(favs.get(javaClass.simpleName)).thenReturn(sequenceOf())
+
+        val returnedItems = favs.getWeighted(javaClass.simpleName, 4, 99, defaultItems, allItems)
         assertEquals(defaultItems, returnedItems)
     }
 
-    @Test fun `weighted sort considers frequency first, then recency, then defaults`() {
-        on(favs.get(key)).thenReturn(sequenceOf("A", "C", "B", "B", "C", "D"))
-        val returnedItems = favs.getWeighted(key, 6, 99, defaultItems, allItems)
-        val expectedItems = listOf(C, B, A, D, X, Y).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin sorts by frequency first, then recency`() {
+        val items = sequenceOf(A, C, B, B, C, D)
+        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(C, B, A, D))
     }
 
-    @Test fun `weighted sort returns most recent item even if it is not the most picked`() {
-        on(favs.get(key)).thenReturn(sequenceOf("A", "B", "B", "B", "C", "C"))
-        val returnedItems = favs.getWeighted(key, 2, 99, defaultItems, allItems)
-        val expectedItems = listOf(B, A).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin includes the most recent item even if it is not the most common`() {
+        val items = sequenceOf(A, B, B, B, C, C)
+        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(B, A))
     }
 
-    @Test fun `weighted sort doesn't return duplicates`() {
-        on(favs.get(key)).thenReturn(sequenceOf("X", "Y", "X", "A"))
-        val returnedItems = favs.getWeighted(key, 4, 99, defaultItems, allItems)
-        val expectedItems = listOf(X, Y, A, Z).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin doesn't return duplicates`() {
+        val items = sequenceOf(A, B, A, B)
+        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(A, B))
     }
 
-    @Test fun `weighted sort only returns items in itemPool (the most recent is not exempt)`() {
-        on(favs.get(key)).thenReturn(sequenceOf("p", "B", "q", "C"))
-        val returnedItems = favs.getWeighted(key, 2, 99, defaultItems, allItems)
-        val expectedItems = listOf(B, C).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin doesn't include the first item if it's null`() {
+        val items = sequenceOf(null, B, null, C)
+        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(B, C))
     }
 
-    @Test fun `weighted sort still counts non-itemPool values in the history window`() {
-        on(favs.get(key)).thenReturn(sequenceOf("A", "p", "q", "B", /**/ "B", "C", "D"))
-        val returnedItems = favs.getWeighted(key, 2, 4, defaultItems, allItems)
-        val expectedItems = listOf(A, B).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin includes nulls in the number of items to count`() {
+        val items = sequenceOf(A, null, null, B, /* stops here */ B, C, D)
+        assertEquals(items.mostCommonWithin(2, 4).toList(), listOf(A, B))
     }
 
-    @Test fun `weighted sort extends the history window (only) as needed to find enough items`() {
-        on(favs.get(key)).thenReturn(sequenceOf("A", "p", "q", "B", "B", "C", /**/ "D"))
-        val returnedItems = favs.getWeighted(key, 3, 4, defaultItems, allItems)
-        val expectedItems = listOf(B, A, C).toItems()
-        assertEquals(expectedItems, returnedItems)
+    @Test fun `mostCommonWithin keeps counting until enough non-null items have been found`() {
+        val items = sequenceOf(A, null, null, B, B, C, /* stops here */ D)
+        assertEquals(items.mostCommonWithin(3, 4).toList(), listOf(B, A, C))
     }
 }
 
-private enum class Letter { A, B, C, D, X, Y, Z }
-private fun List<Letter>.toItems(): List<Item<Letter>> = this.map(::Item)
+private enum class Letter { A, B, C, D }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
@@ -1,25 +1,11 @@
 package de.westnordost.streetcomplete.quests
 
 import de.westnordost.streetcomplete.quests.Letter.*
-import de.westnordost.streetcomplete.testutils.mock
-import de.westnordost.streetcomplete.testutils.on
-import de.westnordost.streetcomplete.view.image_select.Item
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 
 class LastPickedValuesStoreTest {
-
-    @Test fun `weighted sort returns the default items when there is no history`() {
-        val allItems = Letter.values().toList().map { Item(it) }
-        val defaultItems = listOf(A, B, C).map { Item(it) }
-
-        val favs = mock<LastPickedValuesStore<Letter>>()
-        on(favs.get(javaClass.simpleName)).thenReturn(sequenceOf())
-
-        val returnedItems = favs.getWeighted(javaClass.simpleName, 4, 99, defaultItems, allItems)
-        assertEquals(defaultItems, returnedItems)
-    }
 
     @Test fun `mostCommonWithin sorts by frequency first, then recency`() {
         val items = sequenceOf(A, C, B, B, C, D)
@@ -49,6 +35,11 @@ class LastPickedValuesStoreTest {
     @Test fun `mostCommonWithin keeps counting until enough non-null items have been found`() {
         val items = sequenceOf(A, null, null, B, B, C, /* stops here */ D)
         assertEquals(items.mostCommonWithin(3, 4).toList(), listOf(B, A, C))
+    }
+
+    @Test fun `padWith doesn't include duplicates`() {
+        val items = sequenceOf(A, B).padWith(listOf(B, C, D, A))
+        assertEquals(items.toList(), listOf(A, B, C, D))
     }
 }
 


### PR DESCRIPTION
…but keep the same sort order.

Also, store duplicates in history for all quests, so if we want to switch to the "smart" order later, there will already be data.

Fun story: when I was implementing this, I initially added a version of `get` that implemented the previous de-duplication and maximum size on the other end… then found out we didn't need to use it anywhere, because `get` is only called from the extension functions defined right there, which all do it themselves already.

*(as discussed in https://github.com/streetcomplete/StreetComplete/pull/3373#issuecomment-949031515)*