### PR TITLE
Resurvey for `opening_hours:signed=no` (fixes #3130)

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/TestQuestType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.osm.osmquests
 
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
 import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
@@ -10,7 +10,7 @@ open class TestQuestType : OsmElementQuestType<String> {
 
     override fun getTitle(tags: Map<String, String>) = 0
     override fun isApplicableTo(element: Element): Boolean? = null
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {}
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {}
     override val icon = 0
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
     override val changesetComment = ""

--- a/app/src/main/java/de/westnordost/streetcomplete/data/meta/ResurveyUtils.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/meta/ResurveyUtils.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.data.meta
 
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import java.time.DateTimeException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -39,7 +39,7 @@ fun String.toCheckDate(): LocalDate? {
 
 /** adds or modifies the given tag. If the updated tag is the same as before, sets the check date
  *  tag to today instead. */
-fun StringMapChangesBuilder.updateWithCheckDate(key: String, value: String) {
+fun Tags.updateWithCheckDate(key: String, value: String) {
     val previousValue = get(key)
     if (previousValue != value) {
         set(key, value)
@@ -55,32 +55,33 @@ fun StringMapChangesBuilder.updateWithCheckDate(key: String, value: String) {
 
 /** Set/update solely the check date to today for the given key, this also removes other less
  *  preferred check date keys. */
-fun StringMapChangesBuilder.updateCheckDateForKey(key: String) {
-    set("$SURVEY_MARK_KEY:$key", LocalDate.now().toCheckDateString())
-    // remove old check date keys (except the one we want to set)
-    getLastCheckDateKeys(key).forEach {
-        if (it != "$SURVEY_MARK_KEY:$key") remove(it)
-    }
+fun Tags.updateCheckDateForKey(key: String) {
+    setCheckDateForKey(key, LocalDate.now())
+}
+
+fun Tags.setCheckDateForKey(key: String, date: LocalDate) {
+    removeCheckDatesForKey(key)
+    set("$SURVEY_MARK_KEY:$key", date.toCheckDateString())
 }
 
 /** Return whether a check date is set for the given key */
-fun StringMapChangesBuilder.hasCheckDateForKey(key: String): Boolean =
+fun Tags.hasCheckDateForKey(key: String): Boolean =
     getLastCheckDateKeys(key).any { get(it) != null }
 
 /** Delete any check date keys for the given key */
-fun StringMapChangesBuilder.removeCheckDatesForKey(key: String) {
+fun Tags.removeCheckDatesForKey(key: String) {
     getLastCheckDateKeys(key).forEach { remove(it) }
 }
 
 /** Set/update solely the check date for the entire item to today, this also removes other less
  *  preferred check date keys for the entire item. */
-fun StringMapChangesBuilder.updateCheckDate() {
+fun Tags.updateCheckDate() {
     set(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
     removeOtherCheckDates()
 }
 
 /** Delete solely the other check date for the entire item, don't touch SURVEY_MARK_KEY */
-fun StringMapChangesBuilder.removeOtherCheckDates() {
+fun Tags.removeOtherCheckDates() {
     // remove old check dates (except the one we want to set)
     LAST_CHECK_DATE_KEYS.forEach {
         if (it != SURVEY_MARK_KEY) remove(it)
@@ -88,11 +89,11 @@ fun StringMapChangesBuilder.removeOtherCheckDates() {
 }
 
 /** Return whether any check dates are set */
-fun StringMapChangesBuilder.hasCheckDate(): Boolean =
+fun Tags.hasCheckDate(): Boolean =
     LAST_CHECK_DATE_KEYS.any { get(it) != null }
 
 /** Delete any check date for the entire item */
-fun StringMapChangesBuilder.removeCheckDates() {
+fun Tags.removeCheckDates() {
     remove(SURVEY_MARK_KEY)
     removeOtherCheckDates()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesXt.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesXt.kt
@@ -28,7 +28,3 @@ fun Element.changesApplied(changes: StringMapChanges): Element {
         timestampEdited = currentTimeMillis()
     )
 }
-
-fun StringMapChangesBuilder.deleteIfExistList(keys: List<String>) {
-    keys.forEach { remove(it) }
-}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
@@ -75,12 +75,14 @@ interface OsmElementQuestType<T> : QuestType<T> {
      *  any mix-ups that far apart */
     val highlightedElementsRadius: Double get() = 30.0
 
-    /** applies the data from [answer] to the given element. The element is not directly modified,
-     *  instead, a map of [tags] is built */
-    fun applyAnswerTo(answer: T, tags: StringMapChangesBuilder)
+    /** applies the data from [answer] to the element that has last been edited at [timestamp].
+     * The element is not directly modified, instead, a map of [tags] is built */
+    fun applyAnswerTo(answer: T, tags: Tags, timestampEdited: Long)
 
     @Suppress("UNCHECKED_CAST")
-    fun applyAnswerToUnsafe(answer: Any, tags: StringMapChangesBuilder) {
-        applyAnswerTo(answer as T, tags)
+    fun applyAnswerToUnsafe(answer: Any, tags: Tags, timestampEdited: Long) {
+        applyAnswerTo(answer as T, tags, timestampEdited)
     }
 }
+
+typealias Tags = StringMapChangesBuilder

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
@@ -75,7 +75,7 @@ interface OsmElementQuestType<T> : QuestType<T> {
      *  any mix-ups that far apart */
     val highlightedElementsRadius: Double get() = 30.0
 
-    /** applies the data from [answer] to the element that has last been edited at [timestamp].
+    /** applies the data from [answer] to the element that has last been edited at [timestampEdited].
      * The element is not directly modified, instead, a map of [tags] is built */
     fun applyAnswerTo(answer: T, tags: Tags, timestampEdited: Long)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestController.kt
@@ -224,7 +224,7 @@ import kotlin.collections.ArrayList
 
     private fun createOsmQuestChanges(quest: OsmQuest, element: Element, answer: Any) : StringMapChanges {
         val changesBuilder = StringMapChangesBuilder(element.tags)
-        quest.osmElementQuestType.applyAnswerToUnsafe(answer, changesBuilder)
+        quest.osmElementQuestType.applyAnswerToUnsafe(answer, changesBuilder, element.timestampEdited)
         return changesBuilder.create()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
@@ -76,6 +76,7 @@ import de.westnordost.streetcomplete.quests.fuel_service.AddFuelSelfService
 import de.westnordost.streetcomplete.quests.lanes.AddLanes
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
 import de.westnordost.streetcomplete.quests.level.AddLevel
+import de.westnordost.streetcomplete.quests.opening_hours_signed.CheckOpeningHoursSigned
 import de.westnordost.streetcomplete.quests.orchard_produce.AddOrchardProduce
 import de.westnordost.streetcomplete.quests.parking_access.AddBikeParkingAccess
 import de.westnordost.streetcomplete.quests.parking_access.AddParkingAccess
@@ -287,6 +288,7 @@ import javax.inject.Singleton
         AddAddressStreet(),
 
         // shops: text input / opening hours input take longer than other quests
+        CheckOpeningHoursSigned(featureDictionaryFuture),
         AddPlaceName(featureDictionaryFuture),
         SpecifyShopType(),
         CheckShopType(),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -4,7 +4,7 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -68,7 +68,7 @@ class AddAcceptsCash(
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["payment:cash"] = answer.toYesNo()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.address
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.Relation
@@ -65,7 +65,7 @@ class AddAddressStreet : OsmElementQuestType<AddressStreetAnswer> {
 
     override fun createForm() = AddAddressStreetForm()
 
-    override fun applyAnswerTo(answer: AddressStreetAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: AddressStreetAnswer, tags: Tags, timestampEdited: Long) {
         val key = when(answer) {
             is StreetName -> "addr:street"
             is PlaceName -> "addr:place"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.address
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -126,7 +126,7 @@ class AddHousenumber :  OsmElementQuestType<HousenumberAnswer> {
 
     override fun createForm() = AddHousenumberForm()
 
-    override fun applyAnswerTo(answer: HousenumberAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: HousenumberAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoHouseNumber -> tags["nohousenumber"] = "yes"
             is HouseNumber   -> tags["addr:housenumber"] = answer.number

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.air_conditioning
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -39,7 +39,7 @@ class AddAirConditioning : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["air_conditioning"] = answer.toYesNo()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.atm_operator
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -25,7 +25,7 @@ class AddAtmOperator : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddAtmOperatorForm()
 
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {
         tags["operator"] = answer
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.baby_changing_table
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -37,7 +37,7 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["changing_table"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
@@ -21,7 +21,7 @@ class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
 
     override fun createForm() = AddBicycleBarrierTypeForm()
 
-    override fun applyAnswerTo(answer: BicycleBarrierType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BicycleBarrierType, tags: Tags, timestampEdited: Long) {
         tags["cycle_barrier"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnPath.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnPath.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.barrier_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.ALL_PATHS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
@@ -41,5 +41,6 @@ class AddBarrierOnPath: OsmElementQuestType<BarrierType> {
 
     override fun createForm() = AddBarrierTypeForm()
 
-    override fun applyAnswerTo(answer: BarrierType, tags: StringMapChangesBuilder) = answer.applyTo(tags)
+    override fun applyAnswerTo(answer: BarrierType, tags: Tags, timestampEdited: Long) =
+        answer.applyTo(tags)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnRoad.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnRoad.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.barrier_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.ALL_ROADS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
@@ -39,5 +39,6 @@ class AddBarrierOnRoad: OsmElementQuestType<BarrierType> {
 
     override fun createForm() = AddBarrierTypeForm()
 
-    override fun applyAnswerTo(answer: BarrierType, tags: StringMapChangesBuilder) = answer.applyTo(tags)
+    override fun applyAnswerTo(answer: BarrierType, tags: Tags, timestampEdited: Long) =
+        answer.applyTo(tags)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.barrier_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
@@ -34,5 +34,6 @@ class AddBarrierType : OsmFilterQuestType<BarrierType>() {
 
     override fun createForm() = AddBarrierTypeForm()
 
-    override fun applyAnswerTo(answer: BarrierType, tags: StringMapChangesBuilder) = answer.applyTo(tags)
+    override fun applyAnswerTo(answer: BarrierType, tags: Tags, timestampEdited: Long) =
+        answer.applyTo(tags)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -4,8 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.hasCheckDate
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.deleteIfExistList
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -49,7 +48,7 @@ class AddStileType : OsmElementQuestType<StileTypeAnswer> {
 
     override fun createForm() = AddStileTypeForm()
 
-    override fun applyAnswerTo(answer: StileTypeAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: StileTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is StileType -> {
                 val newType = answer.osmValue
@@ -62,7 +61,7 @@ class AddStileType : OsmElementQuestType<StileTypeAnswer> {
 
                 if (stileWasRebuilt) {
                     // => properties that refer to the old replaced stile should be removed
-                    tags.deleteIfExistList(STILE_PROPERTIES - "material")
+                    STILE_PROPERTIES.forEach { tags.remove(it) }
                     if(newMaterial != null) {
                         tags["material"] = newMaterial
                     } else {
@@ -78,7 +77,7 @@ class AddStileType : OsmElementQuestType<StileTypeAnswer> {
                 }
             }
             is ConvertedStile -> {
-                tags.deleteIfExistList(STILE_PROPERTIES)
+                STILE_PROPERTIES.forEach { tags.remove(it) }
                 tags.remove("stile")
                 tags["barrier"] = answer.newBarrier
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -59,22 +59,14 @@ class AddStileType : OsmElementQuestType<StileTypeAnswer> {
                     oldType != null && oldType != newType ||
                     newMaterial != null && oldMaterial != null && oldMaterial != newMaterial
 
+                // => properties that refer to the old replaced stile should be removed
                 if (stileWasRebuilt) {
-                    // => properties that refer to the old replaced stile should be removed
                     STILE_PROPERTIES.forEach { tags.remove(it) }
-                    if(newMaterial != null) {
-                        tags["material"] = newMaterial
-                    } else {
-                        tags.remove("material")
-                    }
-                } else if (newMaterial != null && oldMaterial == null) {
-                    // not considered as rebuilt, but material info still
-                    // can be added where it was missing
+                }
+                if(newMaterial != null) {
                     tags["material"] = newMaterial
                 }
-                if (newType != oldType) {
-                    tags["stile"] = newType
-                }
+                tags["stile"] = newType
             }
             is ConvertedStile -> {
                 STILE_PROPERTIES.forEach { tags.remove(it) }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/BarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/BarrierType.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.barrier_type
 
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 
 enum class BarrierType(val osmValue: String) {
     PASSAGE("entrance"),
@@ -28,7 +28,7 @@ enum class BarrierType(val osmValue: String) {
     BICYCLE_BARRIER("cycle_barrier")
 }
 
-fun BarrierType.applyTo(tags: StringMapChangesBuilder) {
+fun BarrierType.applyTo(tags: Tags) {
     tags["barrier"] = this.osmValue
     when (this) {
         BarrierType.STILE_SQUEEZER -> {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bench_backrest
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -33,7 +33,7 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
 
     override fun createForm() = AddBenchBackrestForm()
 
-    override fun applyAnswerTo(answer: BenchBackrestAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BenchBackrestAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             PICNIC_TABLE -> {
                 tags["leisure"] = "picnic_table"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_capacity
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -39,7 +39,7 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
 
     override fun createForm() = AddBikeParkingCapacityForm()
 
-    override fun applyAnswerTo(answer: Int, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Int, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("capacity", answer.toString())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_cover
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -34,7 +34,7 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["covered"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bike_parking_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -30,7 +30,7 @@ class AddBikeParkingType : OsmFilterQuestType<BikeParkingType>() {
 
     override fun createForm() = AddBikeParkingTypeForm()
 
-    override fun applyAnswerTo(answer: BikeParkingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BikeParkingType, tags: Tags, timestampEdited: Long) {
         tags["bicycle_parking"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.board_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -33,7 +33,7 @@ class AddBoardType : OsmFilterQuestType<BoardType>() {
 
     override fun createForm() = AddBoardTypeForm()
 
-    override fun applyAnswerTo(answer: BoardType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BoardType, tags: Tags, timestampEdited: Long) {
         if(answer == BoardType.MAP) {
             tags["information"] = "map"
         } else {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bollard_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -52,7 +52,7 @@ class AddBollardType : OsmElementQuestType<BollardType> {
 
     override fun createForm() = AddBollardTypeForm()
 
-    override fun applyAnswerTo(answer: BollardType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BollardType, tags: Tags, timestampEdited: Long) {
         tags["bollard"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructure.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bridge_structure
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
@@ -18,7 +18,7 @@ class AddBridgeStructure : OsmFilterQuestType<BridgeStructure>() {
 
     override fun createForm() = AddBridgeStructureForm()
 
-    override fun applyAnswerTo(answer: BridgeStructure, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BridgeStructure, tags: Tags, timestampEdited: Long) {
         tags["bridge:structure"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.building_levels
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
@@ -29,7 +29,7 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
 
     override fun createForm() = AddBuildingLevelsForm()
 
-    override fun applyAnswerTo(answer: BuildingLevelsAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BuildingLevelsAnswer, tags: Tags, timestampEdited: Long) {
         tags["building:levels"] = answer.levels.toString()
         answer.roofLevels?.let { tags["roof:levels"] = it.toString() }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.building_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
 class AddBuildingType : OsmFilterQuestType<BuildingType>() {
@@ -39,7 +39,7 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
 
     override fun createForm() = AddBuildingTypeForm()
 
-    override fun applyAnswerTo(answer: BuildingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BuildingType, tags: Tags, timestampEdited: Long) {
         if (answer.osmKey == "man_made") {
             tags.remove("building")
             tags["man_made"] = answer.osmValue

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.building_underground
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 
@@ -23,7 +23,7 @@ class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["location"] = if (answer) "underground" else "surface"
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_bench
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
@@ -45,7 +45,7 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("bench", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_bin
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
@@ -45,7 +45,7 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("bin", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_lit
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
@@ -49,7 +49,7 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("lit", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_name
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
@@ -33,7 +33,7 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
 
     override fun createForm() = AddBusStopNameForm()
 
-    override fun applyAnswerTo(answer: BusStopNameAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BusStopNameAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoBusStopName -> {
                 tags["name:signed"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_ref
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
@@ -33,7 +33,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
 
     override fun createForm() = AddBusStopRefForm()
 
-    override fun applyAnswerTo(answer: BusStopRefAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BusStopRefAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoBusStopRef -> tags["ref:signed"] = "no"
             is BusStopRef ->   tags["ref"] = answer.ref

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_shelter
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
@@ -47,7 +47,7 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
 
     override fun createForm() = AddBusStopShelterForm()
 
-    override fun applyAnswerTo(answer: BusStopShelterAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: BusStopShelterAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             SHELTER -> tags.updateWithCheckDate("shelter", "yes")
             NO_SHELTER -> tags.updateWithCheckDate("shelter", "no")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.camera_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -30,7 +30,7 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
 
     override fun createForm() = AddCameraTypeForm()
 
-    override fun applyAnswerTo(answer: CameraType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CameraType, tags: Tags, timestampEdited: Long) {
         tags["camera:type"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.car_wash_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.*
@@ -20,7 +20,7 @@ class AddCarWashType : OsmFilterQuestType<List<CarWashType>>() {
 
     override fun createForm() = AddCarWashTypeForm()
 
-    override fun applyAnswerTo(answer: List<CarWashType>, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: List<CarWashType>, tags: Tags, timestampEdited: Long) {
         val isAutomated = answer.contains(AUTOMATED)
         tags["automated"] = isAutomated.toYesNo()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.charging_station_capacity
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -41,7 +41,7 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>() {
 
     override fun createForm() = AddChargingStationCapacityForm()
 
-    override fun applyAnswerTo(answer: Int, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Int, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("capacity", answer.toString())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/charging_station_operator/AddChargingStationOperator.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.charging_station_operator
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -29,7 +29,7 @@ class AddChargingStationOperator : OsmFilterQuestType<String>() {
 
     override fun createForm() = AddChargingStationOperatorForm()
 
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {
         tags["operator"] = answer
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.clothing_bin_operator
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -48,7 +48,7 @@ class AddClothingBinOperator : OsmElementQuestType<String> {
 
     override fun createForm() = AddClothingBinOperatorForm()
 
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {
         tags["operator"] = answer
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.construction
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
 
@@ -24,7 +24,7 @@ class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructi
 
     override fun createForm() = MarkCompletedConstructionForm()
 
-    override fun applyAnswerTo(answer: CompletedConstructionAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CompletedConstructionAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is OpeningDateAnswer -> {
                 tags["opening_date"] = answer.date.toCheckDateString()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionUtils.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionUtils.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.construction
 import de.westnordost.streetcomplete.data.meta.SURVEY_MARK_KEY
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 
-fun removeTagsDescribingConstruction(tags: Tags, timestampEdited: Long) {
+fun removeTagsDescribingConstruction(tags: Tags) {
     tags.remove("construction")
     tags.remove("source:construction")
     tags.remove("opening_date")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionUtils.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionUtils.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.construction
 
 import de.westnordost.streetcomplete.data.meta.SURVEY_MARK_KEY
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 
-fun removeTagsDescribingConstruction(tags: StringMapChangesBuilder) {
+fun removeTagsDescribingConstruction(tags: Tags, timestampEdited: Long) {
     tags.remove("construction")
     tags.remove("source:construction")
     tags.remove("opening_date")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ALL_ROADS
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
@@ -39,7 +39,7 @@ class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructio
 
     override fun createForm() = MarkCompletedConstructionForm()
 
-    override fun applyAnswerTo(answer: CompletedConstructionAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CompletedConstructionAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is OpeningDateAnswer -> {
                 tags["opening_date"] = answer.date.toCheckDateString()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.crossing
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.*
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
@@ -73,7 +73,7 @@ class AddCrossing : OsmElementQuestType<KerbHeight> {
 
     override fun createForm() = AddKerbHeightForm()
 
-    override fun applyAnswerTo(answer: KerbHeight, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: KerbHeight, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("kerb", answer.osmValue)
         /* So, we don't assume there is a crossing here for kerb=no and kerb=raised.
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.crossing_island
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
@@ -57,7 +57,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["crossing:island"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -64,7 +64,7 @@ class AddCrossingType : OsmElementQuestType<CrossingType> {
 
     override fun createForm() = AddCrossingTypeForm()
 
-    override fun applyAnswerTo(answer: CrossingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CrossingType, tags: Tags, timestampEdited: Long) {
         val crossingValue = tags["crossing"]
         val isAndWasMarked = answer == CrossingType.MARKED && crossingValue in listOf("zebra", "marked", "uncontrolled")
         /* don't change the tag value of the synonyms for "marked" because it is something of a

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.elementfilter.filters.RelativeDate
 import de.westnordost.streetcomplete.data.elementfilter.filters.TagOlderThan
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.*
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
@@ -137,7 +137,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
 
     override fun createForm() = AddCyclewayForm()
 
-    override fun applyAnswerTo(answer: CyclewayAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CyclewayAnswer, tags: Tags, timestampEdited: Long) {
         if (answer.left == answer.right) {
             answer.left?.let { applyCyclewayAnswerTo(it.cycleway, Side.BOTH, 0, tags) }
             deleteCyclewayAnswerIfExists(Side.LEFT, tags)
@@ -167,7 +167,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
 
     /** Just add a sidewalk if we implicitly know from the answer that there is one */
     private fun applySidewalkAnswerTo(
-        cyclewayLeft: Cycleway?, cyclewayRight: Cycleway?, tags: StringMapChangesBuilder) {
+        cyclewayLeft: Cycleway?, cyclewayRight: Cycleway?, tags: Tags, timestampEdited: Long) {
 
         /* only tag if we know the sidewalk value for both sides (because it is not possible in
            OSM to specify the sidewalk value only for one side. sidewalk:right/left=yes is not
@@ -182,7 +182,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
     }
 
     private fun applyCyclewayAnswerTo(
-        cycleway: Cycleway, side: Side, dir: Int, tags: StringMapChangesBuilder)
+        cycleway: Cycleway, side: Side, dir: Int, tags: Tags, timestampEdited: Long)
     {
         val directionValue = when {
             dir > 0 -> "yes"
@@ -267,7 +267,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
     }
 
     /** clear previous answers for the given side */
-    private fun deleteCyclewayAnswerIfExists(side: Side?, tags: StringMapChangesBuilder) {
+    private fun deleteCyclewayAnswerIfExists(side: Side?, tags: Tags, timestampEdited: Long) {
         val sideVal = if (side == null) "" else ":" + side.value
         val cyclewayKey = "cycleway$sideVal"
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -166,8 +166,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
     }
 
     /** Just add a sidewalk if we implicitly know from the answer that there is one */
-    private fun applySidewalkAnswerTo(
-        cyclewayLeft: Cycleway?, cyclewayRight: Cycleway?, tags: Tags, timestampEdited: Long) {
+    private fun applySidewalkAnswerTo(cyclewayLeft: Cycleway?, cyclewayRight: Cycleway?, tags: Tags) {
 
         /* only tag if we know the sidewalk value for both sides (because it is not possible in
            OSM to specify the sidewalk value only for one side. sidewalk:right/left=yes is not
@@ -181,8 +180,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
         LEFT("left"), RIGHT("right"), BOTH("both")
     }
 
-    private fun applyCyclewayAnswerTo(
-        cycleway: Cycleway, side: Side, dir: Int, tags: Tags, timestampEdited: Long)
+    private fun applyCyclewayAnswerTo(cycleway: Cycleway, side: Side, dir: Int, tags: Tags)
     {
         val directionValue = when {
             dir > 0 -> "yes"
@@ -267,7 +265,7 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
     }
 
     /** clear previous answers for the given side */
-    private fun deleteCyclewayAnswerIfExists(side: Side?, tags: Tags, timestampEdited: Long) {
+    private fun deleteCyclewayAnswerIfExists(side: Side?, tags: Tags) {
         val sideVal = if (side == null) "" else ":" + side.value
         val cyclewayKey = "cycleway$sideVal"
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -8,7 +8,6 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.meta.*
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/defibrillator/AddIsDefibrillatorIndoor.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.defibrillator
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -31,7 +31,7 @@ class AddIsDefibrillatorIndoor : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["indoor"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.diet_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -38,7 +38,7 @@ class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_halal)
 
-    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is DietAvailability -> tags.updateWithCheckDate("diet:halal", answer.osmValue)
             NoFood -> tags["food"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.diet_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -39,7 +39,7 @@ class AddKosher : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_kosher)
 
-    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is DietAvailability -> tags.updateWithCheckDate("diet:kosher", answer.osmValue)
             NoFood -> tags["food"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -43,7 +43,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegan)
 
-    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is DietAvailability -> tags.updateWithCheckDate("diet:vegan", answer.osmValue)
             NoFood -> tags["food"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -40,7 +40,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override fun createForm() = AddDietTypeForm.create(R.string.quest_dietType_explanation_vegetarian)
 
-    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is DietAvailability -> {
                 tags.updateWithCheckDate("diet:vegetarian", answer.osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.drinking_water
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -43,7 +43,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
     override fun createForm() = AddDrinkingWaterForm()
 
-    override fun applyAnswerTo(answer: DrinkingWater, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: DrinkingWater, tags: Tags, timestampEdited: Long) {
         tags["drinking_water"] = answer.osmValue
         answer.osmLegalValue?.let { tags["drinking_water:legal"] = it }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.LAST_CHECK_DATE_KEYS
 import de.westnordost.streetcomplete.data.meta.updateCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
@@ -115,7 +115,7 @@ class CheckExistence(
 
     override fun createForm() = CheckExistenceForm()
 
-    override fun applyAnswerTo(answer: Unit, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Unit, tags: Tags, timestampEdited: Long) {
         tags.updateCheckDate()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.ferry
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -26,7 +26,7 @@ class AddFerryAccessMotorVehicle : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["motor_vehicle"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.ferry
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -26,7 +26,7 @@ class AddFerryAccessPedestrian : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["foot"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.fire_hydrant
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -25,7 +25,7 @@ class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
 
     override fun createForm() = AddFireHydrantTypeForm()
 
-    override fun applyAnswerTo(answer: FireHydrantType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: FireHydrantType, tags: Tags, timestampEdited: Long) {
         tags["fire_hydrant:type"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.fire_hydrant_diameter
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -49,7 +49,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
 
     override fun createForm() = AddFireHydrantDiameterForm()
 
-    override fun applyAnswerTo(answer: FireHydrantDiameterAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: FireHydrantDiameterAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is FireHydrantDiameter ->       tags["fire_hydrant:diameter"] = answer.toOsmValue()
             is NoFireHydrantDiameterSign -> tags["fire_hydrant:diameter:signed"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.fire_hydrant_position
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
@@ -29,7 +29,7 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
 
     override fun createForm() = AddFireHydrantPositionForm()
 
-    override fun applyAnswerTo(answer: FireHydrantPosition, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: FireHydrantPosition, tags: Tags, timestampEdited: Long) {
         tags["fire_hydrant:position"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.foot
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.*
 
@@ -47,7 +47,7 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
 
     override fun createForm() = AddProhibitedForPedestriansForm()
 
-    override fun applyAnswerTo(answer: ProhibitedForPedestriansAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ProhibitedForPedestriansAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             // the question is whether it is prohibited, so YES -> foot=no etc
             YES -> tags["foot"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fuel_service/AddFuelSelfService.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fuel_service/AddFuelSelfService.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.fuel_service
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
@@ -35,7 +35,7 @@ class AddFuelSelfService : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["self_service"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.general_fee
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -26,7 +26,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["fee"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.handrail
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -35,7 +35,7 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("handrail", answer.toYesNo())
         if (!answer) {
             tags.remove("handrail:left")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.internet_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
@@ -36,7 +36,7 @@ class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
 
     override fun createForm() = AddInternetAccessForm()
 
-    override fun applyAnswerTo(answer: InternetAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: InternetAccess, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("internet_access", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeight.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
@@ -40,7 +40,7 @@ class AddKerbHeight : OsmElementQuestType<KerbHeight> {
 
     override fun createForm() = AddKerbHeightForm()
 
-    override fun applyAnswerTo(answer: KerbHeight, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: KerbHeight, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("kerb", answer.osmValue)
         tags["barrier"] = "kerb"
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.lanes
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
@@ -34,7 +34,7 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
 
     override fun createForm() = AddLanesForm()
 
-    override fun applyAnswerTo(answer: LanesAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: LanesAnswer, tags: Tags, timestampEdited: Long) {
 
         val laneCount = answer.total
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.leaf_detail
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -49,7 +49,7 @@ class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
 
     override fun createForm() = AddForestLeafTypeForm()
 
-    override fun applyAnswerTo(answer: ForestLeafType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ForestLeafType, tags: Tags, timestampEdited: Long) {
         tags["leaf_type"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/level/AddLevel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/level/AddLevel.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -113,7 +113,7 @@ class AddLevel : OsmElementQuestType<String> {
 
     override fun createForm() = AddLevelForm()
 
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {
         tags["level"] = answer
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.max_height
 
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.ALL_PATHS
 import de.westnordost.streetcomplete.data.meta.ALL_ROADS
@@ -129,7 +129,7 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
 
     override fun createForm() = AddMaxHeightForm()
 
-    override fun applyAnswerTo(answer: MaxHeightAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: MaxHeightAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is MaxHeight -> {
                 tags["maxheight"] = answer.value.toString()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -43,7 +43,7 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
 
     override fun createForm() = AddMaxSpeedForm()
 
-    override fun applyAnswerTo(answer: MaxSpeedAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: MaxSpeedAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is MaxSpeedSign -> {
                 tags["maxspeed"] = answer.value.toString()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.max_weight
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.*
 
@@ -36,7 +36,7 @@ class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
 
     override fun createForm() = AddMaxWeightForm()
 
-    override fun applyAnswerTo(answer: MaxWeightAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: MaxWeightAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is MaxWeight -> {
                 tags[answer.sign.osmKey] = answer.weight.toString()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.motorcycle_parking_capacity
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -30,7 +30,7 @@ class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter("nodes, ways with amenity = motorcycle_parking")
 
-    override fun applyAnswerTo(answer: Int, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Int, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("capacity", answer.toString())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.motorcycle_parking_cover
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -32,7 +32,7 @@ class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["covered"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.ALL_ROADS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -79,7 +79,7 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
 
     override fun createForm() = AddOnewayForm()
 
-    override fun applyAnswerTo(answer: OnewayAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: OnewayAnswer, tags: Tags, timestampEdited: Long) {
         tags["oneway"] = when(answer) {
             FORWARD -> "yes"
             BACKWARD -> "-1"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
@@ -139,7 +139,7 @@ class AddSuspectedOneway(
 
     override fun createForm() = AddSuspectedOnewayForm()
 
-    override fun applyAnswerTo(answer: SuspectedOnewayAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SuspectedOnewayAnswer, tags: Tags, timestampEdited: Long) {
         if (!answer.isOneway) {
             tags["oneway"] = "no"
         } else {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.opening_hours
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
@@ -155,7 +155,7 @@ class AddOpeningHours (
 
     override fun createForm() = AddOpeningHoursForm()
 
-    override fun applyAnswerTo(answer: OpeningHoursAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: OpeningHoursAnswer, tags: Tags, timestampEdited: Long) {
         if (answer is NoOpeningHoursSign) {
             tags["opening_hours:signed"] = "no"
             // don't delete current opening hours: these may be the correct hours, they are just not visible anywhere on the door

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -1,0 +1,115 @@
+package de.westnordost.streetcomplete.quests.opening_hours_signed
+
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.osmfeatures.FeatureDictionary
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.meta.getLastCheckDateKeys
+import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
+import de.westnordost.streetcomplete.data.meta.setCheckDateForKey
+import de.westnordost.streetcomplete.data.meta.toCheckDate
+import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.ktx.containsAny
+import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.concurrent.FutureTask
+
+class CheckOpeningHoursSigned (
+    private val featureDictionaryFuture: FutureTask<FeatureDictionary>
+) : OsmElementQuestType<Boolean> {
+
+    private val filter by lazy { """
+        nodes, ways, relations with
+          opening_hours:signed = no
+          and (
+            $hasOldOpeningHoursCheckDateFilter
+            or older today -1 years
+          )
+          and access !~ private|no
+          and (name or brand or noname = yes or name:signed = no or amenity = recycling)
+    """.trimIndent().toElementFilterExpression() }
+
+    private val hasOldOpeningHoursCheckDateFilter: String get() =
+        getLastCheckDateKeys("opening_hours").joinToString("\nor ") {
+            "$it < today -1 years"
+        }
+
+    private val nameTags = listOf("name", "brand")
+
+    override val changesetComment = "Check whether opening hours are signed"
+    override val wikiLink = "Key:opening_hours:signed"
+    override val icon = R.drawable.ic_quest_opening_hours_signed
+    override val isReplaceShopEnabled = true
+    override val questTypeAchievements = listOf(CITIZEN)
+
+    override fun getTitle(tags: Map<String, String>): Int {
+        val hasProperName = hasProperName(tags)
+        val hasFeatureName = hasFeatureName(tags)
+        return  when {
+            !hasProperName  -> R.string.quest_openingHours_signed_no_name_title
+            !hasFeatureName -> R.string.quest_openingHours_signed_name_title
+            else            -> R.string.quest_openingHours_signed_name_type_title
+        }
+    }
+
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> {
+        val name = tags["name"] ?: tags["brand"]
+        val hasProperName = name != null
+        val hasFeatureName = hasFeatureName(tags)
+        return when {
+            !hasProperName  -> arrayOf(featureName.value.toString())
+            !hasFeatureName -> arrayOf(name!!)
+            else            -> arrayOf(name!!, featureName.value.toString())
+        }
+    }
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
+        mapData.filter { isApplicableTo(it) }
+
+    override fun isApplicableTo(element: Element) : Boolean =
+        filter.matches(element) && hasName(element.tags)
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("nodes, ways, relations with " + isKindOfShopExpression())
+
+    override fun createForm() = YesNoQuestAnswerFragment()
+
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
+
+        if (answer) {
+            tags.remove("opening_hours:signed")
+            /* it is now signed: we set the check date for the opening hours to the previous edit
+               timestamp because this or an older date is the date the opening hours were last
+               checked. This is set so that the app will ask about the (signed) opening hours in
+               a follow up quest
+             */
+            val hasCheckDate = getLastCheckDateKeys("opening_hours")
+                .any { tags[it]?.toCheckDate() != null }
+
+            if (!hasCheckDate) {
+                tags.setCheckDateForKey("opening_hours", LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(timestampEdited), ZoneId.systemDefault()
+                ).toLocalDate())
+            }
+        } else {
+            tags["opening_hours:signed"] = "no"
+            /* still unsigned: just set the check date to now, user was on-site */
+            tags.updateCheckDateForKey("opening_hours")
+        }
+    }
+
+    private fun hasName(tags: Map<String, String>) = hasProperName(tags) || hasFeatureName(tags)
+
+    private fun hasProperName(tags: Map<String, String>): Boolean =
+        tags.keys.containsAny(nameTags)
+
+    private fun hasFeatureName(tags: Map<String, String>): Boolean =
+        featureDictionaryFuture.get().byTags(tags).isSuggestion(false).find().isNotEmpty()
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -34,7 +34,7 @@ class CheckOpeningHoursSigned (
           )
           and access !~ private|no
           and (name or brand or noname = yes or name:signed = no or amenity = recycling)
-    """.trimIndent().toElementFilterExpression() }
+    """.toElementFilterExpression() }
 
     private val hasOldOpeningHoursCheckDateFilter: String get() =
         getLastCheckDateKeys("opening_hours").joinToString("\nor ") {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.orchard_produce
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
@@ -22,7 +22,7 @@ class AddOrchardProduce : OsmFilterQuestType<List<OrchardProduce>>() {
 
     override fun createForm() = AddOrchardProduceForm()
 
-    override fun applyAnswerTo(answer: List<OrchardProduce>, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: List<OrchardProduce>, tags: Tags, timestampEdited: Long) {
         tags["produce"] = answer.joinToString(";") { it.osmValue }
 
         val landuse = answer.singleOrNull()?.osmLanduseValue

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
@@ -25,7 +25,7 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
     override fun createForm() = AddParkingAccessForm()
 
-    override fun applyAnswerTo(answer: ParkingAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ParkingAccess, tags: Tags, timestampEdited: Long) {
         tags["access"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.parking_access
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
@@ -33,7 +33,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
 
     override fun createForm() = AddParkingAccessForm()
 
-    override fun applyAnswerTo(answer: ParkingAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ParkingAccess, tags: Tags, timestampEdited: Long) {
         tags["access"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 
 class AddBikeParkingFee : OsmFilterQuestType<Fee>() {
@@ -31,5 +31,6 @@ class AddBikeParkingFee : OsmFilterQuestType<Fee>() {
 
     override fun createForm() = AddParkingFeeForm()
 
-    override fun applyAnswerTo(answer: Fee, tags: StringMapChangesBuilder) = answer.applyTo(tags)
+    override fun applyAnswerTo(answer: Fee, tags: Tags, timestampEdited: Long) =
+        answer.applyTo(tags)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.parking_fee
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingFee : OsmFilterQuestType<Fee>() {
@@ -25,5 +25,6 @@ class AddParkingFee : OsmFilterQuestType<Fee>() {
 
     override fun createForm() = AddParkingFeeForm()
 
-    override fun applyAnswerTo(answer: Fee, tags: StringMapChangesBuilder) = answer.applyTo(tags)
+    override fun applyAnswerTo(answer: Fee, tags: Tags, timestampEdited: Long) =
+        answer.applyTo(tags)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/Fee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/Fee.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.parking_fee
 
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 
 
@@ -12,7 +12,7 @@ object HasNoFee : Fee()
 data class HasFeeAtHours(val openingHours: OpeningHoursRuleList) : Fee()
 data class HasFeeExceptAtHours(val openingHours: OpeningHoursRuleList) : Fee()
 
-fun Fee.applyTo(tags: StringMapChangesBuilder) {
+fun Fee.applyTo(tags: Tags) {
     when(this) {
         is HasFee   -> {
             tags.updateWithCheckDate("fee", "yes")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.parking_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddParkingType : OsmFilterQuestType<ParkingType>() {
@@ -22,7 +22,7 @@ class AddParkingType : OsmFilterQuestType<ParkingType>() {
 
     override fun createForm() = AddParkingTypeForm()
 
-    override fun applyAnswerTo(answer: ParkingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ParkingType, tags: Tags, timestampEdited: Long) {
         tags["parking"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/picnic_table_cover/AddPicnicTableCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/picnic_table_cover/AddPicnicTableCover.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.picnic_table_cover
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -32,7 +32,7 @@ class AddPicnicTableCover : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["covered"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.pitch_lit
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -35,7 +35,7 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("lit", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.place_name
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
@@ -120,7 +120,7 @@ class AddPlaceName(
 
     override fun createForm() = AddPlaceNameForm()
 
-    override fun applyAnswerTo(answer: PlaceNameAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PlaceNameAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoPlaceNameSign -> {
                 tags["name:signed"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/playground_access/AddPlaygroundAccess.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.playground_access
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddPlaygroundAccess : OsmFilterQuestType<PlaygroundAccess>() {
@@ -18,7 +18,7 @@ class AddPlaygroundAccess : OsmFilterQuestType<PlaygroundAccess>() {
 
     override fun createForm() = AddPlaygroundAccessForm()
 
-    override fun applyAnswerTo(answer: PlaygroundAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PlaygroundAccess, tags: Tags, timestampEdited: Long) {
         tags["access"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.police_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
@@ -24,7 +24,7 @@ class AddPoliceType : OsmFilterQuestType<PoliceType>() {
 
     override fun createForm() = AddPoliceTypeForm()
 
-    override fun applyAnswerTo(answer: PoliceType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PoliceType, tags: Tags, timestampEdited: Long) {
         tags["operator"] = answer.operatorName
         tags["operator:wikidata"] = answer.wikidata
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.postbox_collection_times
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -96,7 +96,7 @@ class AddPostboxCollectionTimes : OsmElementQuestType<CollectionTimesAnswer> {
 
     override fun createForm() = AddPostboxCollectionTimesForm()
 
-    override fun applyAnswerTo(answer: CollectionTimesAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: CollectionTimesAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoCollectionTimesSign -> {
                 tags["collection_times:signed"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.postbox_ref
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -40,7 +40,7 @@ class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
 
     override fun createForm() = AddPostboxRefForm()
 
-    override fun applyAnswerTo(answer: PostboxRefAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PostboxRefAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoRefVisible -> tags["ref:signed"] = "no"
             is Ref ->          tags["ref"] = answer.ref

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.postbox_royal_cypher
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -32,7 +32,7 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
 
     override fun createForm() = AddPostboxRoyalCypherForm()
 
-    override fun applyAnswerTo(answer: PostboxRoyalCypher, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PostboxRoyalCypher, tags: Tags, timestampEdited: Long) {
         tags["royal_cypher"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.powerpoles_material
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -36,7 +36,7 @@ class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterial>() {
 
     override fun createForm() = AddPowerPolesMaterialForm()
 
-    override fun applyAnswerTo(answer: PowerPolesMaterial, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: PowerPolesMaterial, tags: Tags, timestampEdited: Long) {
         tags["material"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrier.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.railway_crossing
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -49,7 +49,7 @@ class AddRailwayCrossingBarrier : OsmElementQuestType<RailwayCrossingBarrier> {
 
     override fun createForm() = AddRailwayCrossingBarrierForm()
 
-    override fun applyAnswerTo(answer: RailwayCrossingBarrier, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RailwayCrossingBarrier, tags: Tags, timestampEdited: Long) {
         if (answer.osmValue != null) {
             tags.remove("crossing:chicane")
             tags.updateWithCheckDate("crossing:barrier", answer.osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.recycling
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -27,7 +27,7 @@ class AddRecyclingType : OsmFilterQuestType<RecyclingType>() {
 
     override fun createForm() = AddRecyclingTypeForm()
 
-    override fun applyAnswerTo(answer: RecyclingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RecyclingType, tags: Tags, timestampEdited: Long) {
         when (answer) {
             RECYCLING_CENTRE -> {
                 tags["recycling_type"] = "centre"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.recycling_glass
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -32,7 +32,7 @@ class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
 
     override fun createForm() = DetermineRecyclingGlassForm()
 
-    override fun applyAnswerTo(answer: RecyclingGlass, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RecyclingGlass, tags: Tags, timestampEdited: Long) {
         when(answer) {
             ANY -> {
                 // to mark that it has been checked

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.filters.RelativeDate
 import de.westnordost.streetcomplete.data.elementfilter.filters.TagOlderThan
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.removeCheckDatesForKey
 import de.westnordost.streetcomplete.data.meta.hasCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
@@ -51,7 +51,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter("nodes with amenity = recycling")
 
-    override fun applyAnswerTo(answer: RecyclingContainerMaterialsAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RecyclingContainerMaterialsAnswer, tags: Tags, timestampEdited: Long) {
         if (answer is RecyclingMaterials) {
             applyRecyclingMaterialsAnswer(answer.materials, tags)
         } else if(answer is IsWasteContainer) {
@@ -59,7 +59,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
         }
     }
 
-    private fun applyRecyclingMaterialsAnswer(materials: List<RecyclingMaterial>, tags: StringMapChangesBuilder) {
+    private fun applyRecyclingMaterialsAnswer(materials: List<RecyclingMaterial>, tags: Tags, timestampEdited: Long) {
         // first clear recycling:* taggings previously "yes"
         for ((key, value) in tags.entries) {
             if (key.startsWith("recycling:") && value == "yes") {
@@ -107,7 +107,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
         }
     }
 
-    private fun applyWasteContainerAnswer(tags: StringMapChangesBuilder) {
+    private fun applyWasteContainerAnswer(tags: Tags, timestampEdited: Long) {
         tags["amenity"] = "waste_disposal"
         tags.remove("recycling_type")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -59,7 +59,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
         }
     }
 
-    private fun applyRecyclingMaterialsAnswer(materials: List<RecyclingMaterial>, tags: Tags, timestampEdited: Long) {
+    private fun applyRecyclingMaterialsAnswer(materials: List<RecyclingMaterial>, tags: Tags) {
         // first clear recycling:* taggings previously "yes"
         for ((key, value) in tags.entries) {
             if (key.startsWith("recycling:") && value == "yes") {
@@ -107,7 +107,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
         }
     }
 
-    private fun applyWasteContainerAnswer(tags: Tags, timestampEdited: Long) {
+    private fun applyWasteContainerAnswer(tags: Tags) {
         tags["amenity"] = "waste_disposal"
         tags.remove("recycling_type")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.religion
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 
 class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
@@ -30,7 +30,7 @@ class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
 
     override fun createForm() = AddReligionForm()
 
-    override fun applyAnswerTo(answer: Religion, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Religion, tags: Tags, timestampEdited: Long) {
         tags["religion"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionToWaysideShrine.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.religion
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
@@ -23,7 +23,7 @@ class AddReligionToWaysideShrine : OsmFilterQuestType<Religion>() {
 
     override fun createForm() = AddReligionForm()
 
-    override fun applyAnswerTo(answer: Religion, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Religion, tags: Tags, timestampEdited: Long) {
         tags["religion"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.road_name
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
@@ -42,7 +42,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>() {
 
     override fun createForm() = AddRoadNameForm()
 
-    override fun applyAnswerTo(answer: RoadNameAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RoadNameAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is NoRoadName        -> tags["noname"] = "yes"
             is RoadIsServiceRoad -> {
@@ -73,7 +73,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>() {
         }
     }
 
-    private fun applyAnswerRoadName(answer: RoadName, tags: StringMapChangesBuilder) {
+    private fun applyAnswerRoadName(answer: RoadName, tags: Tags, timestampEdited: Long) {
         for ((languageTag, name) in answer.localizedNames) {
             val key = when (languageTag) {
                 "" -> "name"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -73,7 +73,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>() {
         }
     }
 
-    private fun applyAnswerRoadName(answer: RoadName, tags: Tags, timestampEdited: Long) {
+    private fun applyAnswerRoadName(answer: RoadName, tags: Tags) {
         for ((languageTag, name) in answer.localizedNames) {
             val key = when (languageTag) {
                 "" -> "name"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfos
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BUILDING
@@ -52,7 +52,7 @@ class AddRoofShape(private val countryInfos: CountryInfos) : OsmElementQuestType
         return countryInfos.get(center.longitude, center.latitude).isRoofsAreUsuallyFlat
     }
 
-    override fun applyAnswerTo(answer: RoofShape, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: RoofShape, tags: Tags, timestampEdited: Long) {
         tags["roof:shape"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.ktx.toYesNo
@@ -36,7 +36,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = AddCyclewaySegregationForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("segregated", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.self_service
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.quests.self_service.SelfServiceLaundry.*
 
@@ -20,7 +20,7 @@ class AddSelfServiceLaundry : OsmFilterQuestType<SelfServiceLaundry>() {
 
     override fun createForm() = AddSelfServiceLaundryForm()
 
-    override fun applyAnswerTo(answer: SelfServiceLaundry, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SelfServiceLaundry, tags: Tags, timestampEdited: Long) {
         when(answer) {
             NO -> {
                 tags["self_service"] = "no"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.shop_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.*
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -48,7 +48,7 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
 
     override fun createForm() = ShopTypeForm()
 
-    override fun applyAnswerTo(answer: ShopTypeAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ShopTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is IsShopVacant -> {
                 tags.updateCheckDate()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.shop_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.removeCheckDates
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -49,7 +49,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
         tags.keys.containsAny(listOf("name", "brand", "operator"))
 
 
-    override fun applyAnswerTo(answer: ShopTypeAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ShopTypeAnswer, tags: Tags, timestampEdited: Long) {
         tags.removeCheckDates()
         when (answer) {
             is IsShopVacant -> {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shoulder/AddShoulder.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shoulder/AddShoulder.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.shoulder
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -65,7 +65,7 @@ class AddShoulder : OsmFilterQuestType<ShoulderSides>() {
 
     override fun createForm() = AddShoulderForm()
 
-    override fun applyAnswerTo(answer: ShoulderSides, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: ShoulderSides, tags: Tags, timestampEdited: Long) {
         tags["shoulder"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -110,7 +110,7 @@ class AddSidewalk : OsmElementQuestType<SidewalkSides> {
 
     override fun createForm() = AddSidewalkForm()
 
-    override fun applyAnswerTo(answer: SidewalkSides, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SidewalkSides, tags: Tags, timestampEdited: Long) {
         answer.applyTo(tags)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/Sidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/Sidewalk.kt
@@ -22,7 +22,7 @@ val SidewalkSides.simpleOsmValue: String? get() = when {
     else -> null
 }
 
-fun SidewalkSides.applyTo(tags: Tags, timestampEdited: Long) {
+fun SidewalkSides.applyTo(tags: Tags) {
     val sidewalkValue = simpleOsmValue
     if (sidewalkValue != null) {
         tags["sidewalk"] = sidewalkValue

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/Sidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/Sidewalk.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.sidewalk
 
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.quests.sidewalk.Sidewalk.*
 
 data class SidewalkSides(val left: Sidewalk, val right: Sidewalk)
@@ -22,7 +22,7 @@ val SidewalkSides.simpleOsmValue: String? get() = when {
     else -> null
 }
 
-fun SidewalkSides.applyTo(tags: StringMapChangesBuilder) {
+fun SidewalkSides.applyTo(tags: Tags, timestampEdited: Long) {
     val sidewalkValue = simpleOsmValue
     if (sidewalkValue != null) {
         tags["sidewalk"] = sidewalkValue

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.removeCheckDatesForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
@@ -49,7 +49,7 @@ class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
 
     override fun createForm() = AddSmoothnessForm()
 
-    override fun applyAnswerTo(answer: SmoothnessAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SmoothnessAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is SmoothnessValueAnswer -> {
                 tags.updateWithCheckDate("smoothness", answer.value.osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.removeCheckDatesForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
@@ -47,7 +47,7 @@ class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
 
     override fun createForm() = AddSmoothnessForm()
 
-    override fun applyAnswerTo(answer: SmoothnessAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SmoothnessAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is SmoothnessValueAnswer -> {
                 tags.updateWithCheckDate("smoothness", answer.value.osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.sport
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 class AddSport : OsmFilterQuestType<List<Sport>>() {
@@ -30,7 +30,7 @@ class AddSport : OsmFilterQuestType<List<Sport>>() {
 
     override fun createForm() = AddSportForm()
 
-    override fun applyAnswerTo(answer: List<Sport>, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: List<Sport>, tags: Tags, timestampEdited: Long) {
         tags["sport"] = answer.joinToString(";") { it.osmValue }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.step_count
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
 class AddStepCount : OsmFilterQuestType<Int>() {
@@ -28,7 +28,7 @@ class AddStepCount : OsmFilterQuestType<Int>() {
 
     override fun createForm() = AddStepCountForm()
 
-    override fun applyAnswerTo(answer: Int, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Int, tags: Tags, timestampEdited: Long) {
         tags["step_count"] = answer.toString()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.steps_incline
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.quests.steps_incline.StepsIncline.*
@@ -27,7 +27,7 @@ class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
 
     override fun createForm() = AddStepsInclineForm()
 
-    override fun applyAnswerTo(answer: StepsIncline, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: StepsIncline, tags: Tags, timestampEdited: Long) {
         tags["incline"] = when(answer) {
             UP -> "up"
             UP_REVERSED -> "down"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.steps_ramp
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
@@ -36,7 +36,7 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
 
     override fun createForm() = AddStepsRampForm()
 
-    override fun applyAnswerTo(answer: StepsRampAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: StepsRampAnswer, tags: Tags, timestampEdited: Long) {
         // special tagging if the wheelchair ramp is separate
         if (answer.wheelchairRamp == WheelchairRampStatus.SEPARATE) {
             val hasAnotherRamp = answer.bicycleRamp || answer.strollerRamp
@@ -64,7 +64,7 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
     }
 }
 
-private fun applyRampAnswer(tags: StringMapChangesBuilder, rampType: String, hasRamp: Boolean, rampTagForcedToBeYes: Boolean) {
+private fun applyRampAnswer(tags: Tags, rampType: String, hasRamp: Boolean, rampTagForcedToBeYes: Boolean) {
     if (hasRamp) {
         tags["ramp:$rampType"] = "yes"
     } else if(rampTagForcedToBeYes) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.street_parking
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -79,7 +79,7 @@ class AddStreetParking : OsmFilterQuestType<LeftAndRightStreetParking>() {
 
     override fun createForm() = AddStreetParkingForm()
 
-    override fun applyAnswerTo(answer: LeftAndRightStreetParking, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: LeftAndRightStreetParking, tags: Tags, timestampEdited: Long) {
         /* Note: If a resurvey is implemented, old
            parking:lane:*:(parallel|diagonal|perpendicular|...) values must be cleaned up */
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.summit_register
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
@@ -67,7 +67,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("summit:register", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
@@ -36,7 +36,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
     override fun createForm() = AddPathPartSurfaceForm()
 
-    override fun applyAnswerTo(answer: SurfaceAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SurfaceAnswer, tags: Tags, timestampEdited: Long) {
         answer.applyTo(tags, "cycleway:surface")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
@@ -36,7 +36,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
     override fun createForm() = AddPathPartSurfaceForm()
 
-    override fun applyAnswerTo(answer: SurfaceAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SurfaceAnswer, tags: Tags, timestampEdited: Long) {
         answer.applyTo(tags, "footway:surface")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.surface
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
@@ -46,7 +46,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
 
     override fun createForm() = AddPathSurfaceForm()
 
-    override fun applyAnswerTo(answer: SurfaceOrIsStepsAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SurfaceOrIsStepsAnswer, tags: Tags, timestampEdited: Long) {
         when(answer) {
             is SurfaceAnswer -> {
                 answer.applyTo(tags, "surface")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 
 
@@ -53,7 +53,7 @@ class AddPitchSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
     override fun createForm() = AddPitchSurfaceForm()
 
-    override fun applyAnswerTo(answer: SurfaceAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SurfaceAnswer, tags: Tags, timestampEdited: Long) {
         answer.applyTo(tags, "surface")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.surface
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
@@ -45,7 +45,7 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
 
     override fun createForm() = AddRoadSurfaceForm()
 
-    override fun applyAnswerTo(answer: SurfaceAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: SurfaceAnswer, tags: Tags, timestampEdited: Long) {
         answer.applyTo(tags, "surface")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
@@ -2,14 +2,14 @@ package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.data.meta.removeCheckDatesForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 
 sealed class SurfaceOrIsStepsAnswer
 object IsActuallyStepsAnswer : SurfaceOrIsStepsAnswer()
 
 data class SurfaceAnswer(val value: Surface, val note: String? = null) : SurfaceOrIsStepsAnswer()
 
-fun SurfaceAnswer.applyTo(tags: StringMapChangesBuilder, key: String) {
+fun SurfaceAnswer.applyTo(tags: Tags, key: String) {
     val osmValue = value.osmValue
     val previousOsmValue = tags[key]
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.tactile_paving
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.ktx.toYesNo
 
@@ -44,7 +44,7 @@ class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = TactilePavingForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("tactile_paving", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
@@ -61,7 +61,7 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
 
     override fun createForm() = TactilePavingForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("tactile_paving", answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
@@ -41,7 +41,7 @@ class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
         if (!eligibleKerbsFilter.matches(element) || element !is Node || !element.couldBeAKerb()) false
         else null
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("tactile_paving", answer.toYesNo())
         tags["barrier"] = "kerb"
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.toilet_availability
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -33,7 +33,7 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["toilets"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.toilets_fee
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.ktx.toYesNo
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
@@ -26,7 +26,7 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["fee"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.tourism_information
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
@@ -25,7 +25,7 @@ class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
 
     override fun createForm() = AddInformationForm()
 
-    override fun applyAnswerTo(answer: TourismInformation, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: TourismInformation, tags: Tags, timestampEdited: Long) {
         tags["information"] = answer.osmValue
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 
 class AddTracktype : OsmFilterQuestType<Tracktype>() {
@@ -32,7 +32,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
 
     override fun createForm() = AddTracktypeForm()
 
-    override fun applyAnswerTo(answer: Tracktype, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Tracktype, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("tracktype", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingType.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.traffic_calming_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
@@ -18,7 +18,7 @@ class AddTrafficCalmingType : OsmFilterQuestType<TrafficCalmingType>() {
 
     override fun createForm() = AddTrafficCalmingTypeForm()
 
-    override fun applyAnswerTo(answer: TrafficCalmingType, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: TrafficCalmingType, tags: Tags, timestampEdited: Long) {
         tags["traffic_calming"] = answer.osmValue
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_button/AddTrafficSignalsButton.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.traffic_signals_button
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
@@ -32,7 +32,7 @@ class AddTrafficSignalsButton : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags["button_operated"] = answer.toYesNo()
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.traffic_signals_sound
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -57,7 +57,7 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
 
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate(SOUND_SIGNALS, answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.traffic_signals_vibrate
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -57,7 +57,7 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
 
     override fun createForm() = AddTrafficSignalsVibrationForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate(VIBRATING_BUTTON, answer.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.way_lit
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.MAXSPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
@@ -62,7 +62,7 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
 
     override fun createForm() = WayLitForm()
 
-    override fun applyAnswerTo(answer: WayLitOrIsStepsAnswer, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WayLitOrIsStepsAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is IsActuallyStepsAnswer -> tags["highway"] = "steps"
             is WayLit -> tags.updateWithCheckDate("lit", answer.osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -4,7 +4,7 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.isKindOfShopExpression
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -115,7 +115,7 @@ class AddWheelchairAccessBusiness(
 
     override fun createForm() = AddWheelchairAccessBusinessForm()
 
-    override fun applyAnswerTo(answer: WheelchairAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WheelchairAccess, tags: Tags, timestampEdited: Long) {
         tags["wheelchair"] = answer.osmValue
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
@@ -25,7 +25,7 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
 
     override fun createForm() = AddWheelchairAccessOutsideForm()
 
-    override fun applyAnswerTo(answer: WheelchairAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WheelchairAccess, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>() {
@@ -47,7 +47,7 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>(
 
     override fun createForm() = AddWheelchairAccessPublicTransportForm()
 
-    override fun applyAnswerTo(answer: WheelchairAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WheelchairAccess, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
 class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
@@ -32,7 +32,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
 
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
-    override fun applyAnswerTo(answer: WheelchairAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WheelchairAccess, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.RARE
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
 
@@ -32,7 +32,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
 
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
-    override fun applyAnswerTo(answer: WheelchairAccess, tags: StringMapChangesBuilder) {
+    override fun applyAnswerTo(answer: WheelchairAccess, tags: Tags, timestampEdited: Long) {
         tags.updateWithCheckDate("toilets:wheelchair", answer.osmValue)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
 import de.westnordost.streetcomplete.BaseActivity
 import javax.inject.Inject
@@ -141,7 +140,7 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractQuestAnswerFragment.Liste
 
     override fun onAnsweredQuest(questKey: QuestKey, answer: Any) {
         val builder = StringMapChangesBuilder(mapOf())
-        (currentQuestType as? OsmElementQuestType<Any>)?.applyAnswerTo(answer, builder)
+        (currentQuestType as? OsmElementQuestType<Any>)?.applyAnswerTo(answer, builder, 0)
         val tagging = builder.create().changes.joinToString("\n")
         AlertDialog.Builder(this)
             .setMessage("Tagging\n$tagging")

--- a/app/src/main/res/drawable/ic_quest_opening_hours_signed.xml
+++ b/app/src/main/res/drawable/ic_quest_opening_hours_signed.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+  <path
+      android:pathData="m128,64c0,35.346 -28.654,64 -64,64s-64,-28.654 -64,-64 28.654,-64 64,-64 64,28.654 64,64"
+      android:fillColor="#e9a76f"/>
+  <path
+      android:pathData="M35.082,28L92.918,28A11.082,11.082 0,0 1,104 39.082L104,96.918A11.082,11.082 0,0 1,92.918 108L35.082,108A11.082,11.082 0,0 1,24 96.918L24,39.082A11.082,11.082 0,0 1,35.082 28z"
+      android:strokeAlpha="0.2"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M35.082,24L92.918,24A11.082,11.082 0,0 1,104 35.082L104,92.918A11.082,11.082 0,0 1,92.918 104L35.082,104A11.082,11.082 0,0 1,24 92.918L24,35.082A11.082,11.082 0,0 1,35.082 24z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8"
+      android:fillColor="#fcfcfc"
+      android:strokeColor="#666"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m64,64 l-23.236,-13.955"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8"
+      android:strokeColor="#666"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M91.838,46.045 L64,64"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:strokeColor="#666"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m72.03,64a8.03,8.015 0,0 1,-8.03 8.015,8.03 8.015,0 0,1 -8.03,-8.015 8.03,8.015 0,0 1,8.03 -8.015,8.03 8.015,0 0,1 8.03,8.015"
+      android:fillColor="#444"/>
+</vector>

--- a/app/src/main/res/raw/changelog.yml
+++ b/app/src/main/res/raw/changelog.yml
@@ -4,7 +4,7 @@ v40.0-beta1: |
   <li><i>How does this road cross the barrier here?</i> (#3372, #3515), by @matkoniecz</li>
   <li><i>Can you pump gas yourself at this fuel station?</i> (#2822, #1827), by @naposm</li>
   <li><i>Does this place have air conditioning?</i> (#3641, #3127), by @coolultra1</li>
-  <li><i>Are the opening hours signed for this place?</i>, in intervals asked for places that have previously been tagged as having no signed opening hours (#3130)</li>
+  <li><i>Are the opening hours signed for this place?</i>, in intervals asked for places that have previously been tagged as having no signed opening hours (#3682, #3130)</li>
   </ul>
   <h3>Quest enhancements</h3>
   <ul>

--- a/app/src/main/res/raw/changelog.yml
+++ b/app/src/main/res/raw/changelog.yml
@@ -4,6 +4,7 @@ v40.0-beta1: |
   <li><i>How does this road cross the barrier here?</i> (#3372, #3515), by @matkoniecz</li>
   <li><i>Can you pump gas yourself at this fuel station?</i> (#2822, #1827), by @naposm</li>
   <li><i>Does this place have air conditioning?</i> (#3641, #3127), by @coolultra1</li>
+  <li><i>Are the opening hours signed for this place?</i>, in intervals asked for places that have previously been tagged as having no signed opening hours (#3130)</li>
   </ul>
   <h3>Quest enhancements</h3>
   <ul>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,11 @@
     <string name="quest_openingHours_name_title">"What are the opening hours of %s?"</string>
     <string name="quest_openingHours_name_type_title">"What are the opening hours of %1$s (%2$s)?"</string>
     <string name="quest_openingHours_no_name_title">"What are the opening hours of this place? (%s)"</string>
+
+    <string name="quest_openingHours_signed_name_title">"Are the opening hours signed for %s?"</string>
+    <string name="quest_openingHours_signed_name_type_title">"Are the opening hours signed for %1$s (%2$s)?"</string>
+    <string name="quest_openingHours_signed_no_name_title">"Are the opening hours of this place signed? (%s)"</string>
+
     <string name="quest_openingHours_resurvey_name_title">"Are these opening hours for %s still correct?"</string>
     <string name="quest_openingHours_resurvey_name_type_title">"Are these opening hours for %1$s (%2$s) still correct?"</string>
     <string name="quest_openingHours_resurvey_no_name_title">"Are these opening hours still correct (%s)?"</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.meta
 
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.ktx.containsExactlyInAnyOrder
 import org.junit.Assert.*
 import org.junit.Test
@@ -20,7 +20,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate adds new tag`() {
-        val builder = StringMapChangesBuilder(emptyMap())
+        val builder = Tags(emptyMap())
         builder.updateWithCheckDate("new key", "tag")
         val changes = builder.create().changes
 
@@ -30,21 +30,21 @@ class ResurveyUtilsTest {
     }
 
     @Test fun hasCheckDateForKey() {
-        assertFalse(StringMapChangesBuilder(mapOf("key" to "value")).hasCheckDateForKey("key"))
+        assertFalse(Tags(mapOf("key" to "value")).hasCheckDateForKey("key"))
 
-        assertFalse(StringMapChangesBuilder(mapOf(
+        assertFalse(Tags(mapOf(
             "key" to "value",
             "check_date:another_key" to "value"
         )).hasCheckDateForKey("key"))
 
-        assertTrue(StringMapChangesBuilder(mapOf(
+        assertTrue(Tags(mapOf(
             "key" to "value",
             "check_date:another_key" to "value"
         )).hasCheckDateForKey("another_key"))
     }
 
     @Test fun `updateWithCheckDate modifies tag`() {
-        val builder = StringMapChangesBuilder(mapOf("old key" to "old value"))
+        val builder = Tags(mapOf("old key" to "old value"))
         builder.updateWithCheckDate("old key", "new value")
         val changes = builder.create().changes
 
@@ -54,7 +54,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate adds check date`() {
-        val builder = StringMapChangesBuilder(mapOf("key" to "value"))
+        val builder = Tags(mapOf("key" to "value"))
         builder.updateWithCheckDate("key", "value")
         val changes = builder.create().changes
 
@@ -64,7 +64,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate modifies check date`() {
-        val builder = StringMapChangesBuilder(mapOf("key" to "value", "check_date:key" to "2000-11-11"))
+        val builder = Tags(mapOf("key" to "value", "check_date:key" to "2000-11-11"))
         builder.updateWithCheckDate("key", "value")
         val changes = builder.create().changes
 
@@ -74,7 +74,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate modifies old check date on modifying key`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "key" to "old value",
             "key:check_date" to "2000-11-01",
             "check_date:key" to "2000-11-02",
@@ -98,7 +98,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate modifies old check dates on adding key`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "key:check_date" to "2000-11-01",
             "check_date:key" to "2000-11-02",
             "key:lastcheck" to "2000-11-03",
@@ -121,7 +121,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateWithCheckDate removes old check dates on modifying check date`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "key" to "value",
             "check_date:key" to "2000-11-01",
             "key:check_date" to "2000-11-02",
@@ -144,7 +144,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDateForKey adds check date`() {
-        val builder = StringMapChangesBuilder(mapOf())
+        val builder = Tags(mapOf())
         builder.updateCheckDateForKey("key")
         val changes = builder.create().changes
 
@@ -154,7 +154,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDateForKey modifies check date`() {
-        val builder = StringMapChangesBuilder(mapOf("check_date:key" to "2000-11-11"))
+        val builder = Tags(mapOf("check_date:key" to "2000-11-11"))
         builder.updateCheckDateForKey("key")
         val changes = builder.create().changes
 
@@ -164,7 +164,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDateForKey removes old check dates on modifying check date`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "check_date:key" to "2000-11-01",
             "key:check_date" to "2000-11-02",
             "key:lastcheck" to "2000-11-03",
@@ -186,7 +186,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDate adds check date`() {
-        val builder = StringMapChangesBuilder(mapOf())
+        val builder = Tags(mapOf())
         builder.updateCheckDate()
         val changes = builder.create().changes
 
@@ -196,7 +196,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDate modifies check date`() {
-        val builder = StringMapChangesBuilder(mapOf("check_date" to "2000-11-11"))
+        val builder = Tags(mapOf("check_date" to "2000-11-11"))
         builder.updateCheckDate()
         val changes = builder.create().changes
 
@@ -206,7 +206,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `updateCheckDate removes old check dates on modifying check date`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "check_date" to "2000-11-01",
             "lastcheck" to "2000-11-02",
             "last_checked" to "2000-11-03",
@@ -222,7 +222,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteCheckDates does not add a check date`() {
-        val builder = StringMapChangesBuilder(mapOf())
+        val builder = Tags(mapOf())
         builder.removeOtherCheckDates()
         val changes = builder.create().changes
 
@@ -230,7 +230,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteCheckDates removes check date`() {
-        val builder = StringMapChangesBuilder(mapOf("check_date" to "2000-11-11"))
+        val builder = Tags(mapOf("check_date" to "2000-11-11"))
         builder.removeCheckDates()
         val changes = builder.create().changes
 
@@ -240,7 +240,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteCheckDates removes all check dates`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "check_date" to "2000-11-01",
             "lastcheck" to "2000-11-02",
             "last_checked" to "2000-11-03",
@@ -256,7 +256,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteOtherCheckDates does not add a check date`() {
-        val builder = StringMapChangesBuilder(mapOf())
+        val builder = Tags(mapOf())
         builder.removeOtherCheckDates()
         val changes = builder.create().changes
 
@@ -264,7 +264,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteOtherCheckDates does not modify check date`() {
-        val builder = StringMapChangesBuilder(mapOf("check_date" to "2000-11-11"))
+        val builder = Tags(mapOf("check_date" to "2000-11-11"))
         builder.removeOtherCheckDates()
         val changes = builder.create().changes
 
@@ -272,7 +272,7 @@ class ResurveyUtilsTest {
     }
 
     @Test fun `deleteOtherCheckDates removes other check dates but does not touch check date`() {
-        val builder = StringMapChangesBuilder(mapOf(
+        val builder = Tags(mapOf(
             "check_date" to "2000-11-01",
             "lastcheck" to "2000-11-02",
             "last_checked" to "2000-11-03",

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/TestQuestTypes.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.data.quest
 
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement
@@ -12,7 +12,7 @@ open class TestQuestTypeA : OsmElementQuestType<String> {
 
     override fun getTitle(tags: Map<String, String>) = 0
     override fun isApplicableTo(element: Element):Boolean? = null
-    override fun applyAnswerTo(answer: String, tags: StringMapChangesBuilder) {}
+    override fun applyAnswerTo(answer: String, tags: Tags, timestampEdited: Long) {}
     override fun createForm(): AbstractQuestAnswerFragment<String> = object : AbstractQuestAnswerFragment<String>() {}
     override val changesetComment = "test me"
     override fun getApplicableElements(mapData: MapDataWithGeometry) = mapData.filter { isApplicableTo(it) == true }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddSidewalkTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddSidewalkTest.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.quests.sidewalk.AddSidewalk
-import de.westnordost.streetcomplete.quests.sidewalk.SeparatelyMapped
+import de.westnordost.streetcomplete.quests.sidewalk.Sidewalk.*
 import de.westnordost.streetcomplete.quests.sidewalk.SidewalkSides
 import de.westnordost.streetcomplete.util.translate
 import de.westnordost.streetcomplete.testutils.way
@@ -105,36 +105,50 @@ class AddSidewalkTest {
 
     @Test fun `apply no sidewalk answer`() {
         questType.verifyAnswer(
-            SidewalkSides(left = false, right = false),
+            SidewalkSides(left = NO, right = NO),
             StringMapEntryAdd("sidewalk", "no")
         )
     }
 
     @Test fun `apply sidewalk left answer`() {
         questType.verifyAnswer(
-            SidewalkSides(left = true, right = false),
+            SidewalkSides(left = YES, right = NO),
             StringMapEntryAdd("sidewalk", "left")
         )
     }
 
     @Test fun `apply sidewalk right answer`() {
         questType.verifyAnswer(
-            SidewalkSides(left = false, right = true),
+            SidewalkSides(left = NO, right = YES),
             StringMapEntryAdd("sidewalk", "right")
         )
     }
 
     @Test fun `apply sidewalk on both sides answer`() {
         questType.verifyAnswer(
-            SidewalkSides(left = true, right = true),
+            SidewalkSides(left = YES, right = YES),
             StringMapEntryAdd("sidewalk", "both")
         )
     }
 
     @Test fun `apply separate sidewalk answer`() {
         questType.verifyAnswer(
-            SeparatelyMapped,
+            SidewalkSides(left = SEPARATE, right = SEPARATE),
             StringMapEntryAdd("sidewalk", "separate")
+        )
+    }
+
+    @Test fun `apply separate sidewalk on one side answer`() {
+        questType.verifyAnswer(
+            SidewalkSides(left = YES, right = SEPARATE),
+            StringMapEntryAdd("sidewalk:left", "yes"),
+            StringMapEntryAdd("sidewalk:right", "separate"),
+        )
+
+        questType.verifyAnswer(
+            SidewalkSides(left = SEPARATE, right = NO),
+            StringMapEntryAdd("sidewalk:left", "separate"),
+            StringMapEntryAdd("sidewalk:right", "no"),
         )
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/OsmElementQuestType.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/OsmElementQuestType.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.quests
 
-import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 
 import org.assertj.core.api.Assertions.*
 
 fun <T> OsmElementQuestType<T>.verifyAnswer(tags:Map<String,String>, answer:T, vararg expectedChanges: StringMapEntryChange) {
     val cb = StringMapChangesBuilder(tags)
-    this.applyAnswerTo(answer, cb)
+    this.applyAnswerTo(answer, cb, 0)
     val changes = cb.create().changes
     assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeTest.kt
@@ -31,6 +31,7 @@ class AddStileTypeTest {
             ),
             StileType.SQUEEZER,
             StringMapEntryAdd("check_date", LocalDate.now().toCheckDateString()),
+            StringMapEntryModify("stile", "squeezer", "squeezer"),
         )
     }
 
@@ -47,6 +48,7 @@ class AddStileTypeTest {
             StileType.STEPOVER_STONE,
             StringMapEntryDelete("steps", "5"),
             StringMapEntryModify("material", "wood", "stone"),
+            StringMapEntryModify("stile", "stepover", "stepover"),
         )
     }
 
@@ -90,6 +92,7 @@ class AddStileTypeTest {
             ),
             StileType.STEPOVER_WOODEN,
             StringMapEntryAdd("stile", "stepover"),
+            StringMapEntryModify("material", "wood", "wood"),
         )
     }
 
@@ -119,6 +122,9 @@ class AddStileTypeTest {
             ),
             StileType.STEPOVER_WOODEN,
             StringMapEntryAdd("check_date", LocalDate.now().toCheckDateString()),
+            StringMapEntryModify("stile", "stepover", "stepover"),
+            StringMapEntryModify("material", "wood", "wood"),
+
         )
     }
 
@@ -131,6 +137,7 @@ class AddStileTypeTest {
             ),
             StileType.STEPOVER_WOODEN,
             StringMapEntryAdd("material", "wood"),
+            StringMapEntryModify("stile", "stepover", "stepover"),
         )
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
@@ -1,0 +1,89 @@
+package de.westnordost.streetcomplete.quests.opening_hours_signed
+
+import de.westnordost.streetcomplete.data.meta.toCheckDateString
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
+import de.westnordost.streetcomplete.quests.verifyAnswer
+import de.westnordost.streetcomplete.testutils.mock
+import de.westnordost.streetcomplete.testutils.node
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class CheckOpeningHoursSignedTest {
+    private val questType = CheckOpeningHoursSigned(mock())
+
+    @Test fun `is applicable to old place`() {
+        assertTrue(questType.isApplicableTo(node(timestamp = 0, tags = mapOf(
+            "name" to "XYZ",
+            "opening_hours:signed" to "no"
+        ))))
+    }
+
+    @Test fun `is not applicable to new place`() {
+        assertFalse(questType.isApplicableTo(node(tags = mapOf(
+            "name" to "XYZ",
+            "opening_hours:signed" to "no"
+        ))))
+    }
+
+
+    @Test fun `is applicable to place with old check_date`() {
+        assertTrue(questType.isApplicableTo(node(tags = mapOf(
+            "name" to "XYZ",
+            "check_date:opening_hours" to "2020-12-12",
+            "opening_hours:signed" to "no"
+        ))))
+    }
+
+    @Test fun `is not applicable to place with new check_date`() {
+        assertFalse(questType.isApplicableTo(node(tags = mapOf(
+            "name" to "XYZ",
+            "check_date:opening_hours" to LocalDate.now().toCheckDateString(),
+            "opening_hours:signed" to "no"
+        ))))
+    }
+
+    @Test fun `apply yes answer with no prior check date`() {
+        questType.verifyAnswer(
+            mapOf("opening_hours:signed" to "no"),
+            true,
+            StringMapEntryDelete("opening_hours:signed", "no"),
+            StringMapEntryAdd("check_date:opening_hours", "1970-01-01"),
+        )
+    }
+
+    @Test fun `apply yes answer with prior check date`() {
+        questType.verifyAnswer(
+            mapOf(
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours" to "2020-03-04"
+            ),
+            true,
+            StringMapEntryDelete("opening_hours:signed", "no"),
+        )
+    }
+
+    @Test fun `apply no answer`() {
+        questType.verifyAnswer(
+            mapOf("opening_hours:signed" to "no"),
+            false,
+            StringMapEntryModify("opening_hours:signed", "no", "no"),
+            StringMapEntryAdd("check_date:opening_hours", LocalDate.now().toCheckDateString()),
+        )
+    }
+
+    @Test fun `apply no answer with prior check date`() {
+        questType.verifyAnswer(
+            mapOf(
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours" to "2020-03-04"
+            ),
+            false,
+            StringMapEntryModify("opening_hours:signed", "no", "no"),
+            StringMapEntryModify("check_date:opening_hours", "2020-03-04", LocalDate.now().toCheckDateString()),
+        )
+    }
+}

--- a/res/graphics/quest icons/opening_hours_signed.svg
+++ b/res/graphics/quest icons/opening_hours_signed.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+ <path d="m128 64c0 35.346-28.654 64-64 64s-64-28.654-64-64 28.654-64 64-64 64 28.654 64 64" fill="#e9a76f" stroke-width=".2"/>
+ <rect x="24" y="28" width="80" height="80" ry="11.082" fill="none" stroke="#000" stroke-dashoffset="3" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".2" stroke-width="8"/>
+ <rect x="24" y="24" width="80" height="80" ry="11.082" fill="#fcfcfc" fill-rule="evenodd" stroke="#666" stroke-dashoffset="3" stroke-linecap="round" stroke-linejoin="round" stroke-width="8"/>
+ <path d="m64 64-23.236-13.955" fill="none" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="8"/>
+ <path d="M 91.838,46.045 64,64" fill="none" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"/>
+ <path d="m72.03 64a8.0303 8.0146 0 0 1-8.0302 8.0146 8.0303 8.0146 0 0 1-8.0303-8.0146 8.0303 8.0146 0 0 1 8.0303-8.0146 8.0303 8.0146 0 0 1 8.0302 8.0146" fill="#444" style="paint-order:normal"/>
+</svg>


### PR DESCRIPTION
Ask every year whether places that have been tagged with having no opening hours sign (now) have one. This way, implictly, POIs with no (signed) opening hours are checked every year whether they are still there. Also, maybe they have an opening hours sign now. Fixes #3130.
Direct link to the new quest source code: https://github.com/streetcomplete/StreetComplete/compare/opening-hours-signed-resurvey?expand=1#diff-b05845227ebb46097644bc5eab15e1b36ece352cb19d1bc7489cf0f124950c08

Furthermore, typealiased `StringMapChangesBuilder` to `Tags`, simply because it is shorter.

This PR was mentioned in #3680