### PR TITLE
Prevent Dialog Cancel

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
@@ -309,8 +309,10 @@ class QuestSelectionAdapter(
                 visibleQuestTypeController.setVisible(item.questType, item.visible)
             }
             if (b && item.questType.defaultDisabledMessage > 0) {
-                AlertDialog.Builder(compoundButton.context)
+                val dialog = AlertDialog.Builder(compoundButton.context)
+                dialog
                     .setTitle(R.string.enable_quest_confirmation_title)
+                    .setCancelable(false)
                     .setMessage(item.questType.defaultDisabledMessage)
                     .setPositiveButton(android.R.string.yes, null)
                     .setNegativeButton(android.R.string.no) { _, _ ->


### PR DESCRIPTION
Partly resolves #3783.

Using `.setCancelable(true)` will prevent accepting clicks outside the dialog and thus not cancel the dialog, which means you **have** to use either the Yes or Cancel buttons. Nothing else will cancel the dialog.

Well...

Almost nothing, except for rotating the device 🙄 

There is a way to prevent the [Dialog Dismissal on Device Rotation](https://stackoverflow.com/a/15729764), yet at 23:30 I'm unable to make that Java code work in Kotlin - which might also be partly due to the last change to the answer being 5 years and thus - in Android terms - an eternity ago. If someone feels like implementing that, feel free to commit those changes to my branch and this PR.

Kai