### PR TITLE
make rejecting cancellation more clear

### DIFF
--- a/app/src/main/res/layout/quest_buttonpanel_done_cancel.xml
+++ b/app/src/main/res/layout/quest_buttonpanel_done_cancel.xml
@@ -10,7 +10,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="@style/BottomSheetButtonBarItem"
-        android:text="@string/confirmation_discard_negative" />
+        android:text="@string/confirmation_discard_negative2" />
 
     <Button
         android:id="@+id/doneButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="quest_noteDiscussion_anonymous">"Anonymous"</string>
     <string name="confirmation_discard_title">"Discard input?"</string>
     <string name="confirmation_discard_positive">"Discard"</string>
-    <string name="confirmation_discard_negative">"Cancel"</string>
+    <string name="confirmation_discard_negative2">"No"</string>
     <string name="action_download">"Scan for quests here"</string>
     <string name="action_upload">"Upload answers"</string>
     <string name="no_changes">"You did not give any answer"</string>


### PR DESCRIPTION
There is a "Discard input?" menu appearing after user fills answer, at least partially and tries to leave answer window.

It has options "cancel" and "discard" with "cancel" being not entirely clear - as user is cancelling filling of the quest. And "cancel cancelling" is tricky.

Situation is even worse in some translations where even the best found text is more confusing than English version.

see https://github.com/streetcomplete/StreetComplete/discussions/3396 where it was discussed

![screen02](https://user-images.githubusercontent.com/899988/145291631-1f4486ee-8f00-4e76-999d-7248bb0f07af.png)

Known negative effects: translation required again

I am aware of `<string name="quest_generic_hasFeature_no">"No"</string>` but in some languages this fields may require different translations.