### PR TITLE
Resurvey unsigned hydrant diameter

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.fire_hydrant_diameter
 
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
@@ -21,6 +22,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
          (fire_hydrant:type = pillar or fire_hydrant:type = underground)
          and !fire_hydrant:diameter
          and fire_hydrant:diameter:signed != no
+         or (fire_hydrant:diameter:signed = no and fire_hydrant:diameter:signed older today -2 years)
     """
     override val changesetComment = "Add fire hydrant diameter"
     override val wikiLink = "Tag:emergency=fire_hydrant"
@@ -51,8 +53,11 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
 
     override fun applyAnswerTo(answer: FireHydrantDiameterAnswer, changes: StringMapChangesBuilder) {
         when (answer) {
-            is FireHydrantDiameter ->       changes.add("fire_hydrant:diameter", answer.toOsmValue())
-            is NoFireHydrantDiameterSign -> changes.add("fire_hydrant:diameter:signed", "no")
+            is FireHydrantDiameter ->       {
+                changes.add("fire_hydrant:diameter", answer.toOsmValue())
+                changes.deleteIfPreviously("fire_hydrant:diameter:signed", "no")
+            }
+            is NoFireHydrantDiameterSign -> changes.updateWithCheckDate("fire_hydrant:diameter:signed", "no")
         }
     }
 }


### PR DESCRIPTION
In the UK at least (and I think also all other countries where the fire hydrant diameter quest is enabled) fire hydrants are meant to have a sign. However some are missing or broken. Therefore it may be that a hydrant is surveyed as having no sign, but that sign is later fixed/replaced.

Happy to change the amount of time before resurvey.

Tested that it compiles and runs, but I'm not sure how I can test that it does what I expect without affecting live data. Does it look ok, or should I write a test file?

(Also happy to close if not wanted)