### PR TITLE
deleting offices with shop replacement enabled

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -239,11 +239,14 @@ abstract class AbstractQuestAnswerFragment<T> :
                 && osmElement?.type == ElementType.NODE
         val isReplaceShopEnabled = (questType as? OsmElementQuestType)?.isReplaceShopEnabled == true
         if (!isDeletePoiEnabled && !isReplaceShopEnabled) return null
-        check(!(isDeletePoiEnabled && isReplaceShopEnabled)) {
-            "Only isDeleteElementEnabled OR isReplaceShopEnabled may be true at the same time"
-        }
 
         return AnswerItem(R.string.quest_generic_answer_does_not_exist) {
+            val element = osmElement
+            if(element != null) {
+                if (element.isSomeKindOfShop()) {
+                    if (isReplaceShopEnabled) replaceShopElement()
+                }
+            }
             if (isDeletePoiEnabled) deletePoiNode()
             else if (isReplaceShopEnabled) replaceShopElement()
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -59,6 +59,7 @@ class AddAcceptsCash(
     override val wikiLink = "Key:payment"
     override val icon = R.drawable.ic_quest_cash
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
 
     override val enabledInCountries = NoCountriesExcept("SE")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
@@ -22,6 +22,7 @@ class AddAirConditioning : OsmFilterQuestType<Boolean>() {
     override val wikiLink = "Key:air_conditioning"
     override val icon = R.drawable.ic_quest_snow_poi
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside_regional_warning
 
     override val questTypeAchievements = listOf(CITIZEN)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -26,6 +26,7 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_baby
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
 
     override val questTypeAchievements = listOf(CITIZEN)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -108,6 +108,7 @@ class AddOpeningHours(
     override val wikiLink = "Key:opening_hours"
     override val icon = R.drawable.ic_quest_opening_hours
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
 
     override val questTypeAchievements = listOf(CITIZEN)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -47,6 +47,7 @@ class CheckOpeningHoursSigned (
     override val wikiLink = "Key:opening_hours:signed"
     override val icon = R.drawable.ic_quest_opening_hours_signed
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
     override val questTypeAchievements = listOf(CITIZEN)
 
     override fun getTitle(tags: Map<String, String>): Int {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -109,6 +109,7 @@ class AddPlaceName(
     override val wikiLink = "Key:name"
     override val icon = R.drawable.ic_quest_label
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
 
     override val questTypeAchievements = listOf(CITIZEN)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -24,6 +24,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccess>() {
     override val wikiLink = "Key:toilets:wheelchair"
     override val icon = R.drawable.ic_quest_toilets_wheelchair
     override val isReplaceShopEnabled = true
+    override val isDeleteElementEnabled = true
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
 
     override val questTypeAchievements = listOf(RARE, WHEELCHAIR)


### PR DESCRIPTION
I noticed many notes caused by SC mappers unable to delete objects like offices
this patch allows to fallback from shop replacement to deleting objects rather immediately to note creation

------------------

Additionally, maybe it would be a good idea to allow straight delete of shop objects - not only tagging as vacant.

--------------------

As pull request as it is noticeable change to design,and  I am not entirely happy with code but I see no good replacement (maybe trigger deletion from shop replacement function? But it seems to go against its name...)