### PR TITLE
Steps other answer for path in lit quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/WayLitForm.kt
@@ -25,10 +25,12 @@ class WayLitForm : AbstractQuestAnswerFragment<WayLitOrIsStepsAnswer>() {
 
     private fun createConvertToStepsAnswer(): AnswerItem? {
         val way = osmElement as? Way ?: return null
-        if (way.isArea() || way.tags["highway"] != "footway") return null
-
-        return AnswerItem(R.string.quest_generic_answer_is_actually_steps) {
-            applyAnswer(IsActuallyStepsAnswer)
+        return if (!way.isArea() && (way.tags["highway"] == "footway" || way.tags["highway"] == "path")) {
+            AnswerItem(R.string.quest_generic_answer_is_actually_steps) {
+                applyAnswer(IsActuallyStepsAnswer)
+            }
+        } else {
+            null
         }
     }
 }


### PR DESCRIPTION
Follow up to #3722 

I missed that lit quest also applies for `highway=path` with `foot=designated` (or `bicyce=designated`), so steps answer would make sense for path in that case. (I didn't think it was worth putting in check for `bicycle` tag, but can add if wanted)

Also made the code for this more readable

(Tested and working)