### PR TITLE
Better hint (review of English welcomed!)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
@@ -40,7 +40,10 @@ class ShopGoneDialog(
 
         radioButtons = listOf(binding.vacantRadioButton, binding.replaceRadioButton, binding.leaveNoteRadioButton)
         for (radioButton in radioButtons) {
-            radioButton.setOnClickListener { selectRadioButton(it) }
+            radioButton.setOnClickListener {
+                selectRadioButton(it)
+                binding.presetsEditText.error = null
+            }
         }
 
         binding.presetsEditText.setAdapter(SearchAdapter(context, { term -> getFeatures(term) }, { it.name }))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
@@ -74,7 +74,7 @@ class ShopGoneDialog(
                 R.id.replaceRadioButton -> {
                     val feature = getSelectedFeature()
                     if (feature == null) {
-                        binding.presetsEditText.error = context.resources.getText(R.string.quest_shop_gone_replaced_answer_error)
+                        binding.presetsEditText.error = context.resources.getText(R.string.quest_shop_gone_replaced_answer_error2)
                     } else {
                         onSelectedFeature(feature.addTags)
                         dismiss()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopTypeForm.kt
@@ -48,7 +48,7 @@ class ShopTypeForm : AbstractQuestFormAnswerFragment<ShopTypeAnswer>() {
             R.id.replaceRadioButton   -> {
                 val feature = getSelectedFeature()
                 if (feature == null) {
-                    binding.presetsEditText.error = context?.resources?.getText(R.string.quest_shop_gone_replaced_answer_error)
+                    binding.presetsEditText.error = context?.resources?.getText(R.string.quest_shop_gone_replaced_answer_error2)
                 } else {
                     applyAnswer(ShopType(feature.addTags))
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_shop_gone_vacant_answer">It’s vacant</string>
     <string name="quest_shop_gone_replaced_answer">A(n)…</string>
     <string name="quest_shop_gone_replaced_answer_hint">Type kind of place here</string>
-    <string name="quest_shop_gone_replaced_answer_error2">"Not recognized. Try entering the type of place, for example 'bakery'. Otherwise, consider leaving a note."</string>
+    <string name="quest_shop_gone_replaced_answer_error2">"Not recognized. Try entering the type of place, for example “bakery”. Otherwise, consider leaving a note."</string>
     <string name="quest_shop_vacant_type_title">This shop has been vacant. What’s here now?</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">No cycleway at all</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">As usual, tap on one side of the illustration, select a proper answer and do the same for the other side.\n\nNote all the available options: some cases are not obvious, like a oneway road that allows cyclists in both directions!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_shop_gone_vacant_answer">It’s vacant</string>
     <string name="quest_shop_gone_replaced_answer">A(n)…</string>
     <string name="quest_shop_gone_replaced_answer_hint">Type kind of place here</string>
-    <string name="quest_shop_gone_replaced_answer_error2">"Enter the type of object, for example 'bakery', not the name.\nLeave note if that fails."</string>
+    <string name="quest_shop_gone_replaced_answer_error2">"Enter only the type of object, for example 'bakery', not the name.\nLeave note if that fails."</string>
     <string name="quest_shop_vacant_type_title">This shop has been vacant. What’s here now?</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">No cycleway at all</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">As usual, tap on one side of the illustration, select a proper answer and do the same for the other side.\n\nNote all the available options: some cases are not obvious, like a oneway road that allows cyclists in both directions!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_shop_gone_vacant_answer">It’s vacant</string>
     <string name="quest_shop_gone_replaced_answer">A(n)…</string>
     <string name="quest_shop_gone_replaced_answer_hint">Type kind of place here</string>
-    <string name="quest_shop_gone_replaced_answer_error2">"Enter only the type of object, for example 'bakery', not the name.\nLeave note if that fails."</string>
+    <string name="quest_shop_gone_replaced_answer_error2">"Enter only the type of object, for example 'bakery', not the name.\nLeave a note if that fails."</string>
     <string name="quest_shop_vacant_type_title">This shop has been vacant. What’s here now?</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">No cycleway at all</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">As usual, tap on one side of the illustration, select a proper answer and do the same for the other side.\n\nNote all the available options: some cases are not obvious, like a oneway road that allows cyclists in both directions!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_shop_gone_vacant_answer">It’s vacant</string>
     <string name="quest_shop_gone_replaced_answer">A(n)…</string>
     <string name="quest_shop_gone_replaced_answer_hint">Type kind of place here</string>
-    <string name="quest_shop_gone_replaced_answer_error2">"Enter only the type of object, for example 'bakery', not the name.\nLeave a note if that fails."</string>
+    <string name="quest_shop_gone_replaced_answer_error2">"Not recognized. Try entering the type of place, for example 'bakery'. Otherwise, consider leaving a note."</string>
     <string name="quest_shop_vacant_type_title">This shop has been vacant. What’s here now?</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">No cycleway at all</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">As usual, tap on one side of the illustration, select a proper answer and do the same for the other side.\n\nNote all the available options: some cases are not obvious, like a oneway road that allows cyclists in both directions!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_shop_gone_vacant_answer">It’s vacant</string>
     <string name="quest_shop_gone_replaced_answer">A(n)…</string>
     <string name="quest_shop_gone_replaced_answer_hint">Type kind of place here</string>
-    <string name="quest_shop_gone_replaced_answer_error">"Don’t know what this is. Consider leaving a note."</string>
+    <string name="quest_shop_gone_replaced_answer_error2">"Enter the type of object, for example 'bakery', not the name.\nLeave note if that fails."</string>
     <string name="quest_shop_vacant_type_title">This shop has been vacant. What’s here now?</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">No cycleway at all</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">As usual, tap on one side of the illustration, select a proper answer and do the same for the other side.\n\nNote all the available options: some cases are not obvious, like a oneway road that allows cyclists in both directions!</string>


### PR DESCRIPTION
Fixes #3227 in a modified way.

Showing this error/hint while typing would be annoying. And user who is new to this menu and types things like "Jolly Good" or "Polska Chata" will not be expecting dropdown to appear - they will type and press OK button.

Also, I have not figured out how to do this anyway, but I am pretty sure that showing error in normal operation - as I proposed - would be really annoying.

![screen02](https://user-images.githubusercontent.com/899988/140101146-05e5caad-0937-402e-9a3f-7ef756ebb4d2.png)

original text:

> Don’t know what this is. Consider leaving a note.