### PR TITLE
improve English in note creation window

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,7 +787,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_leaf_type_needles">Needles</string>
     <string name="quest_leaf_type_broadleaved">Broadleaved</string>
     <string name="quest_leaf_type_mixed">Both are present</string>
-    <string name="create_new_note_hint">Best write the note in the locally spoken language or otherwise in English.</string>
+    <string name="create_new_note_hint">Ideally, write the note in the local language, or otherwise in English.</string>
     <string name="quest_cyclewayPartSurface_title">What’s the surface of the cycleway here?</string>
     <string name="quest_footwayPartSurface_title">What’s the surface of the footway here?</string>
     <string name="quest_board_type_history">History</string>


### PR DESCRIPTION
"Best write the note in the locally spoken language or otherwise English." -> "Ideally, write the note in the local language, or otherwise in English."

fixes #3792

improves English from #1471

Creating PR and pinging @peternewman @smichel17 as I also authored the original and I am not a native speaker (let me know if you prefer to not be pinged as English experts in SC issues/PRs)