### PR TITLE
Sort building type recents by chronological order

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -34,8 +34,8 @@ private const val MAX_ENTRIES = 100
  *  items of the sequence, in their original order.
  * If there are fewer than `count` unique items, continues counting items
  *  until that many are found, or the end of the sequence is reached.
- * If the first item is not null, it is always included, displacing the
- *  least-common of the other items if necessary.
+ * If the first item (i.e. the most recent one) is not null, it is always
+ *  included, displacing the least-common of the other items if necessary.
  */
 fun <T : Any> Sequence<T?>.mostCommonWithin(count: Int, historyCount: Int): Sequence<T> {
     val counts = this.countUniqueNonNull(historyCount, count)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -51,14 +51,12 @@ private data class ItemStats(val indexOfFirst: Int, var count: Int = 0)
 private fun <T : Any> Sequence<T?>.countUniqueNonNull(target: Int, minItems: Int): Map<T, ItemStats> {
     val counts = mutableMapOf<T, ItemStats>()
 
-    // Because this is a sequence, the chain of calls is applied to items one at a time.
-    // This means the `getOrPut` for one item affects the `counts.size` for the next item
-    this.withIndex()
-        .filter { it.value != null }
-        .takeWhile { it.index < minItems || counts.size < target }
-        .forEach {
-            counts.getOrPut(it.value!!) { ItemStats(it.index) }.count++
+    for (item in this.withIndex()) {
+        if (item.index >= minItems && counts.size >= target) break
+        item.value?.let { value ->
+            counts.getOrPut(value) { ItemStats(item.index) }.count++
         }
+    }
 
     return counts
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -30,18 +30,18 @@ class LastPickedValuesStore<T : Any>(
 
 private const val MAX_ENTRIES = 100
 
-/* Returns the `count` most-common non-null items in the first `historyCount`
+/* Returns the `target` most-common non-null items in the first `historyCount`
  *  items of the sequence, in their original order.
- * If there are fewer than `count` unique items, continues counting items
+ * If there are fewer than `target` unique items, continues counting items
  *  until that many are found, or the end of the sequence is reached.
  * If the first item (i.e. the most recent one) is not null, it is always
  *  included, displacing the least-common of the other items if necessary.
  */
-fun <T : Any> Sequence<T?>.mostCommonWithin(count: Int, historyCount: Int): Sequence<T> {
-    val counts = this.countUniqueNonNull(historyCount, count)
-    val top = counts.keys.sortedByDescending { counts[it]!!.count }.take(count)
+fun <T : Any> Sequence<T?>.mostCommonWithin(target: Int, historyCount: Int): Sequence<T> {
+    val counts = this.countUniqueNonNull(historyCount, target)
+    val top = counts.keys.sortedByDescending { counts[it]!!.count }.take(target)
     val latest = this.take(1).filterNotNull()
-    val items = (latest + top).distinct().take(count)
+    val items = (latest + top).distinct().take(target)
     return items.sortedBy { counts[it]!!.indexOfFirst }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -51,7 +51,8 @@ private data class ItemStats(val indexOfFirst: Int, var count: Int = 0)
 private fun <T : Any> Sequence<T?>.countUniqueNonNull(target: Int, minItems: Int): Map<T, ItemStats> {
     val counts = mutableMapOf<T, ItemStats>()
 
-    // Sequences are evaluated lazily, so the `forEach` affects each `counts.size` check
+    // Because this is a sequence, the chain of calls is applied to items one at a time.
+    // This means the `getOrPut` for one item affects the `counts.size` for the next item
     this.withIndex()
         .filter { it.value != null }
         .takeWhile { it.index < minItems || counts.size < target }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -38,7 +38,7 @@ private const val MAX_ENTRIES = 100
  *  included, displacing the least-common of the other items if necessary.
  */
 fun <T : Any> Sequence<T?>.mostCommonWithin(target: Int, historyCount: Int): Sequence<T> {
-    val counts = this.countUniqueNonNull(historyCount, target)
+    val counts = this.countUniqueNonNull(target, historyCount)
     val top = counts.keys.sortedByDescending { counts[it]!!.count }.take(target)
     val latest = this.take(1).filterNotNull()
     val items = (latest + top).distinct().take(target)
@@ -48,7 +48,7 @@ fun <T : Any> Sequence<T?>.mostCommonWithin(target: Int, historyCount: Int): Seq
 private data class ItemStats(val indexOfFirst: Int, var count: Int = 0)
 
 // Counts at least the first `minItems`, keeps going until it finds at least `target` unique values
-private fun <T : Any> Sequence<T?>.countUniqueNonNull(minItems: Int, target: Int): Map<T, ItemStats> {
+private fun <T : Any> Sequence<T?>.countUniqueNonNull(target: Int, minItems: Int): Map<T, ItemStats> {
     val counts = mutableMapOf<T, ItemStats>()
 
     // Sequences are evaluated lazily, so the `forEach` affects each `counts.size` check

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -30,9 +30,12 @@ class LastPickedValuesStore<T : Any>(
 
 private const val MAX_ENTRIES = 100
 
-/* Returns the `count` most-common non-null items in the first `historyCount` items of the sequence.
- * If fewer than `count` unique items are found, continues counting items until that many are found,
- * or the end of the sequence is reached. If the first item is not null, it is always included.
+/* Returns the `count` most-common non-null items in the first `historyCount`
+ *  items of the sequence, in their original order.
+ * If there are fewer than `count` unique items, continues counting items
+ *  until that many are found, or the end of the sequence is reached.
+ * If the first item is not null, it is always included, displacing the
+ *  least-common of the other items if necessary.
  */
 fun <T : Any> Sequence<T?>.mostCommonWithin(count: Int, historyCount: Int): Sequence<T> {
     val counts = this.countUniqueNonNull(historyCount, count)

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
@@ -7,14 +7,14 @@ import org.junit.Test
 
 class LastPickedValuesStoreTest {
 
-    @Test fun `mostCommonWithin sorts by frequency first, then recency`() {
+    @Test fun `mostCommonWithin sorts by recency`() {
         val items = sequenceOf(A, C, B, B, C, D)
-        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(C, B, A, D))
+        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(A, C, B, D))
     }
 
     @Test fun `mostCommonWithin includes the most recent item even if it is not the most common`() {
         val items = sequenceOf(A, B, B, B, C, C)
-        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(B, A))
+        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(A, B))
     }
 
     @Test fun `mostCommonWithin doesn't return duplicates`() {
@@ -34,7 +34,7 @@ class LastPickedValuesStoreTest {
 
     @Test fun `mostCommonWithin keeps counting until enough non-null items have been found`() {
         val items = sequenceOf(A, null, null, B, B, C, /* stops here */ D)
-        assertEquals(items.mostCommonWithin(3, 4).toList(), listOf(B, A, C))
+        assertEquals(items.mostCommonWithin(3, 4).toList(), listOf(A, B, C))
     }
 
     @Test fun `padWith doesn't include duplicates`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/LastPickedValuesStoreTest.kt
@@ -7,40 +7,71 @@ import org.junit.Test
 
 class LastPickedValuesStoreTest {
 
-    @Test fun `mostCommonWithin sorts by recency`() {
-        val items = sequenceOf(A, C, B, B, C, D)
-        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(A, C, B, D))
+    @Test fun `mostCommonWithin`() {
+        assertEquals(
+            "Returns the most common items",
+            listOf(A, C),
+            sequenceOf(A, A, B, C, C).mostCommonWithin(2, 99).toList(),
+        )
+        assertEquals(
+            "Sorted in the original order",
+            listOf(A, C, B),
+            sequenceOf(A, C, B, B, C).mostCommonWithin(4, 99).toList(),
+        )
+        assertEquals(
+            "Doesn't return nulls",
+            listOf(A),
+            sequenceOf(A, null).mostCommonWithin(2, 99).toList()
+        )
     }
 
-    @Test fun `mostCommonWithin includes the most recent item even if it is not the most common`() {
-        val items = sequenceOf(A, B, B, B, C, C)
-        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(A, B))
+    @Test fun `mostCommonWithin first item special case`() {
+        assertEquals(
+            "Included even if it is not the most common",
+            listOf(A, B),
+            sequenceOf(A, B, B, C, C).mostCommonWithin(2, 99).toList(),
+        )
+        assertEquals(
+            "Not included if null",
+            listOf(B, C),
+            sequenceOf(null, B, C).mostCommonWithin(2, 99).toList(),
+        )
+        assertEquals(
+            "Not duplicated if it was already among the most common",
+            listOf(A, B),
+            sequenceOf(A, B, A, B).mostCommonWithin(4, 99).toList(),
+        )
     }
 
-    @Test fun `mostCommonWithin doesn't return duplicates`() {
-        val items = sequenceOf(A, B, A, B)
-        assertEquals(items.mostCommonWithin(4, 99).toList(), listOf(A, B))
-    }
-
-    @Test fun `mostCommonWithin doesn't include the first item if it's null`() {
-        val items = sequenceOf(null, B, null, C)
-        assertEquals(items.mostCommonWithin(2, 99).toList(), listOf(B, C))
-    }
-
-    @Test fun `mostCommonWithin includes nulls in the number of items to count`() {
-        val items = sequenceOf(A, null, null, B, /* stops here */ B, C, D)
-        assertEquals(items.mostCommonWithin(2, 4).toList(), listOf(A, B))
-    }
-
-    @Test fun `mostCommonWithin keeps counting until enough non-null items have been found`() {
-        val items = sequenceOf(A, null, null, B, B, C, /* stops here */ D)
-        assertEquals(items.mostCommonWithin(3, 4).toList(), listOf(A, B, C))
+    @Test fun `mostCommonWithin counts the right number of items`() {
+        assertEquals(
+            "Always counts the minimum",
+            listOf(A, C),
+            sequenceOf(A, B, C, C).mostCommonWithin(2, 4).toList(),
+        )
+        assertEquals(
+            "Counts more to find the target",
+            listOf(A, B, C),
+            sequenceOf(A, B, C, C).mostCommonWithin(3, 1).toList(),
+        )
+        assertEquals(
+            "Counts nulls towards the minimum",
+            listOf(A, B),
+            sequenceOf(A, null, B, null, C, C).mostCommonWithin(2, 3).toList(),
+        )
+        assertEquals(
+            "Doesn't count null toward the target",
+            listOf(A, B, C),
+            sequenceOf(A, null, B, null, C, C).mostCommonWithin(3, 2).toList(),
+        )
     }
 
     @Test fun `padWith doesn't include duplicates`() {
-        val items = sequenceOf(A, B).padWith(listOf(B, C, D, A))
-        assertEquals(items.toList(), listOf(A, B, C, D))
+        assertEquals(
+            listOf(A, B, C),
+            sequenceOf(A).padWith(listOf(B, A, C)).toList(),
+        )
     }
 }
 
-private enum class Letter { A, B, C, D }
+private enum class Letter { A, B, C }


### PR DESCRIPTION
The new "weighted" strategy is good for deciding *which* entries to show, but it does not provide a stable order; sometimes entries jump around, which is confusing/disorienting. This returns the sort order to chronological, while keeping the same strategy for choosing which entries to show. You'll lose the ability to predict *which* entry will disappear from the list (although it's usually nearer to the end), in exchange for the ability able to predict what order they'll be in, which means you can easily tell which one disappeared after it happens.

From https://github.com/streetcomplete/StreetComplete/discussions/3493