### PR TITLE
Improve database performance

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
@@ -40,10 +40,13 @@ class StreetCompleteSQLiteOpenHelper(context: Context, dbName: String) :
         db.execSQL(NoteEditsTable.NOTE_ID_INDEX_CREATE)
 
         // OSM map data
-        db.execSQL(ElementGeometryTable.CREATE)
-        db.execSQL(ElementGeometryTable.SPATIAL_INDEX_CREATE)
+        db.execSQL(ElementGeometryTable.CREATE_WAYS)
+        db.execSQL(ElementGeometryTable.CREATE_RELATIONS)
+        db.execSQL(ElementGeometryTable.SPATIAL_INDEX_CREATE_WAYS)
+        db.execSQL(ElementGeometryTable.SPATIAL_INDEX_CREATE_RELATIONS)
 
         db.execSQL(NodeTable.CREATE)
+        db.execSQL(NodeTable.SPATIAL_INDEX_CREATE)
 
         db.execSQL(WayTables.CREATE)
         db.execSQL(WayTables.NODES_CREATE)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryTable.kt
@@ -1,11 +1,11 @@
 package de.westnordost.streetcomplete.data.osm.geometry
 
 object ElementGeometryTable {
-    const val NAME = "elements_geometry"
+    const val NAME_RELATIONS = "elements_geometry_relations"
+    const val NAME_WAYS = "elements_geometry_ways"
 
     object Columns {
-        const val ELEMENT_ID = "element_id"
-        const val ELEMENT_TYPE = "element_type"
+        const val ID = "id"
         const val GEOMETRY_POLYGONS = "geometry_polygons"
         const val GEOMETRY_POLYLINES = "geometry_polylines"
         const val CENTER_LATITUDE = "latitude"
@@ -16,10 +16,9 @@ object ElementGeometryTable {
         const val MAX_LONGITUDE = "max_lon"
     }
 
-    const val CREATE = """
-        CREATE TABLE $NAME (
-            ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
-            ${Columns.ELEMENT_ID} int NOT NULL,
+    const val CREATE_WAYS = """
+        CREATE TABLE $NAME_WAYS (
+            ${Columns.ID} int PRIMARY KEY,
             ${Columns.GEOMETRY_POLYLINES} blob,
             ${Columns.GEOMETRY_POLYGONS} blob,
             ${Columns.CENTER_LATITUDE} double NOT NULL,
@@ -27,16 +26,33 @@ object ElementGeometryTable {
             ${Columns.MIN_LATITUDE} double NOT NULL,
             ${Columns.MAX_LATITUDE} double NOT NULL,
             ${Columns.MIN_LONGITUDE} double NOT NULL,
-            ${Columns.MAX_LONGITUDE} double NOT NULL,
-            CONSTRAINT primary_key PRIMARY KEY (
-                ${Columns.ELEMENT_TYPE},
-                ${Columns.ELEMENT_ID}
-            )
+            ${Columns.MAX_LONGITUDE} double NOT NULL
+        );"""
+
+    const val CREATE_RELATIONS = """
+        CREATE TABLE $NAME_RELATIONS (
+            ${Columns.ID} int PRIMARY KEY,
+            ${Columns.GEOMETRY_POLYLINES} blob,
+            ${Columns.GEOMETRY_POLYGONS} blob,
+            ${Columns.CENTER_LATITUDE} double NOT NULL,
+            ${Columns.CENTER_LONGITUDE} double NOT NULL,
+            ${Columns.MIN_LATITUDE} double NOT NULL,
+            ${Columns.MAX_LATITUDE} double NOT NULL,
+            ${Columns.MIN_LONGITUDE} double NOT NULL,
+            ${Columns.MAX_LONGITUDE} double NOT NULL
+        );"""
+
+    const val SPATIAL_INDEX_CREATE_WAYS = """
+        CREATE INDEX elements_geometry_bounds_index_ways ON $NAME_WAYS (
+            ${Columns.MIN_LATITUDE},
+            ${Columns.MAX_LATITUDE},
+            ${Columns.MIN_LONGITUDE},
+            ${Columns.MAX_LONGITUDE}
         );
     """
 
-    const val SPATIAL_INDEX_CREATE = """
-        CREATE INDEX elements_geometry_bounds_index ON $NAME (
+    const val SPATIAL_INDEX_CREATE_RELATIONS = """
+        CREATE INDEX elements_geometry_bounds_index_relations ON $NAME_RELATIONS (
             ${Columns.MIN_LATITUDE},
             ${Columns.MAX_LATITUDE},
             ${Columns.MIN_LONGITUDE},

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/NodeTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/NodeTable.kt
@@ -24,4 +24,11 @@ object NodeTable {
             ${Columns.LAST_SYNC} int NOT NULL
         );
     """
+
+    const val SPATIAL_INDEX_CREATE = """
+        CREATE INDEX osm_nodes_spatial_index ON $NAME (
+            ${Columns.LATITUDE},
+            ${Columns.LONGITUDE}
+        );
+    """
 }


### PR DESCRIPTION
`ElementGeometryDao` is optimized in this PR, see https://github.com/streetcomplete/StreetComplete/issues/3609#issuecomment-1031177576 for performance comparison with current version.

The element geometry table is split into separate tables for ways and relations to avoid slow `queryIn` in `getAllEntries(keys)`.
Nodes do not have a separate geometry table, as nodes have a simple point geometry that can be created from the node position.

A spatial index is added to `NodeTable`, and some functions for querying nodes inside a bbox are added to `NodeDao` (equivalents to functions in `ElementGeometryDao`).

`MapDataController.getMapDataWithGeometry` makes use of the the new table layout by not querying node geometry and data separatly, instead point geometry is created from node positions.

Still a draft, because database upgrade is missing and tests have not been updated yet.