### PR TITLE
embed git commit id into Debug APK filename

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -20,9 +20,11 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew assembleDebug
+    - name: Rename APK
+      run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$(git log -n 1 --format='%h').apk
     - name: Archive APK
       uses: actions/upload-artifact@v2
       with: 
         name: debug-apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: app/build/outputs/apk/debug/*.apk
         retention-days: 1


### PR DESCRIPTION
This PR makes the `.apk` file name for debug build contain **git commit** id, to make it easier to find it when you need to handle more of them when debugging. 

eg. instead of `app-debug.apk`, the file will be named (for example) `StreetComplete-debug-431cfdd.apk`