### PR TITLE
Run `ktlint` on any push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,5 @@
 name: "Lint"
-on:
-  push:
-    branches:
-      - "master"
+on: push
 
 jobs:
   ktlint:


### PR DESCRIPTION
At the moment it is easy to make some changes and only get feedback that there are linting issues after that change reaching master.

By running ktlint on any push contributors will get feedback sooner. This should hopefully result in fewer linting issues reaching master.