### PR TITLE
Make the questName regex more robust

### DIFF
--- a/buildSrc/src/main/java/GenerateQuestListTask.kt
+++ b/buildSrc/src/main/java/GenerateQuestListTask.kt
@@ -37,9 +37,9 @@ open class GenerateQuestListTask : DefaultTask() {
     @TaskAction
     fun run() {
         val questFileContent = sourceDirectory.resolve("quests/QuestsModule.kt").readText()
-        val questNameRegex = Regex("(?<=^ {4})[A-Z][a-zA-Z]+(?=\\()", RegexOption.MULTILINE)
+        val questNameRegex = Regex("^\s+([A-Z][a-zA-Z]+)\\(", RegexOption.MULTILINE)
         val questNames =
-            listOf(noteQuestName) + questNameRegex.findAll(questFileContent).map { it.value }
+            listOf(noteQuestName) + questNameRegex.findAll(questFileContent).map { it.groupValues[1] }
 
         val questFiles = sourceDirectory.resolve("quests/").listFilesRecursively()
         val strings = getStrings(projectDirectory.resolve("app/src/main/res/values/strings.xml"))


### PR DESCRIPTION
Improve on c1a7d1eea9daabed2185118636851b12e1bbc132

Untested, but based on some Kotlin I've been using in #2754