### PR TITLE
Tweak amount of answer history considered in recently-used values

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -98,7 +98,7 @@ abstract class AGroupedImageListQuestAnswerFragment<I, T> : AbstractQuestFormAns
     }
 
     private fun getInitialItems(): List<GroupableDisplayItem<I>> =
-        favs.get().mostCommonWithin(6, historyCount = 30, first = 1).padWith(topItems).toList()
+        favs.get().mostCommonWithin(6, historyCount = 50, first = 1).padWith(topItems).toList()
 
     override fun onClickOk() {
         val item = selectedItem!!

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -31,7 +31,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
 
     private val lastPickedAnswers by lazy {
         favs.get()
-            .mostCommonWithin(target = 5, historyCount = 30, first = 1)
+            .mostCommonWithin(target = 5, historyCount = 15, first = 1)
             .sortedWith(compareBy<BuildingLevelsAnswer> { it.levels }.thenBy { it.roofLevels })
             .toList()
     }


### PR DESCRIPTION
- Building levels `historyCount`: 30 → 15
- Building type `historyCount`: 30 → 50

Fixes #3593