### PR TITLE
property defining changeset comments is now named changesetComment 

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
@@ -13,7 +13,7 @@ open class TestQuestType : OsmElementQuestType<String> {
     override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {}
     override val icon = 0
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
-    override val commitMessage = ""
+    override val changesetComment = ""
     override fun getApplicableElements(mapData: MapDataWithGeometry) = emptyList<Element>()
     override val wikiLink: String? = null
     override val questTypeAchievements = emptyList<QuestTypeAchievement>()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
@@ -13,7 +13,7 @@ data class ElementEdit(
     var id: Long,
 
     /** quest type associated with the edit. This is used to sort this edit into a changeset
-     *  associated with the quest type. A changeset gets its commit message from the quest type */
+     *  associated with the quest type. A changeset gets its comment from the quest type */
     val questType: OsmElementQuestType<*>,
 
     /** element type this edit refers to */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManager.kt
@@ -53,7 +53,7 @@ class OpenQuestChangesetsManager @Inject constructor(
 
     private fun createChangesetTags(questType: OsmElementQuestType<*>, source: String) =
         mapOf(
-            "comment" to questType.commitMessage,
+            "comment" to questType.changesetComment,
             "created_by" to USER_AGENT,
             "locale" to Locale.getDefault().toLanguageTag(),
             QUESTTYPE_TAG_KEY to questType.name,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 /** Quest type where each quest refers to an OSM element */
 interface OsmElementQuestType<T> : QuestType<T> {
 
-    /** the commit message to be used for this quest type */
+    /** the changeset comment to be used for this quest type */
     val changesetComment: String
 
     /** the OpenStreetMap wiki page with the documentation */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 interface OsmElementQuestType<T> : QuestType<T> {
 
     /** the commit message to be used for this quest type */
-    val commitMessage: String
+    val changesetComment: String
 
     /** the OpenStreetMap wiki page with the documentation */
     val wikiLink: String?

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -49,7 +49,7 @@ class AddAcceptsCash(
         and (name or brand) and !payment:cash and !payment:coins and !payment:notes
     """}
 
-    override val commitMessage = "Add whether this place accepts cash as payment"
+    override val changesetComment = "Add whether this place accepts cash as payment"
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val wikiLink = "Key:payment"
     override val icon = R.drawable.ic_quest_cash

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -26,7 +26,7 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
           addr:street and addr:interpolation
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add street/place names to address"
+    override val changesetComment = "Add street/place names to address"
     override val icon = R.drawable.ic_quest_housenumber_street
     override val wikiLink = "Key:addr"
     // In Japan, housenumbers usually have block numbers, not streets

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -15,7 +15,7 @@ import de.westnordost.streetcomplete.util.isInMultipolygon
 
 class AddHousenumber :  OsmElementQuestType<HousenumberAnswer> {
 
-    override val commitMessage = "Add housenumbers"
+    override val changesetComment = "Add housenumbers"
     override val wikiLink = "Key:addr"
     override val icon = R.drawable.ic_quest_housenumber
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddAtmOperator : OsmFilterQuestType<String>() {
 
     override val elementFilter = "nodes with amenity = atm and !operator and !name and !brand"
-    override val commitMessage = "Add ATM operator"
+    override val changesetComment = "Add ATM operator"
     override val wikiLink = "Tag:amenity=atm"
     override val icon = R.drawable.ic_quest_money
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -21,7 +21,7 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
         )
         and !diaper and !changing_table
     """
-    override val commitMessage = "Add baby changing table"
+    override val changesetComment = "Add baby changing table"
     override val wikiLink = "Key:changing_table"
     override val icon = R.drawable.ic_quest_baby
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
 
     override val elementFilter = "nodes with barrier = cycle_barrier and !cycle_barrier"
-    override val commitMessage = "Add specific cycle barrier type"
+    override val changesetComment = "Add specific cycle barrier type"
     override val wikiLink = "Key:cycle_barrier"
     override val icon = R.drawable.ic_quest_no_bicycles
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -23,7 +23,7 @@ class AddBarrierType : OsmFilterQuestType<BarrierType>() {
          and !amenity
          and !leisure
     """
-    override val commitMessage = "Add specific barrier type on a point"
+    override val changesetComment = "Add specific barrier type on a point"
     override val wikiLink = "Key:barrier"
     override val icon = R.drawable.ic_quest_barrier
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -38,7 +38,7 @@ class AddStileType : OsmElementQuestType<StileTypeAnswer> {
     override fun isApplicableTo(element: Element): Boolean? =
         if (!stileNodeFilter.matches(element)) false else null
 
-    override val commitMessage = "Add specific stile type"
+    override val changesetComment = "Add specific stile type"
     override val wikiLink = "Key:stile"
     override val icon = R.drawable.ic_quest_cow
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -19,7 +19,7 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
           and !backrest
           and !bench:type
     """
-    override val commitMessage = "Add backrest information to benches"
+    override val changesetComment = "Add backrest information to benches"
     override val wikiLink = "Tag:amenity=bench"
     override val icon = R.drawable.ic_quest_bench_poi
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -25,7 +25,7 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
        removing a few of them is minor work
      */
 
-    override val commitMessage = "Add bicycle parking capacities"
+    override val changesetComment = "Add bicycle parking capacities"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_capacity
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -19,7 +19,7 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
          and !covered
          and bicycle_parking !~ shed|lockers|building
     """
-    override val commitMessage = "Add bicycle parkings cover"
+    override val changesetComment = "Add bicycle parkings cover"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_cover
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
@@ -16,7 +16,7 @@ class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
           and access !~ private|no
           and !bicycle_parking
     """
-    override val commitMessage = "Add bicycle parking type"
+    override val changesetComment = "Add bicycle parking type"
     override val wikiLink = "Key:bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -19,7 +19,7 @@ class AddBoardType : OsmFilterQuestType<BoardType>() {
          and access !~ private|no
          and (!board_type or board_type ~ yes|board)
     """
-    override val commitMessage = "Add board type"
+    override val changesetComment = "Add board type"
     override val wikiLink = "Key:board_type"
     override val icon = R.drawable.ic_quest_board_type
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -24,7 +24,7 @@ class AddBollardType : OsmElementQuestType<BollardType> {
           and area != yes
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add bollard type"
+    override val changesetComment = "Add bollard type"
     override val wikiLink = "Key:bollard"
     override val icon = R.drawable.ic_quest_no_cars
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
 
     override val elementFilter = "ways with man_made = bridge and !bridge:structure and !bridge:movable"
-    override val commitMessage = "Add bridge structures"
+    override val changesetComment = "Add bridge structures"
     override val wikiLink = "Key:bridge:structure"
     override val icon = R.drawable.ic_quest_bridge
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -15,7 +15,7 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
          and location != underground
          and ruins != yes
     """
-    override val commitMessage = "Add building and roof levels"
+    override val changesetComment = "Add building and roof levels"
     override val wikiLink = "Key:building:levels"
     override val icon = R.drawable.ic_quest_building_levels
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -29,7 +29,7 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
          and abandoned:building != yes
          and ruins != yes and ruined != yes
     """
-    override val commitMessage = "Add building types"
+    override val changesetComment = "Add building types"
     override val wikiLink = "Key:building"
     override val icon = R.drawable.ic_quest_building
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = "ways, relations with building and layer ~ -[0-9]+ and !location"
-    override val commitMessage = "Determine whether building is fully underground"
+    override val changesetComment = "Determine whether building is fully underground"
     override val wikiLink = "Key:location"
     override val icon = R.drawable.ic_quest_building_underground
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -23,7 +23,7 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
         and (!bench or bench older today -4 years)
     """
 
-    override val commitMessage = "Add whether a bus stop has a bench"
+    override val changesetComment = "Add whether a bus stop has a bench"
     override val wikiLink = "Key:bench"
     override val icon = R.drawable.ic_quest_bench_public_transport
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -23,7 +23,7 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
         and (!bin or bin older today -4 years)
     """
 
-    override val commitMessage = "Add whether a bus stop has a bin"
+    override val changesetComment = "Add whether a bus stop has a bin"
     override val wikiLink = "Key:bin"
     override val icon = R.drawable.ic_quest_bin_public_transport
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -27,7 +27,7 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
         )
     """
 
-    override val commitMessage = "Add whether a bus stop is lit"
+    override val changesetComment = "Add whether a bus stop is lit"
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_bus_stop_lit
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -19,7 +19,7 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
     """
 
     override val enabledInCountries = AllCountriesExcept("US", "CA")
-    override val commitMessage = "Determine bus/tram stop names"
+    override val changesetComment = "Determine bus/tram stop names"
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -19,7 +19,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
     """
 
     override val enabledInCountries = NoCountriesExcept("US", "CA", "JE")
-    override val commitMessage = "Determine bus/tram stop ref"
+    override val changesetComment = "Determine bus/tram stop ref"
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -25,7 +25,7 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
     /* Not asking again if it is covered because it means the stop itself is under a large
        building or roof building so this won't usually change */
 
-    override val commitMessage = "Add bus stop shelter"
+    override val changesetComment = "Add bus stop shelter"
     override val wikiLink = "Key:shelter"
     override val icon = R.drawable.ic_quest_bus_stop_shelter
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -17,7 +17,7 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
          and surveillance ~ public|outdoor|traffic
          and !camera:type
     """
-    override val commitMessage = "Add camera type"
+    override val changesetComment = "Add camera type"
     override val wikiLink = "Tag:surveillance:type"
     override val icon = R.drawable.ic_quest_surveillance_camera
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.*
 class AddCarWashType : OsmFilterQuestType<List<CarWashType>>() {
 
     override val elementFilter = "nodes, ways with amenity = car_wash and !automated and !self_service"
-    override val commitMessage = "Add car wash type"
+    override val changesetComment = "Add car wash type"
     override val wikiLink = "Tag:amenity=car_wash"
     override val icon = R.drawable.ic_quest_car_wash
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -20,7 +20,7 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>() {
           and !capacity
           and bicycle != yes and scooter != yes and motorcar != no
     """
-    override val commitMessage = "Add charging station capacities"
+    override val changesetComment = "Add charging station capacities"
     override val wikiLink = "Tag:amenity=charging_station"
     override val icon = R.drawable.ic_quest_car_charger_capacity
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
@@ -15,7 +15,7 @@ class AddChargingStationOperator : OsmFilterQuestType<String>() {
           amenity = charging_station
           and !operator and !name and !brand
     """
-    override val commitMessage = "Add charging station operator"
+    override val changesetComment = "Add charging station operator"
     override val wikiLink = "Tag:amenity=charging_station"
     override val icon = R.drawable.ic_quest_car_charger
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -20,7 +20,7 @@ class AddClothingBinOperator : OsmElementQuestType<String> {
          and !operator and !name and !brand
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add clothing bin operator"
+    override val changesetComment = "Add clothing bin operator"
     override val wikiLink = "Tag:amenity=recycling"
     override val icon = R.drawable.ic_quest_recycling_clothes
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
@@ -14,7 +14,7 @@ class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructi
          and (!opening_date or opening_date < today)
          and older today -6 months
     """
-    override val commitMessage = "Determine whether construction is now completed"
+    override val changesetComment = "Determine whether construction is now completed"
     override val wikiLink = "Tag:building=construction"
     override val icon = R.drawable.ic_quest_building_construction
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
@@ -15,7 +15,7 @@ class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructio
          and (!opening_date or opening_date < today)
          and older today -2 weeks
     """
-    override val commitMessage = "Determine whether construction is now completed"
+    override val changesetComment = "Determine whether construction is now completed"
     override val wikiLink = "Tag:highway=construction"
     override val icon = R.drawable.ic_quest_road_construction
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -33,7 +33,7 @@ class AddCrossing : OsmElementQuestType<KerbHeight> {
     *  tagging crossing=no on the vertex.
     *  See https://github.com/streetcomplete/StreetComplete/pull/2999#discussion_r681516203 */
 
-    override val commitMessage = "Add whether there is a crossing"
+    override val changesetComment = "Add whether there is a crossing"
     override val wikiLink = "Tag:highway=crossing"
     override val icon = R.drawable.ic_quest_pedestrian
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -30,7 +30,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
           or highway and oneway and oneway != no
     """.toElementFilterExpression()}
 
-    override val commitMessage = "Add whether pedestrian crossing has an island"
+    override val changesetComment = "Add whether pedestrian crossing has an island"
     override val wikiLink = "Key:crossing:island"
     override val icon = R.drawable.ic_quest_pedestrian_crossing_island
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -37,7 +37,7 @@ class AddCrossingType : OsmElementQuestType<CrossingType> {
           or highway and access ~ private|no
     """.toElementFilterExpression()}
 
-    override val commitMessage = "Add crossing type"
+    override val changesetComment = "Add crossing type"
     override val wikiLink = "Key:crossing"
     override val icon = R.drawable.ic_quest_pedestrian_crossing
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -25,7 +25,7 @@ import de.westnordost.streetcomplete.util.isNearAndAligned
 
 class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<CyclewayAnswer> {
 
-    override val commitMessage = "Add whether there are cycleways"
+    override val changesetComment = "Add whether there are cycleways"
     override val wikiLink = "Key:cycleway"
     override val icon = R.drawable.ic_quest_bicycleway
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -18,7 +18,7 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
          and access !~ private|no
          and !indoor
     """
-    override val commitMessage = "Add whether defibrillator is inside building"
+    override val changesetComment = "Add whether defibrillator is inside building"
     override val wikiLink = "Key:indoor"
     override val icon = R.drawable.ic_quest_defibrillator
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
@@ -23,7 +23,7 @@ class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
           or diet:halal != only and diet:halal older today -4 years
         )
     """
-    override val commitMessage = "Add Halal status"
+    override val changesetComment = "Add Halal status"
     override val wikiLink = "Key:diet:halal"
     override val icon = R.drawable.ic_quest_halal
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -24,7 +24,7 @@ class AddKosher : OsmFilterQuestType<DietAvailabilityAnswer>() {
           or diet:kosher != only and diet:kosher older today -4 years
         )
     """
-    override val commitMessage = "Add kosher status"
+    override val changesetComment = "Add kosher status"
     override val wikiLink = "Key:diet:kosher"
     override val icon = R.drawable.ic_quest_kosher
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -28,7 +28,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
           or diet:vegan != only and diet:vegan older today -2 years
         )
     """
-    override val commitMessage = "Add vegan diet type"
+    override val changesetComment = "Add vegan diet type"
     override val wikiLink = "Key:diet"
     override val icon = R.drawable.ic_quest_restaurant_vegan
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -25,7 +25,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
         )
     """
 
-    override val commitMessage = "Add vegetarian diet type"
+    override val changesetComment = "Add vegetarian diet type"
     override val wikiLink = "Key:diet"
     override val icon = R.drawable.ic_quest_restaurant_vegetarian
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -20,7 +20,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
         and !drinking_water and !drinking_water:legal and amenity != drinking_water
     """
 
-    override val commitMessage = "Add whether water is drinkable"
+    override val changesetComment = "Add whether water is drinkable"
     override val wikiLink = "Key:drinking_water"
     override val icon = R.drawable.ic_quest_drinking_water
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -78,7 +78,7 @@ class CheckExistence(
     /* not including bicycle parkings, motorcycle parkings because their capacity is asked every
     *  few years already, so if it's gone now, it will be noticed that way. */
 
-    override val commitMessage = "Check if element still exists"
+    override val changesetComment = "Check if element still exists"
     override val wikiLink: String? = null
     override val icon = R.drawable.ic_quest_check
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddFerryAccessMotorVehicle : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = "ways, relations with route = ferry and !motor_vehicle"
-    override val commitMessage = "Specify ferry access for motor vehicles"
+    override val changesetComment = "Specify ferry access for motor vehicles"
     override val wikiLink = "Tag:route=ferry"
     override val icon = R.drawable.ic_quest_ferry
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddFerryAccessPedestrian : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = "ways, relations with route = ferry and !foot"
-    override val commitMessage = "Specify ferry access for pedestrians"
+    override val changesetComment = "Specify ferry access for pedestrians"
     override val wikiLink = "Tag:route=ferry"
     override val icon = R.drawable.ic_quest_ferry_pedestrian
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
 
     override val elementFilter = "nodes with emergency = fire_hydrant and !fire_hydrant:type"
-    override val commitMessage = "Add fire hydrant type"
+    override val changesetComment = "Add fire hydrant type"
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = R.drawable.ic_quest_fire_hydrant
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -22,7 +22,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
          and !fire_hydrant:diameter
          and fire_hydrant:diameter:signed != no
     """
-    override val commitMessage = "Add fire hydrant diameter"
+    override val changesetComment = "Add fire hydrant diameter"
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = R.drawable.ic_quest_fire_hydrant_diameter
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -13,7 +13,7 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
          (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme") and
          (fire_hydrant:type = pillar or fire_hydrant:type = underground)
     """
-    override val commitMessage = "Add fire hydrant position"
+    override val changesetComment = "Add fire hydrant position"
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = R.drawable.ic_quest_fire_hydrant_grass
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -36,7 +36,7 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
         // fuzzy filter for above mentioned situations + developed-enough / non-rural roads
         "and ( oneway ~ yes|-1 or bridge = yes or tunnel = yes or bicycle ~ no|use_sidepath )"
 
-    override val commitMessage = "Add whether roads are prohibited for pedestrians"
+    override val changesetComment = "Add whether roads are prohibited for pedestrians"
     override val wikiLink = "Key:foot"
     override val icon = R.drawable.ic_quest_no_pedestrians
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -16,7 +16,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
          and !fee
          and name
     """
-    override val commitMessage = "Add fee info"
+    override val changesetComment = "Add fee info"
     override val wikiLink = "Key:fee"
     override val icon = R.drawable.ic_quest_fee
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -24,7 +24,7 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
          )
     """
 
-    override val commitMessage = "Add whether steps have a handrail"
+    override val changesetComment = "Add whether steps have a handrail"
     override val wikiLink = "Key:handrail"
     override val icon = R.drawable.ic_quest_steps_handrail
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -25,7 +25,7 @@ class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
     /* Asked less often than for example opening hours because this quest is only asked for
        tendentially larger places which are less likely to change often */
 
-    override val commitMessage = "Add internet access"
+    override val changesetComment = "Add internet access"
     override val wikiLink = "Key:internet_access"
     override val icon = R.drawable.ic_quest_wifi
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
@@ -23,7 +23,7 @@ class AddKerbHeight : OsmElementQuestType<KerbHeight> {
           or kerb !~ no|rolled and kerb older today -8 years
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add kerb height info"
+    override val changesetComment = "Add kerb height info"
     override val wikiLink = "Key:kerb"
     override val icon = R.drawable.ic_quest_kerb_type
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -23,7 +23,7 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
           and (!lanes:backward or !lanes:forward)
           and lane_markings != no
     """
-    override val commitMessage = "Add road lanes"
+    override val changesetComment = "Add road lanes"
     override val wikiLink = "Key:lanes"
     override val icon = R.drawable.ic_quest_street_lanes
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -19,7 +19,7 @@ class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
         ways with natural = tree_row and !leaf_type
     """.toElementFilterExpression()}
 
-    override val commitMessage = "Add leaf type"
+    override val changesetComment = "Add leaf type"
     override val wikiLink = "Key:leaf_type"
     override val icon = R.drawable.ic_quest_leaf
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/level/AddLevel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/level/AddLevel.kt
@@ -37,7 +37,7 @@ class AddLevel : OsmElementQuestType<String> {
          and !level and (name or brand)
     """.toElementFilterExpression()}
 
-    override val commitMessage = "Add level to shops"
+    override val changesetComment = "Add level to shops"
     override val wikiLink = "Key:level"
     override val icon = R.drawable.ic_quest_level
     /* disabled because in a mall with multiple levels, if there are nodes with no level defined,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -52,7 +52,7 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
           and layer
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add maximum heights"
+    override val changesetComment = "Add maximum heights"
     override val wikiLink = "Key:maxheight"
     override val icon = R.drawable.ic_quest_max_height
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -22,7 +22,7 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
          and area != yes
          and (access !~ private|no or (foot and foot !~ private|no))
     """
-    override val commitMessage = "Add speed limits"
+    override val changesetComment = "Add speed limits"
     override val wikiLink = "Key:maxspeed"
     override val icon = R.drawable.ic_quest_max_speed
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.*
 
 class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
 
-    override val commitMessage = "Add maximum allowed weight"
+    override val changesetComment = "Add maximum allowed weight"
     override val wikiLink = "Key:maxweight"
     override val icon = R.drawable.ic_quest_max_weight
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -16,7 +16,7 @@ class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
          and access !~ private|no
          and (!capacity or capacity older today -4 years)
     """
-    override val commitMessage = "Add motorcycle parking capacities"
+    override val changesetComment = "Add motorcycle parking capacities"
     override val wikiLink = "Tag:amenity=motorcycle_parking"
     override val icon = R.drawable.ic_quest_motorcycle_parking_capacity
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -18,7 +18,7 @@ class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
         and !covered
         and motorcycle_parking !~ shed|garage_boxes|building
     """
-    override val commitMessage = "Add motorcycle parkings cover"
+    override val changesetComment = "Add motorcycle parkings cover"
     override val wikiLink = "Tag:amenity=motorcycle_parking"
     override val icon = R.drawable.ic_quest_motorcycle_parking_cover
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -27,7 +27,7 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
          and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add whether this road is a one-way road because it is quite slim"
+    override val changesetComment = "Add whether this road is a one-way road because it is quite slim"
     override val wikiLink = "Key:oneway"
     override val icon = R.drawable.ic_quest_oneway
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -33,7 +33,7 @@ class AddSuspectedOneway(
           )
     """.toElementFilterExpression() }
 
-    override val commitMessage =
+    override val changesetComment =
         "Add whether roads are one-way roads as they were marked as likely oneway by improveosm.org"
     override val wikiLink = "Key:oneway"
     override val icon = R.drawable.ic_quest_oneway

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -96,7 +96,7 @@ class AddOpeningHours (
 
     private val nameTags = listOf("name", "brand")
 
-    override val commitMessage = "Add opening hours"
+    override val changesetComment = "Add opening hours"
     override val wikiLink = "Key:opening_hours"
     override val icon = R.drawable.ic_quest_opening_hours
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -12,7 +12,7 @@ class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
         and !trees and !produce and !crop
         and orchard != meadow_orchard
     """
-    override val commitMessage = "Add orchard produces"
+    override val changesetComment = "Add orchard produces"
     override val wikiLink = "Tag:landuse=orchard"
     override val icon = R.drawable.ic_quest_apple
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -15,7 +15,7 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
         and (!access or access = unknown)
     """
 
-    override val commitMessage = "Add type of bike parking access"
+    override val changesetComment = "Add type of bike parking access"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_access
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -23,7 +23,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
         )
     """
 
-    override val commitMessage = "Add type of parking access"
+    override val changesetComment = "Add type of parking access"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_access
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -21,7 +21,7 @@ class AddBikeParkingFee : OsmFilterQuestType<Fee>() {
             or fee older today -8 years
         )
     """
-    override val commitMessage = "Add whether there is a bike parking fee"
+    override val changesetComment = "Add whether there is a bike parking fee"
     override val wikiLink = "Tag:amenity=bicycle_parking"
     override val icon = R.drawable.ic_quest_bicycle_parking_fee
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -15,7 +15,7 @@ class AddParkingFee : OsmFilterQuestType<Fee>() {
             or fee older today -8 years
         )
     """
-    override val commitMessage = "Add whether there is a parking fee"
+    override val changesetComment = "Add whether there is a parking fee"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking_fee
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
@@ -12,7 +12,7 @@ class AddParkingType : OsmFilterQuestType<ParkingType>() {
           amenity = parking
           and (!parking or parking = yes)
     """
-    override val commitMessage = "Add parking type"
+    override val changesetComment = "Add parking type"
     override val wikiLink = "Tag:amenity=parking"
     override val icon = R.drawable.ic_quest_parking
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/picnic_table_cover/AddPicnicTableCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/picnic_table_cover/AddPicnicTableCover.kt
@@ -18,7 +18,7 @@ class AddPicnicTableCover : OsmFilterQuestType<Boolean>() {
          and !covered
     """
 
-    override val commitMessage = "Add picnic table cover"
+    override val changesetComment = "Add picnic table cover"
     override val wikiLink = "Key:covered"
     override val icon = R.drawable.ic_quest_picnic_table_cover
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -21,7 +21,7 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
         )
     """
 
-    override val commitMessage = "Add whether pitch is lit"
+    override val changesetComment = "Add whether pitch is lit"
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_pitch_lantern
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -97,7 +97,7 @@ class AddPlaceName(
         and !name and !brand and noname != yes and name:signed != no
     """.trimIndent()).toElementFilterExpression() }
 
-    override val commitMessage = "Determine place names"
+    override val changesetComment = "Determine place names"
     override val wikiLink = "Key:name"
     override val icon = R.drawable.ic_quest_label
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddPlaygroundAccess : OsmFilterQuestType<PlaygroundAccess>() {
 
     override val elementFilter = "nodes, ways, relations with leisure = playground and (!access or access = unknown)"
-    override val commitMessage = "Add playground access"
+    override val changesetComment = "Add playground access"
     override val wikiLink = "Tag:leisure=playground"
     override val icon = R.drawable.ic_quest_playground
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
@@ -13,7 +13,7 @@ class AddPoliceType : OsmFilterQuestType<PoliceType>() {
           amenity = police
           and !operator
     """
-    override val commitMessage = "Add police type"
+    override val changesetComment = "Add police type"
     override val wikiLink = "Tag:amenity=police"
     override val icon = R.drawable.ic_quest_police
     override val enabledInCountries = NoCountriesExcept("IT")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -28,7 +28,7 @@ class AddPostboxCollectionTimes : OsmElementQuestType<CollectionTimesAnswer> {
     /* Don't ask again for postboxes without signed collection times. This is very unlikely to
     *  change and problematic to tag clearly with the check date scheme */
 
-    override val commitMessage = "Add postbox collection times"
+    override val changesetComment = "Add postbox collection times"
     override val wikiLink = "Key:collection_times"
     override val icon = R.drawable.ic_quest_mail
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -14,7 +14,7 @@ import de.westnordost.streetcomplete.ktx.containsAnyKey
 class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
 
     override val elementFilter = "nodes with amenity = post_box and !ref and !ref:signed"
-    override val commitMessage = "Add postbox refs"
+    override val changesetComment = "Add postbox refs"
     override val wikiLink = "Tag:amenity=post_box"
     override val icon = R.drawable.ic_quest_mail_ref
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
 
     override val elementFilter = "nodes with amenity = post_box and !royal_cypher"
-    override val commitMessage = "Add postbox royal cypher"
+    override val changesetComment = "Add postbox royal cypher"
     override val wikiLink = "Key:royal_cypher"
     override val icon = R.drawable.ic_quest_crown
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
@@ -15,7 +15,7 @@ class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
           (power = pole or man_made = utility_pole)
           and !material
     """
-    override val commitMessage = "Add power poles material type"
+    override val changesetComment = "Add power poles material type"
     override val wikiLink = "Tag:power=pole"
     override val icon = R.drawable.ic_quest_power
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
@@ -26,7 +26,7 @@ class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
           or railway ~ tram|abandoned|disused
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add type of barrier for railway crossing"
+    override val changesetComment = "Add type of barrier for railway crossing"
     override val wikiLink = "Key:crossing:barrier"
     override val icon = R.drawable.ic_quest_railway
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.quests.recycling.RecyclingType.*
 class AddRecyclingType : OsmFilterQuestType<RecyclingType>() {
 
     override val elementFilter = "nodes, ways, relations with amenity = recycling and !recycling_type"
-    override val commitMessage = "Add recycling type to recycling amenity"
+    override val changesetComment = "Add recycling type to recycling amenity"
     override val wikiLink = "Key:recycling_type"
     override val icon = R.drawable.ic_quest_recycling
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -16,7 +16,7 @@ class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
         nodes with amenity = recycling and recycling_type = container
          and recycling:glass = yes and !recycling:glass_bottles
     """
-    override val commitMessage = "Determine whether any glass or just glass bottles can be recycled here"
+    override val changesetComment = "Determine whether any glass or just glass bottles can be recycled here"
     override val wikiLink = "Key:recycling"
     override val icon = R.drawable.ic_quest_recycling_glass
     // see isUsuallyAnyGlassRecycleableInContainers.yml

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -24,7 +24,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
           and access !~ private|no
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add recycled materials to container"
+    override val changesetComment = "Add recycled materials to container"
     override val wikiLink = "Key:recycling"
     override val icon = R.drawable.ic_quest_recycling_container
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
@@ -16,7 +16,7 @@ class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
         )
         and !religion
     """
-    override val commitMessage = "Add religion for place of worship"
+    override val changesetComment = "Add religion for place of worship"
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
@@ -13,7 +13,7 @@ class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
           and !religion
           and access !~ private|no
     """
-    override val commitMessage = "Add religion for wayside shrine"
+    override val changesetComment = "Add religion for wayside shrine"
     override val wikiLink = "Key:religion"
     override val icon = R.drawable.ic_quest_religion
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -26,7 +26,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>() {
     """
 
     override val enabledInCountries = AllCountriesExcept("JP")
-    override val commitMessage = "Determine road names and types"
+    override val changesetComment = "Determine road names and types"
     override val wikiLink = "Key:name"
     override val icon = R.drawable.ic_quest_street_name
     override val hasMarkersAtEnds = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -18,7 +18,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
           and building !~ no|construction
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add roof shapes"
+    override val changesetComment = "Add roof shapes"
     override val wikiLink = "Key:roof:shape"
     override val icon = R.drawable.ic_quest_roof_shape
     override val defaultDisabledMessage = R.string.default_disabled_msg_roofShape

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -24,7 +24,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
         and (!segregated or segregated older today -8 years)
     """
 
-    override val commitMessage = "Add segregated status for combined footway with cycleway"
+    override val changesetComment = "Add segregated status for combined footway with cycleway"
     override val wikiLink = "Key:segregated"
     override val icon = R.drawable.ic_quest_path_segregation
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.quests.self_service.SelfServiceLaundry.*
 class AddSelfServiceLaundry : OsmFilterQuestType<SelfServiceLaundry>() {
 
     override val elementFilter = "nodes, ways with shop = laundry and !self_service"
-    override val commitMessage = "Add self service info"
+    override val changesetComment = "Add self service info"
     override val wikiLink = "Tag:shop=laundry"
     override val icon = R.drawable.ic_quest_laundry
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -29,7 +29,7 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
         nodes, ways, relations with ${isKindOfShopExpression()}
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Check if vacant shop is still vacant"
+    override val changesetComment = "Check if vacant shop is still vacant"
     override val wikiLink = "Key:disused:"
     override val icon = R.drawable.ic_quest_check_shop
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -28,7 +28,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
          and !leisure
         )
     """
-    override val commitMessage = "Specify shop type"
+    override val changesetComment = "Specify shop type"
     override val wikiLink = "Key:shop"
     override val icon = R.drawable.ic_quest_check_shop
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shoulder/AddShoulder.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shoulder/AddShoulder.kt
@@ -57,7 +57,7 @@ class AddShoulder : OsmFilterQuestType<Boolean>() {
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
         mapData.filter(elementFilter).asIterable()
 
-    override val commitMessage = "Add whether there are shoulders"
+    override val changesetComment = "Add whether there are shoulders"
     override val wikiLink = "Key:shoulder"
     override val icon = R.drawable.ic_quest_street_shoulder
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -62,7 +62,7 @@ class AddSidewalk : OsmElementQuestType<SidewalkAnswer> {
     """.toElementFilterExpression() }
     // highway=construction included, as situation often changes during and after construction
 
-    override val commitMessage = "Add whether there are sidewalks"
+    override val changesetComment = "Add whether there are sidewalks"
     override val wikiLink = "Key:sidewalk"
     override val icon = R.drawable.ic_quest_sidewalk
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
@@ -27,7 +27,7 @@ class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
           )
     """
 
-    override val commitMessage = "Add path smoothness"
+    override val changesetComment = "Add path smoothness"
     override val wikiLink = "Key:smoothness"
     override val icon = R.drawable.ic_quest_way_surface_detail
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -25,7 +25,7 @@ class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
           )
     """
 
-    override val commitMessage = "Add road smoothness"
+    override val changesetComment = "Add road smoothness"
     override val wikiLink = "Key:smoothness"
     override val icon = R.drawable.ic_quest_street_surface_detail
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
@@ -20,7 +20,7 @@ class AddSport : OsmFilterQuestType<List<Sport>>() {
           and (!sport or sport ~ ${ambiguousSportValues.joinToString("|")} )
           and access !~ private|no
     """
-    override val commitMessage = "Add pitches sport"
+    override val changesetComment = "Add pitches sport"
     override val wikiLink = "Key:sport"
     override val icon = R.drawable.ic_quest_sport
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -15,7 +15,7 @@ class AddStepCount : OsmFilterQuestType<Int>() {
          and !step_count
     """
 
-    override val commitMessage = "Add step count"
+    override val changesetComment = "Add step count"
     override val wikiLink = "Key:step_count"
     override val icon = R.drawable.ic_quest_steps_count
     // because the user needs to start counting at the start of the steps

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -16,7 +16,7 @@ class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
          and !incline
     """
 
-    override val commitMessage = "Add which way leads up for these steps"
+    override val changesetComment = "Add which way leads up for these steps"
     override val wikiLink = "Key:incline"
     override val icon = R.drawable.ic_quest_steps
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -25,7 +25,7 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
          )
     """
 
-    override val commitMessage = "Add whether steps have a ramp"
+    override val changesetComment = "Add whether steps have a ramp"
     override val wikiLink = "Key:ramp"
     override val icon = R.drawable.ic_quest_steps_ramp
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
@@ -64,7 +64,7 @@ class AddStreetParking : OsmFilterQuestType<LeftAndRightStreetParking>() {
        roads that are probably outside of settlements (similar idea like for AddWayLit)
       */
 
-    override val commitMessage = "Add how cars park here"
+    override val changesetComment = "Add how cars park here"
     override val wikiLink = "Key:parking:lane"
     override val icon = R.drawable.ic_quest_parking_lane
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -24,7 +24,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
           and (!summit:register or summit:register older today -4 years)
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add whether summit register is present"
+    override val changesetComment = "Add whether summit register is present"
     override val wikiLink = "Key:summit:register"
     override val icon = R.drawable.ic_quest_peak
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -26,7 +26,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
           )
         )
     """
-    override val commitMessage = "Add path surfaces"
+    override val changesetComment = "Add path surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_bicycleway_surface
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -26,7 +26,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
           )
         )
     """
-    override val commitMessage = "Add path surfaces"
+    override val changesetComment = "Add path surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_footway_surface
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -30,7 +30,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
     """
     /* ~paved ways are less likely to change the surface type */
 
-    override val commitMessage = "Add path surfaces"
+    override val changesetComment = "Add path surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_way_surface
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -39,7 +39,7 @@ class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
         )
     """
 
-    override val commitMessage = "Add pitch surfaces"
+    override val changesetComment = "Add pitch surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_pitch_surface
     override val questTypeAchievements = listOf(OUTDOORS)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -25,7 +25,7 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
         )
         and (access !~ private|no or (foot and foot !~ private|no))
     """
-    override val commitMessage = "Add road surface info"
+    override val changesetComment = "Add road surface info"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_street_surface
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -24,7 +24,7 @@ class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
           or tactile_paving = yes and tactile_paving older today -8 years
         )
     """
-    override val commitMessage = "Add tactile pavings on bus stops"
+    override val changesetComment = "Add tactile pavings on bus stops"
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_blind_bus
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -33,7 +33,7 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
           or highway and access ~ private|no
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add tactile pavings on crosswalks"
+    override val changesetComment = "Add tactile pavings on crosswalks"
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_blind_pedestrian_crossing
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
@@ -23,7 +23,7 @@ class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
           or tactile_paving = yes and tactile_paving older today -8 years
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add tactile paving on kerbs"
+    override val changesetComment = "Add tactile paving on kerbs"
     override val wikiLink = "Key:tactile_paving"
     override val icon = R.drawable.ic_quest_kerb_tactile_paving
     override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -19,7 +19,7 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>() {
         )
         and !toilets
     """
-    override val commitMessage = "Add toilet availability"
+    override val changesetComment = "Add toilet availability"
     override val wikiLink = "Key:toilets"
     override val icon = R.drawable.ic_quest_toilets
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -15,7 +15,7 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
           and access !~ private|customers
           and !fee
     """
-    override val commitMessage = "Add toilets fee"
+    override val changesetComment = "Add toilets fee"
     override val wikiLink = "Key:fee"
     override val icon = R.drawable.ic_quest_toilet_fee
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
 
     override val elementFilter = "nodes, ways, relations with tourism = information and !information"
-    override val commitMessage = "Add information type to tourist information"
+    override val changesetComment = "Add information type to tourist information"
     override val wikiLink = "Tag:tourism=information"
     override val icon = R.drawable.ic_quest_information
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -21,7 +21,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
     """
     /* ~paved tracks are less likely to change the surface type */
 
-    override val commitMessage = "Add tracktype"
+    override val changesetComment = "Add tracktype"
     override val wikiLink = "Key:tracktype"
     override val icon = R.drawable.ic_quest_tractor
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingType.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 class AddTrafficCalmingType : OsmFilterQuestType<TrafficCalmingType>() {
 
     override val elementFilter = "nodes with traffic_calming = yes"
-    override val commitMessage = "Add specific traffic calming type on a point"
+    override val changesetComment = "Add specific traffic calming type on a point"
     override val wikiLink = "Key:traffic_calming"
     override val icon = R.drawable.ic_quest_car_bumpy
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
@@ -16,7 +16,7 @@ class AddTrafficSignalsButton : OsmFilterQuestType<Boolean>() {
           and foot != no
           and !button_operated
     """
-    override val commitMessage = "Add whether traffic signals have a button for pedestrians"
+    override val changesetComment = "Add whether traffic signals have a button for pedestrians"
     override val wikiLink = "Tag:highway=traffic_signals"
     override val icon = R.drawable.ic_quest_traffic_lights
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -30,7 +30,7 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
           and foot !~ yes|designated
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add whether traffic signals have sound signals"
+    override val changesetComment = "Add whether traffic signals have sound signals"
     override val wikiLink = "Key:$SOUND_SIGNALS"
     override val icon = R.drawable.ic_quest_blind_traffic_lights_sound
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -30,7 +30,7 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
           and foot !~ yes|designated
     """.toElementFilterExpression() }
 
-    override val commitMessage = "Add whether traffic signals have tactile indication that it's safe to cross"
+    override val changesetComment = "Add whether traffic signals have tactile indication that it's safe to cross"
     override val wikiLink = "Key:$VIBRATING_BUTTON"
     override val icon = R.drawable.ic_quest_blind_traffic_lights
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -41,7 +41,7 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
         and indoor != yes
     """
 
-    override val commitMessage = "Add whether way is lit"
+    override val changesetComment = "Add whether way is lit"
     override val wikiLink = "Key:lit"
     override val icon = R.drawable.ic_quest_lantern
     override val isSplitWayEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -91,7 +91,7 @@ class AddWheelchairAccessBusiness(
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") +
         "  \n)"
 
-    override val commitMessage = "Add wheelchair access"
+    override val changesetComment = "Add wheelchair access"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_wheelchair_shop
     override val isReplaceShopEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -15,7 +15,7 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
          and access !~ no|private
          and (!wheelchair or wheelchair older today -8 years)
     """
-    override val commitMessage = "Add wheelchair access to outside places"
+    override val changesetComment = "Add wheelchair access to outside places"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -18,7 +18,7 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>(
           or wheelchair older today -8 years
          )
     """
-    override val commitMessage = "Add wheelchair access to public transport platforms"
+    override val changesetComment = "Add wheelchair access to public transport platforms"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_wheelchair
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -17,7 +17,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
            or wheelchair older today -8 years
          )
     """
-    override val commitMessage = "Add wheelchair access to toilets"
+    override val changesetComment = "Add wheelchair access to toilets"
     override val wikiLink = "Key:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isDeleteElementEnabled = true

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -20,7 +20,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
            or toilets:wheelchair older today -8 years
          )
     """
-    override val commitMessage = "Add wheelchair access to toilets"
+    override val changesetComment = "Add wheelchair access to toilets"
     override val wikiLink = "Key:toilets:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isReplaceShopEnabled = true

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
@@ -14,7 +14,7 @@ open class TestQuestTypeA : OsmElementQuestType<String> {
     override fun isApplicableTo(element: Element):Boolean? = null
     override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {}
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
-    override val commitMessage = "test me"
+    override val changesetComment = "test me"
     override fun getApplicableElements(mapData: MapDataWithGeometry) = mapData.filter { isApplicableTo(it) == true }
     override val wikiLink: String? = null
     override val icon = 0


### PR DESCRIPTION
See say https://wiki.openstreetmap.org/wiki/Good_changeset_comments

I think that there is no good reason to use `commitMessage` name

Main negative is that merging it will break unmerged quest PRs (and #3648 which triggered it).