### PR TITLE
Fix wrong tags being applied for the AddStreetParking quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParking.kt
@@ -53,7 +53,7 @@ class AddStreetParking : OsmFilterQuestType<LeftAndRightStreetParking>() {
        - roundabouts
        - on sections of the roadway marked with arrows (turn lanes)
 
-       There are some more rules which cannot be filtered due to the lack of tags for that that are
+       There are some more rules that cannot be filtered due to the lack of tags that are
        set on the road-way:
        - in front of important signs (STOP, saltires, yield etc)
        - at taxi stands, bus stops, ...
@@ -108,15 +108,15 @@ class AddStreetParking : OsmFilterQuestType<LeftAndRightStreetParking>() {
             conditionRight?.let { tags["parking:condition:right"] = it }
         }
 
-        // parking:lane:<left/right/both>:<parallel/diagonal/perpendicular> (aka "parking orientation")
-        val orientationRight = (answer.right as? StreetParkingPositionAndOrientation)?.position?.toOsmValue()
-        val orientationLeft = (answer.left as? StreetParkingPositionAndOrientation)?.position?.toOsmValue()
+        // parking:lane:<left/right/both>:<parallel/diagonal/perpendicular>
+        val positionRight = (answer.right as? StreetParkingPositionAndOrientation)?.position?.toOsmValue()
+        val positionLeft = (answer.left as? StreetParkingPositionAndOrientation)?.position?.toOsmValue()
 
-        if (orientationLeft == orientationRight) {
-            if (orientationLeft != null) tags["parking:lane:both:$laneLeft"] = orientationLeft
+        if (laneLeft == laneRight && positionLeft == positionRight) {
+            if (positionLeft != null) tags["parking:lane:both:$laneLeft"] = positionLeft
         } else {
-            if (orientationLeft != null) tags["parking:lane:left:$laneLeft"] = orientationLeft
-            if (orientationRight != null) tags["parking:lane:right:$laneRight"] = orientationRight
+            if (positionLeft != null) tags["parking:lane:left:$laneLeft"] = positionLeft
+            if (positionRight != null) tags["parking:lane:right:$laneRight"] = positionRight
         }
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParkingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/street_parking/AddStreetParkingTest.kt
@@ -62,7 +62,20 @@ class AddStreetParkingTest {
         )
     }
 
-    @Test fun `apply different parkings on sides`() {
+    @Test fun `apply street side parking answer with different orientations on sides`() {
+        questType.verifyAnswer(
+            LeftAndRightStreetParking(
+                StreetParkingPositionAndOrientation(ParkingOrientation.PERPENDICULAR, ParkingPosition.STREET_SIDE),
+                StreetParkingPositionAndOrientation(ParkingOrientation.PARALLEL, ParkingPosition.STREET_SIDE)
+            ),
+            StringMapEntryAdd("parking:lane:left", "perpendicular"),
+            StringMapEntryAdd("parking:lane:right", "parallel"),
+            StringMapEntryAdd("parking:lane:left:perpendicular", "street_side"),
+            StringMapEntryAdd("parking:lane:right:parallel", "street_side"),
+        )
+    }
+
+    @Test fun `apply different parking positions and orientations on sides`() {
         questType.verifyAnswer(
             LeftAndRightStreetParking(
                 StreetParkingPositionAndOrientation(ParkingOrientation.DIAGONAL, ParkingPosition.STREET_SIDE),


### PR DESCRIPTION
For the following parking orientation and position

<img src="https://user-images.githubusercontent.com/6892794/154848587-e5a4067e-1d8c-45e1-bd22-89d67d02fc6b.png" width="400">

the app currently incorrectly generates the following OSM tags even though the parking type (i.e. diagonal and parallel) is not the same for both sides:

<img src="https://user-images.githubusercontent.com/6892794/154848690-9424d94e-c9a4-44ef-a8a9-f23bf97f6b48.png" width="400">

This PR fixes this bug and the app now correctly applies the following tags as described in the [wiki](https://wiki.openstreetmap.org/wiki/Key:parking:lane#Parking_position):

<img src="https://user-images.githubusercontent.com/6892794/154848940-b3665bfd-39c2-42c4-b5ec-2cd421454c08.png" width="400">

