### PR TITLE
Add housename to street quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -37,7 +37,7 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_address_street_title
 
     override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
-        arrayOfNotNull(tags["addr:streetnumber"] ?: tags["addr:housenumber"])
+        arrayOfNotNull(tags["addr:streetnumber"] ?: tags["addr:housenumber"] ?: tags["addr:housename"])
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val excludedWayNodeIds = mutableSetOf<Long>()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -16,7 +16,7 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
 
     private val filter by lazy { """
         nodes, ways, relations with
-          addr:housenumber and !addr:street and !addr:place and !addr:block_number
+          ~"addr:(housenumber|housename)" and !addr:street and !addr:place and !addr:block_number
           or addr:streetnumber and !addr:street
     """.toElementFilterExpression() }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,7 +803,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_steps_incline_title">Which direction leads upwards for these steps?</string>
     <string name="quest_steps_incline_up">This way up</string>
     <string name="quest_step_count_title">How many steps are here?</string>
-    <string name="quest_address_street_title">What street does the (house) number %s belong to?</string>
+    <string name="quest_address_street_title">What street does (house) %s belong to?</string>
     <string name="quest_address_street_no_named_streets">It does not belong to a named street</string>
     <string name="quest_address_street_hint">Tap road on map</string>
     <string name="quest_address_street_place_name_label">Place name:</string>


### PR DESCRIPTION
I can't see that this has been discussed anywhere, I did see https://github.com/streetcomplete/StreetComplete/issues/213#issuecomment-406603714
> * [x]  research what should be done with house names (exclude addr:housename?) - no, if `addr:streetnumber` is present then `addr:housename` also present is not changing anything at all

But this seems to be about excluding objects with both housenumber and housename

At least in the UK, houses with housename belong to a street/place in the same way that houses with housenumber do, so it feels odd when answering quests that only with housenumber do you get the street quest after answering.

I don't know if that's different in different parts of the world though.

(This is untested)