### PR TITLE
Only allow lit quest to change to steps on footway

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
@@ -25,7 +25,7 @@ class WayLitForm : AbstractQuestAnswerFragment<WayLitOrIsStepsAnswer>() {
 
     private fun createConvertToStepsAnswer(): AnswerItem? {
         val way = osmElement as? Way ?: return null
-        if (way.isArea() || way.tags["highway"] == "steps") return null
+        if (way.isArea() || way.tags["highway"] != "footway") return null
 
         return AnswerItem(R.string.quest_generic_answer_is_actually_steps) {
             applyAnswer(IsActuallyStepsAnswer)


### PR DESCRIPTION
At the moment the lit quest can change any highway to steps.

I have no evidence of this producing bad data, but the steps other answer should only be shown on ways that are likely to be steps.

I think that the only highway that the lit quest is shown for that could be changed to steps is `footway`.

Maybe this code isn't as readable now, it could be changed to more clearly only return the steps answer for `footway` which isn't an area - should I do that?