### PR TITLE
Simplify shared complex element filters

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -14,15 +14,14 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.osm.opening_hours.parser.isSupportedOpeningHours
 import de.westnordost.streetcomplete.osm.opening_hours.parser.toOpeningHoursRules
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.OPENING_HOURS_QUEST
+import de.westnordost.streetcomplete.quests.place_name.getPlaceElementFilterString
 import java.util.concurrent.FutureTask
 
 class AddOpeningHours (
     private val featureDictionaryFuture: FutureTask<FeatureDictionary>
 ) : OsmElementQuestType<OpeningHoursAnswer> {
-
-    /* See also AddWheelchairAccessBusiness and AddPlaceName, which has a similar list and is/should
-       be ordered in the same way for better overview */
-    private val filter by lazy { ("""
+    private val filter by lazy { """
         nodes, ways, relations with
         (
           (
@@ -33,57 +32,7 @@ class AddOpeningHours (
               or amenity = recycling and recycling_type = centre
               or tourism = information and information = office
               or (amenity = recycling and recycling:batteries = yes)
-              or """.trimIndent() +
-
-        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
-        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
-        // Independent tags can by added in the "opening_hours only" tab.
-
-        mapOf(
-            "amenity" to arrayOf(
-                // common
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino",                                                                     // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
-                "bank", "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",           // commercial
-                "car_wash", "car_rental", "fuel",                                                                      // car stuff
-                "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
-                "animal_boarding", "animal_shelter", "animal_breeding",                                                // animals
-
-                // name & opening hours
-                "boat_rental"
-
-                // not ATM because too often it's simply 24/7 and too often it is confused with
-                // a bank that might be just next door because the app does not tell the user what
-                // kind of object this is about
-            ),
-            "tourism" to arrayOf(
-                // common
-                "zoo", "aquarium", "theme_park", "gallery", "museum"
-                // and tourism = information, see above
-            ),
-            "leisure" to arrayOf(
-                // common
-                "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
-
-                // name & opening hours
-                "horse_riding"
-
-                // not sports_centre, dance etc because these are often sports clubs which have no
-                // walk-in opening hours but training times
-            ),
-            "office" to arrayOf(
-                // common
-                "insurance", "government", "travel_agent", "tax_advisor", "religion",
-                "employment_agency", "diplomatic"
-            ),
-            "craft" to arrayOf(
-                // common
-                "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
-                "electronics_repair", "key_cutter", "stonemason"
-            )
-        ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") + "\n" + """
+              or ${getPlaceElementFilterString(OPENING_HOURS_QUEST)}
             )
             and !opening_hours
           )
@@ -92,7 +41,7 @@ class AddOpeningHours (
         and access !~ private|no
         and (name or brand or noname = yes or name:signed = no or amenity=recycling)
         and opening_hours:signed != no
-    """.trimIndent()).toElementFilterExpression() }
+    """.toElementFilterExpression() }
 
     private val nameTags = listOf("name", "brand")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -14,7 +14,6 @@ import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.osm.opening_hours.parser.isSupportedOpeningHours
 import de.westnordost.streetcomplete.osm.opening_hours.parser.toOpeningHoursRules
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.OPENING_HOURS_QUEST
 import de.westnordost.streetcomplete.quests.place_name.getPlaceElementFilterString
 import java.util.concurrent.FutureTask
 
@@ -32,7 +31,7 @@ class AddOpeningHours (
               or amenity = recycling and recycling_type = centre
               or tourism = information and information = office
               or (amenity = recycling and recycling:batteries = yes)
-              or ${getPlaceElementFilterString(OPENING_HOURS_QUEST)}
+              or ${getPlaceElementFilterString(this)}
             )
             and !opening_hours
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -11,7 +11,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.PLACE_NAME_QUEST
 import java.util.concurrent.FutureTask
 
 class AddPlaceName(
@@ -26,7 +25,7 @@ class AddPlaceName(
           or tourism = information and information = office
           or landuse ~ cemetery|allotments
           or military ~ airfield|barracks|training_area
-          or ${getPlaceElementFilterString(PLACE_NAME_QUEST)}
+          or ${getPlaceElementFilterString(this)}
         )
         and !name and !brand and noname != yes and name:signed != no
     """.toElementFilterExpression() }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -11,91 +11,25 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.PLACE_NAME_QUEST
 import java.util.concurrent.FutureTask
 
 class AddPlaceName(
     private val featureDictionaryFuture: FutureTask<FeatureDictionary>
 ) : OsmElementQuestType<PlaceNameAnswer> {
-
-    private val filter by lazy { ("""
+    private val filter by lazy { """
         nodes, ways, relations with
         (
           shop and shop !~ no|vacant
           or craft
           or office
           or tourism = information and information = office
-          or """.trimIndent() +
-
-        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
-        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
-        // Independent tags can by added in the "name only" tab.
-
-        mapOf(
-            "amenity" to arrayOf(
-                // common
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino",                                                                     // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
-                "bank", "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",           // commercial
-                "car_wash", "car_rental", "fuel",                                                                      // car stuff
-                "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
-                "animal_boarding", "animal_shelter", "animal_breeding",                                                // animals
-
-                // name & opening hours
-                "boat_rental",
-
-                // name & wheelchair
-                "theatre",                             // culture
-                "conference_centre", "arts_centre",    // events
-                "police", "ranger_station",            // civic
-                "ferry_terminal",                      // transport
-                "place_of_worship",                    // religious
-                "hospital",                            // health care
-
-                // name only
-                "studio",                                                                // culture
-                "events_venue", "exhibition_centre", "music_venue",                      // events
-                "prison", "fire_station",                                                // civic
-                "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", // social
-                "monastery",                                                             // religious
-                "kindergarten", "school", "college", "university", "research_institute", // education
-                "driving_school", "dive_centre", "language_school", "music_school",      // learning
-                "brothel", "gambling", "love_hotel", "stripclub"                         // bad stuff
-            ),
-            "tourism" to arrayOf(
-                // common
-                "zoo", "aquarium", "theme_park", "gallery", "museum",
-
-                // name & wheelchair
-                "attraction",
-                "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site", "chalet" // accommodations
-
-                // and tourism = information, see above
-            ),
-            "leisure" to arrayOf(
-                // common
-                "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
-
-                // name & wheelchair
-                "sports_centre", "stadium",
-
-                // name & opening hours
-                "horse_riding",
-
-                // name only
-                "dance", "nature_reserve", "marina",
-            ),
-            "landuse" to arrayOf(
-                "cemetery", "allotments"
-            ),
-            "military" to arrayOf(
-                "airfield", "barracks", "training_area"
-            )
-        ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
+          or landuse ~ cemetery|allotments
+          or military ~ airfield|barracks|training_area
+          or ${getPlaceElementFilterString(PLACE_NAME_QUEST)}
         )
         and !name and !brand and noname != yes and name:signed != no
-    """.trimIndent()).toElementFilterExpression() }
+    """.toElementFilterExpression() }
 
     override val changesetComment = "Determine place names"
     override val wikiLink = "Key:name"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceFilterTags.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceFilterTags.kt
@@ -1,0 +1,150 @@
+package de.westnordost.streetcomplete.quests.place_name
+
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.OPENING_HOURS_QUEST
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.PLACE_NAME_QUEST
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.WHEELCHAIR_ACCESS_QUEST
+
+enum class PlaceFilterQuestType {
+    OPENING_HOURS_QUEST,
+    PLACE_NAME_QUEST,
+    WHEELCHAIR_ACCESS_QUEST,
+}
+
+private typealias ValuesPerQuestTypes = Map<Set<PlaceFilterQuestType>, List<String>>
+
+fun getPlaceElementFilterString(questType: PlaceFilterQuestType): String {
+    val common = setOf(OPENING_HOURS_QUEST, PLACE_NAME_QUEST, WHEELCHAIR_ACCESS_QUEST)
+    val nameAndOpeningHours = setOf(PLACE_NAME_QUEST, OPENING_HOURS_QUEST)
+    val nameAndWheelchair = setOf(PLACE_NAME_QUEST, WHEELCHAIR_ACCESS_QUEST)
+    val name = setOf(PLACE_NAME_QUEST)
+    val wheelchair = setOf(WHEELCHAIR_ACCESS_QUEST)
+
+    val filterTags: Map<String, ValuesPerQuestTypes> = mapOf(
+        "amenity" to mapOf(
+            common to listOf(
+                // eat & drink
+                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten",
+                "food_court", "nightclub",
+                // amenities
+                "cinema", "planetarium", "casino",
+                // civic
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",
+                // commercial
+                "bank", "bureau_de_change", "money_transfer", "post_office", "marketplace",
+                "internet_cafe",
+                // car stuff
+                "car_wash", "car_rental", "fuel",
+                // health
+                "dentist", "doctors", "clinic", "pharmacy", "veterinary",
+                // animals
+                "animal_boarding", "animal_shelter", "animal_breeding",
+            ),
+            nameAndOpeningHours to listOf(
+                "boat_rental",
+            ),
+            nameAndWheelchair to listOf(
+                // culture
+                "theatre",
+                // events
+                "conference_centre", "arts_centre",
+                // civic
+                "police", "ranger_station",
+                // transport
+                "ferry_terminal",
+                // religious
+                "place_of_worship",
+                // health care
+                "hospital",
+            ),
+            name to listOf(
+                // culture
+                "studio",
+                // events
+                "events_venue", "exhibition_centre", "music_venue",
+                // civic
+                "prison", "fire_station",
+                // social
+                "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre",
+                // religious
+                "monastery",
+                // education
+                "kindergarten", "school", "college", "university", "research_institute",
+                // learning
+                "driving_school", "dive_centre", "language_school", "music_school",
+                // bad stuff
+                "brothel", "gambling", "love_hotel", "stripclub",
+            ),
+
+            // openingHours:
+            // not ATM because too often it's simply 24/7 and too often it is confused with
+            // a bank that might be just next door because the app does not tell the user what
+            // kind of object this is about
+        ),
+        "tourism" to mapOf(
+            common to listOf(
+                "zoo", "aquarium", "theme_park", "gallery", "museum",
+                // plus `tourism = information and information = office`
+            ),
+            nameAndWheelchair to listOf(
+                "attraction",
+                // accommodations
+                "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort",
+                "camp_site", "caravan_site", "chalet",
+            ),
+            wheelchair to listOf(
+                "viewpoint",
+            ),
+        ),
+        "leisure" to mapOf(
+            common to listOf(
+                "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
+                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
+            ),
+            nameAndWheelchair to listOf(
+                "sports_centre", "stadium",
+            ),
+            nameAndOpeningHours to listOf(
+                "horse_riding",
+            ),
+            name to listOf(
+                "dance", "nature_reserve", "marina",
+            ),
+
+            // openingHours:
+            // not sports_centre, dance etc because these are often sports clubs which have no
+            // walk-in opening hours but training times
+        ),
+        "office" to mapOf(
+            common to listOf(
+                "insurance", "government", "travel_agent", "tax_advisor", "religion",
+                "employment_agency", "diplomatic",
+            ),
+            nameAndWheelchair to listOf(
+                "lawyer", "estate_agent", "political_party", "therapist",
+            ),
+            // name: ask for all offices
+        ),
+        "craft" to mapOf(
+            common to listOf(
+                "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
+                "electronics_repair", "key_cutter", "stonemason",
+            ),
+            nameAndWheelchair to listOf(
+                "winery",
+            ),
+            // name: ask for all crafts
+        ),
+    )
+
+    return filterTags.mapNotNull { (key, valuesPerQuestType) ->
+        valuesPerQuestType.forQuestType(questType)?.let { values ->
+            "$key ~ ${values.joinToString("|")}"
+        }
+    }.joinToString(" or ")
+}
+
+private fun ValuesPerQuestTypes.forQuestType(questType: PlaceFilterQuestType): List<String>? =
+    this.entries
+        .filter { questType in it.key }
+        .flatMap { it.value }
+        .ifEmpty { null }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceFilterTags.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceFilterTags.kt
@@ -1,23 +1,18 @@
 package de.westnordost.streetcomplete.quests.place_name
 
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.OPENING_HOURS_QUEST
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.PLACE_NAME_QUEST
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.WHEELCHAIR_ACCESS_QUEST
+import de.westnordost.streetcomplete.data.quest.QuestType
+import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
+import de.westnordost.streetcomplete.quests.wheelchair_access.AddWheelchairAccessBusiness
+import kotlin.reflect.KClass
 
-enum class PlaceFilterQuestType {
-    OPENING_HOURS_QUEST,
-    PLACE_NAME_QUEST,
-    WHEELCHAIR_ACCESS_QUEST,
-}
+private typealias ValuesPerQuestTypes = Map<Set<KClass<*>>, List<String>>
 
-private typealias ValuesPerQuestTypes = Map<Set<PlaceFilterQuestType>, List<String>>
-
-fun getPlaceElementFilterString(questType: PlaceFilterQuestType): String {
-    val common = setOf(OPENING_HOURS_QUEST, PLACE_NAME_QUEST, WHEELCHAIR_ACCESS_QUEST)
-    val nameAndOpeningHours = setOf(PLACE_NAME_QUEST, OPENING_HOURS_QUEST)
-    val nameAndWheelchair = setOf(PLACE_NAME_QUEST, WHEELCHAIR_ACCESS_QUEST)
-    val name = setOf(PLACE_NAME_QUEST)
-    val wheelchair = setOf(WHEELCHAIR_ACCESS_QUEST)
+fun getPlaceElementFilterString(questType: QuestType<*>): String {
+    val common = setOf(AddOpeningHours::class, AddPlaceName::class, AddWheelchairAccessBusiness::class)
+    val nameAndOpeningHours = setOf(AddPlaceName::class, AddOpeningHours::class)
+    val nameAndWheelchair = setOf(AddPlaceName::class, AddWheelchairAccessBusiness::class)
+    val name = setOf(AddPlaceName::class)
+    val wheelchair = setOf(AddWheelchairAccessBusiness::class)
 
     val filterTags: Map<String, ValuesPerQuestTypes> = mapOf(
         "amenity" to mapOf(
@@ -143,8 +138,8 @@ fun getPlaceElementFilterString(questType: PlaceFilterQuestType): String {
     }.joinToString(" or ")
 }
 
-private fun ValuesPerQuestTypes.forQuestType(questType: PlaceFilterQuestType): List<String>? =
+private fun ValuesPerQuestTypes.forQuestType(questType: QuestType<*>): List<String>? =
     this.entries
-        .filter { questType in it.key }
+        .filter { questType::class in it.key }
         .flatMap { it.value }
         .ifEmpty { null }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -10,6 +10,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
+import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.WHEELCHAIR_ACCESS_QUEST
+import de.westnordost.streetcomplete.quests.place_name.getPlaceElementFilterString
 import java.util.concurrent.FutureTask
 
 class AddWheelchairAccessBusiness(
@@ -26,70 +28,9 @@ class AddWheelchairAccessBusiness(
             or amenity = parking and parking = multi-storey
             or amenity = recycling and recycling_type = centre
             or tourism = information and information = office
-            or """.trimIndent() +
-
-        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
-        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
-        // Independent tags can by added in the "wheelchair only" tab.
-
-        mapOf(
-            "amenity" to arrayOf(
-                // common
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino",                                                                     // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
-                "bank", "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",           // commercial
-                "car_wash", "car_rental", "fuel",                                                                      // car stuff
-                "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
-                "animal_boarding", "animal_shelter", "animal_breeding",                                                // animals
-
-                // name & wheelchair only
-                "theatre",                             // culture
-                "conference_centre", "arts_centre",    // events
-                "police", "ranger_station",            // civic
-                "ferry_terminal",                      // transport
-                "place_of_worship",                    // religious
-                "hospital"                             // health care
-            ),
-            "tourism" to arrayOf(
-                // common
-                "zoo", "aquarium", "theme_park", "gallery", "museum",
-
-                // name & wheelchair
-                "attraction",
-                "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site", "chalet", // accommodations
-
-                // wheelchair only
-                "viewpoint"
-
-                // and tourism = information, see above
-            ),
-            "leisure" to arrayOf(
-                // common
-                "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
-
-                // name & wheelchair
-                "sports_centre", "stadium"
-            ),
-            "office" to arrayOf(
-                // common
-                "insurance", "government", "travel_agent", "tax_advisor", "religion",
-                "employment_agency", "diplomatic",
-
-                // name & wheelchair
-                "lawyer", "estate_agent", "political_party", "therapist"
-            ),
-            "craft" to arrayOf(
-                // common
-                "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
-                "electronics_repair", "key_cutter", "stonemason",
-
-                // name & wheelchair
-                "winery"
-            )
-        ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") +
-        "  \n)"
+            or ${getPlaceElementFilterString(WHEELCHAIR_ACCESS_QUEST)}
+          )
+    """
 
     override val changesetComment = "Add wheelchair access"
     override val wikiLink = "Key:wheelchair"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -10,7 +10,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
-import de.westnordost.streetcomplete.quests.place_name.PlaceFilterQuestType.WHEELCHAIR_ACCESS_QUEST
 import de.westnordost.streetcomplete.quests.place_name.getPlaceElementFilterString
 import java.util.concurrent.FutureTask
 
@@ -28,7 +27,7 @@ class AddWheelchairAccessBusiness(
             or amenity = parking and parking = multi-storey
             or amenity = recycling and recycling_type = centre
             or tourism = information and information = office
-            or ${getPlaceElementFilterString(WHEELCHAIR_ACCESS_QUEST)}
+            or ${getPlaceElementFilterString(this)}
           )
     """
 


### PR DESCRIPTION
Instead of keeping a large chunk of copy-pasted (and then adjusted) code in sync between three quests, create the filtered lists programmatically from one single source of truth.

I noticed this in #3649 because the auto-formatting really messed up the indentation there.