### PR TITLE
Fix typo in credits

### DIFF
--- a/app/src/main/res/raw/credits_code.yml
+++ b/app/src/main/res/raw/credits_code.yml
@@ -23,7 +23,7 @@
 - Bruno Pezer (RiffLord)
 - Jeroen Hoek (jdhoek)
 - riQQ
-- Dominik Danielski (Etua)
+- Dominik Danelski (Etua)
 # small usability fixes and enhancements
 - smichel17 # compass mode stuff, fix on quest
 - Hsieh Chin Fan (typebrook) # usability enhancements


### PR DESCRIPTION
I'm grateful for the mention considering I don't do the heavy lifting here but for the sake of correctness I would like to remove one extra letter from my surname. Did @matkoniecz help you in creating this list by any chance? This is a popular error but only among Polish speakers for whom this name feels more natural with that vowel added ;)