### PR TITLE
Tactile paving on steps quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -120,6 +120,7 @@ import de.westnordost.streetcomplete.quests.surface.AddRoadSurface
 import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingBusStop
 import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingCrosswalk
 import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingKerb
+import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingSteps
 import de.westnordost.streetcomplete.quests.toilet_availability.AddToiletAvailability
 import de.westnordost.streetcomplete.quests.toilets_fee.AddToiletsFee
 import de.westnordost.streetcomplete.quests.tourism_information.AddInformationToTourism
@@ -221,6 +222,7 @@ fun questTypeRegistry(
     AddHandrail(), // for accessibility of pedestrian routing, can be gathered when walking past
     AddStepsRamp(),
     AddStepsIncline(), // can be gathered while walking perpendicular to the way e.g. the other side of the road or when running/cycling past, confuses some people, so not as high as it theoretically should be
+    AddTactilePavingSteps(), // need to check top and bottom
 
     AddReligionToPlaceOfWorship(), // icons on maps are different - OSM Carto, mapy.cz, OsmAnd, Sputnik etc
     AddReligionToWaysideShrine(),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
@@ -1,0 +1,40 @@
+package de.westnordost.streetcomplete.quests.tactile_paving
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.meta.ANYTHING_PAVED
+import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.osm.osmquests.Tags
+import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
+import de.westnordost.streetcomplete.ktx.toYesNo
+
+class AddTactilePavingSteps : OsmFilterQuestType<Boolean>() {
+
+    override val elementFilter = """
+        ways with highway = steps
+         and surface ~ ${ANYTHING_PAVED.joinToString("|")}
+         and (!indoor or indoor = no)
+         and access !~ private|no
+        and (
+          !tactile_paving
+          or tactile_paving = unknown
+          or tactile_paving = no and tactile_paving older today -4 years
+          or tactile_paving = yes and tactile_paving older today -8 years
+        )
+    """
+
+    override val changesetComment = "Add tactile paving on steps"
+    override val wikiLink = "Key:tactile_paving"
+    override val icon = R.drawable.ic_quest_steps_tactile_paving
+    override val enabledInCountries = COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON
+
+    override val questTypeAchievements = listOf(BLIND)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_tactile_paving_steps_title
+
+    override fun createForm() = TactilePavingForm()
+
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
+        tags.updateWithCheckDate("tactile_paving", answer.toYesNo())
+    }
+}

--- a/app/src/main/res/drawable/ic_quest_steps_tactile_paving.xml
+++ b/app/src/main/res/drawable/ic_quest_steps_tactile_paving.xml
@@ -1,0 +1,76 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+  <path
+      android:pathData="m128,64c0,35.346 -28.654,64 -64,64s-64,-28.654 -64,-64 28.654,-64 64,-64 64,28.654 64,64"
+      android:strokeWidth=".2"
+      android:fillColor="#529add"/>
+  <path
+      android:pathData="m86.192,95.838v-16H106.41V63.838h20.231"
+      android:strokeAlpha="0.2"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="m86.192,91.838v-16H106.41V59.838h20.231"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="m16.722,91.55c10.077,-8.792 10.967,-17.136 11.654,-26.935 8.458,8.95 10.695,16.984 12.476,26.935"
+      android:strokeAlpha="0.2"
+      android:strokeWidth="8.5769"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m17.352,64.344c-0.065,-7.274 3.043,-13.249 11.023,-16.46 5.72,4.889 8.703,12.169 18.497,16.947"
+      android:strokeAlpha="0.2"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8.5769"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m39.544,33.059a8.21,8.21 0,0 1,-8.21 8.21,8.21 8.21,0 0,1 -8.21,-8.21 8.21,8.21 0,0 1,8.21 -8.21,8.21 8.21,0 0,1 8.21,8.21"
+      android:strokeWidth="0.16881"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="m54.87,70.001 l21.484,23.189"
+      android:strokeAlpha="0.2"
+      android:strokeWidth="4.6784"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m16.722,88.061c10.077,-8.792 10.967,-17.136 11.654,-26.935 8.458,8.95 10.695,16.984 12.476,26.935"
+      android:strokeWidth="8.5769"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m28.377,44.397c-1.371,5.198 -0.338,12.162 0.631,17.36"
+      android:strokeWidth="9.3568"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="m17.352,60.856c-0.065,-7.274 3.043,-13.249 11.023,-16.46 5.72,4.889 8.703,12.169 18.497,16.947"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8.5769"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m39.544,29.57a8.21,8.21 0,0 1,-8.21 8.21,8.21 8.21,0 0,1 -8.21,-8.21 8.21,8.21 0,0 1,8.21 -8.21,8.21 8.21,0 0,1 8.21,8.21"
+      android:strokeWidth="0.16881"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="m54.87,66.513 l21.484,23.189"
+      android:strokeWidth="4.6784"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1202,4 +1202,5 @@ Alternatively, you can leave a note (with a photo)."</string>
     <string name="achievement_lifesaver_solved_X">You solved %d quests that help emergency services and first responders!</string>
     <string name="quest_airConditioning_no_name_title">"Does this place (%s) have air conditioning?"</string>
     <string name="quest_airConditioning_name_type_title">"Does %1$s (%2$s) have air conditioning?"</string>
+    <string name="quest_tactile_paving_steps_title">Is there tactile paving at the top and bottom of these steps?</string>
 </resources>

--- a/res/graphics/quest/steps_tactile_paving.svg
+++ b/res/graphics/quest/steps_tactile_paving.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 128 128"
+   id="svg26"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs30" />
+  <path
+     d="m128 64c0 35.346-28.654 64-64 64s-64-28.654-64-64 28.654-64 64-64 64 28.654 64 64"
+     fill="#529add"
+     stroke-width=".2"
+     id="path2" />
+  <path
+     d="m 86.192206,95.83845 v -16 H 106.41017 V 63.838454 h 20.23105"
+     fill="none"
+     stroke="#000000"
+     stroke-opacity="0.2"
+     stroke-width="8"
+     id="path4" />
+  <path
+     d="m 86.192206,91.83845 v -16 H 106.41017 V 59.838454 h 20.23105"
+     fill="none"
+     stroke="#ffffff"
+     stroke-width="8"
+     id="path10-3" />
+  <path
+     d="m 16.721852,91.55 c 10.077,-8.7923 10.967,-17.136 11.654,-26.935 8.4582,8.9496 10.695,16.984 12.476,26.935"
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-opacity="0.2"
+     stroke-width="8.5769"
+     style="paint-order:stroke fill markers"
+     id="path8" />
+  <path
+     d="m 17.351852,64.344 c -0.0651,-7.2737 3.0428,-13.249 11.023,-16.46 5.72,4.8891 8.7035,12.169 18.497,16.947"
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-opacity="0.2"
+     stroke-width="8.5769"
+     style="paint-order:stroke fill markers"
+     id="path10" />
+  <path
+     d="m 39.543852,33.059 a 8.2096,8.2096 0 0 1 -8.2096,8.2096 8.2096,8.2096 0 0 1 -8.2096,-8.2096 8.2096,8.2096 0 0 1 8.2096,-8.2096 8.2096,8.2096 0 0 1 8.2096,8.2096"
+     fill-opacity="0.2"
+     stroke-width="0.16881"
+     style="paint-order:normal"
+     id="path12" />
+  <path
+     d="m 54.869852,70.001 21.484,23.189"
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-opacity="0.2"
+     stroke-width="4.6784"
+     style="paint-order:stroke fill markers"
+     id="path14" />
+  <path
+     d="m 16.721852,88.061 c 10.077,-8.7923 10.967,-17.136 11.654,-26.935 8.4582,8.9496 10.695,16.984 12.476,26.935"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-width="8.5769"
+     style="paint-order:stroke fill markers"
+     id="path16" />
+  <path
+     d="m 28.376852,44.397 c -1.3709,5.1982 -0.33838,12.162 0.63074,17.36"
+     fill="none"
+     stroke="#ffffff"
+     stroke-width="9.3568"
+     style="paint-order:stroke fill markers"
+     id="path18" />
+  <path
+     d="m 17.351852,60.856 c -0.0651,-7.2737 3.0428,-13.249 11.023,-16.46 5.72,4.8891 8.7035,12.169 18.497,16.947"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="8.5769"
+     style="paint-order:stroke fill markers"
+     id="path20" />
+  <path
+     d="m 39.543852,29.57 a 8.2096,8.2096 0 0 1 -8.2096,8.2096 8.2096,8.2096 0 0 1 -8.2096,-8.2096 8.2096,8.2096 0 0 1 8.2096,-8.2096 8.2096,8.2096 0 0 1 8.2096,8.2096"
+     fill="#ffffff"
+     stroke-width="0.16881"
+     style="paint-order:normal"
+     id="path22" />
+  <path
+     d="m 54.869852,66.513 21.484,23.189"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-width="4.6784"
+     style="paint-order:stroke fill markers"
+     id="path24" />
+</svg>


### PR DESCRIPTION
Fixes #3534 

My first attempt at an icon (combining tactile paving and steps icons)

<img src="https://user-images.githubusercontent.com/77166354/153951605-cacb9e28-ba4d-4bd9-af47-6ac8c2ae0605.png" width="300">

Despite discussion in above linked issue, convention does appear to be to tag it on the way tagged with `highway=steps`

It was added to the [steps page of the wiki in 2009](https://wiki.openstreetmap.org/w/index.php?title=Tag:highway%3Dsteps&diff=246497&oldid=237564) and to [the tactile paving page in 2010](https://wiki.openstreetmap.org/w/index.php?title=Key:tactile_paving&diff=401293&oldid=246498) and marked as being specifically for ways [later that year](https://wiki.openstreetmap.org/w/index.php?title=Key:tactile_paving&diff=535396&oldid=514981).

There's been no discussion on the wiki talk pages about this and it's been tagged on over 18,000 steps.

In addition, it's not a primary feature and there would likely be no other tags on the nodes at either end of the steps.