### PR TITLE
Add other answer "not a bollard" to bollard type quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.LIFESAVER
+import de.westnordost.streetcomplete.quests.bollard_type.BollardType.NOT_BOLLARD
 
 class AddBollardType : OsmElementQuestType<BollardType> {
 
@@ -53,6 +54,11 @@ class AddBollardType : OsmElementQuestType<BollardType> {
     override fun createForm() = AddBollardTypeForm()
 
     override fun applyAnswerTo(answer: BollardType, tags: Tags, timestampEdited: Long) {
-        tags["bollard"] = answer.osmValue
+        when (answer) {
+            NOT_BOLLARD -> {
+                tags["barrier"] = "yes"
+            }
+            else -> tags["bollard"] = answer.osmValue
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -55,9 +55,7 @@ class AddBollardType : OsmElementQuestType<BollardType> {
 
     override fun applyAnswerTo(answer: BollardType, tags: Tags, timestampEdited: Long) {
         when (answer) {
-            NOT_BOLLARD -> {
-                tags["barrier"] = "yes"
-            }
+            NOT_BOLLARD -> tags["barrier"] = "yes"
             else -> tags["bollard"] = answer.osmValue
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FLEXIBLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FOLDABLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.REMOVABLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.RISING
+import de.westnordost.streetcomplete.quests.bollard_type.BollardType.NOT_BOLLARD
 import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardType>() {
@@ -24,4 +25,8 @@ class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardTyp
     override fun onClickOk(selectedItems: List<BollardType>) {
         applyAnswer(selectedItems.single())
     }
+
+    override val otherAnswers get() = listOfNotNull(
+        AnswerItem(R.string.quest_bollard_type_not_bollard) { applyAnswer(NOT_BOLLARD) },
+    )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.bollard_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FIXED
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FLEXIBLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FOLDABLE

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
@@ -6,4 +6,5 @@ enum class BollardType(val osmValue: String) {
     FOLDABLE("foldable"),
     FLEXIBLE("flexible"),
     FIXED("fixed"),
+    NOT_BOLLARD("not_bollard"),
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1090,6 +1090,7 @@ Unfortunately, due to a Google Play Store policy, no links leading to donations 
     <string name="quest_bollard_type_foldable2">Foldable (with or without key)</string>
     <string name="quest_bollard_type_flexible">Flexible</string>
     <string name="quest_bollard_type_fixed">Fixed (not removable)</string>
+    <string name="quest_bollard_type_not_bollard">Not a bollard, but some other barrier</string>
     <string name="quest_camera_type_title">What type of surveillance camera is this?</string>
     <string name="quest_camera_type_dome">Dome</string>
     <string name="quest_camera_type_fixed">Fixed</string>


### PR DESCRIPTION
When users chooses "other answers" and "not a bollard", the former `barrier=bollard` is instead retagged with `barrier=yes`, so regular `barrier type` quest can pop up. 

(Implemented in mostly the same way as `bench_backrest` quest with `it's a picnic table` answer.)

Tested and it seems to work correctly.

Closes https://github.com/streetcomplete/StreetComplete/issues/3817