### PR TITLE
Add other answer "not a cycle barrier" to "cycle barrier type" quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
+import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.NOT_CYCLE_BARRIER
 
 class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
 
@@ -22,6 +23,11 @@ class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
     override fun createForm() = AddBicycleBarrierTypeForm()
 
     override fun applyAnswerTo(answer: BicycleBarrierType, tags: Tags, timestampEdited: Long) {
-        tags["cycle_barrier"] = answer.osmValue
+        when (answer) {
+            NOT_CYCLE_BARRIER -> {
+                tags["barrier"] = "yes"
+            }
+            else -> tags["cycle_barrier"] = answer.osmValue
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -24,9 +24,7 @@ class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
 
     override fun applyAnswerTo(answer: BicycleBarrierType, tags: Tags, timestampEdited: Long) {
         when (answer) {
-            NOT_CYCLE_BARRIER -> {
-                tags["barrier"] = "yes"
-            }
+            NOT_CYCLE_BARRIER -> tags["barrier"] = "yes"
             else -> tags["cycle_barrier"] = answer.osmValue
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
@@ -2,11 +2,13 @@ package de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestAnswerFragment
+import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DIAGONAL
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DOUBLE
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.SINGLE
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TILTED
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TRIPLE
+import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.NOT_CYCLE_BARRIER
 import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBicycleBarrierTypeForm : AImageListQuestAnswerFragment<BicycleBarrierType, BicycleBarrierType>() {
@@ -26,4 +28,8 @@ class AddBicycleBarrierTypeForm : AImageListQuestAnswerFragment<BicycleBarrierTy
     override fun onClickOk(selectedItems: List<BicycleBarrierType>) {
         applyAnswer(selectedItems.single())
     }
+
+    override val otherAnswers get() = listOfNotNull(
+        AnswerItem(R.string.quest_barrier_bicycle_type_not_cycle_barrier) { applyAnswer(NOT_CYCLE_BARRIER) },
+    )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
@@ -6,4 +6,5 @@ enum class BicycleBarrierType(val osmValue: String) {
     TRIPLE("triple"),
     DIAGONAL("diagonal"),
     TILTED("tilted"),
+    NOT_CYCLE_BARRIER("not_cycle_barrier"),
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1162,6 +1162,7 @@ If you are overwhelmed by the number of quests, you can always fine-tune which q
     <string name="quest_barrier_bicycle_type_single">Passage between two barriers</string>
     <string name="quest_barrier_bicycle_type_double">Chicane - barrier on each side</string>
     <string name="quest_barrier_bicycle_type_multiple">Chicane - more than two barriers</string>
+    <string name="quest_barrier_bicycle_type_not_cycle_barrier">Not a cycle barrier, but some other barrier</string>
     <string name="quest_traffic_calming_type_title">What type of traffic calming is this?</string>
     <string name="quest_traffic_calming_type_bump">Bump (shorter)</string>
     <string name="quest_traffic_calming_type_hump">Hump (longer)</string>


### PR DESCRIPTION
When users chooses "other answers" and "not a cycle barrier", the former `barrier=cycle_barrier` is instead retagged with `barrier=yes`, so regular barrier type quest can pop up.

(Implemented in the same way as `bollard type quest` / `not a bollard` PR https://github.com/streetcomplete/StreetComplete/pull/3845)

Tested and it seems to work correctly.

Related to https://github.com/streetcomplete/StreetComplete/issues/3817, it was originally reported in https://github.com/streetcomplete/StreetComplete/issues/3563