### PR TITLE
show nearby steps in steps-related quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -33,6 +33,9 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
 
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("ways with highway = steps")
+
     override fun createForm() = YesNoQuestAnswerFragment()
 
     override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -2,6 +2,9 @@ package de.westnordost.streetcomplete.quests.handrail
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -1,6 +1,9 @@
 package de.westnordost.streetcomplete.quests.step_count
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -26,6 +26,9 @@ class AddStepCount : OsmFilterQuestType<Int>() {
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_step_count_title
 
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("ways with highway = steps")
+
     override fun createForm() = AddStepCountForm()
 
     override fun applyAnswerTo(answer: Int, tags: Tags, timestampEdited: Long) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -1,6 +1,9 @@
 package de.westnordost.streetcomplete.quests.steps_incline
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsIncline.kt
@@ -26,6 +26,9 @@ class AddStepsIncline : OsmFilterQuestType<StepsIncline>() {
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_incline_title
 
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("ways with highway = steps")
+
     override fun createForm() = AddStepsInclineForm()
 
     override fun applyAnswerTo(answer: StepsIncline, tags: Tags, timestampEdited: Long) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -34,6 +34,9 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_steps_ramp_title
 
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("ways with highway = steps")
+
     override fun createForm() = AddStepsRampForm()
 
     override fun applyAnswerTo(answer: StepsRampAnswer, tags: Tags, timestampEdited: Long) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -2,6 +2,9 @@ package de.westnordost.streetcomplete.quests.steps_ramp
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST


### PR DESCRIPTION
Since steps can often be clustered together, it is useful to show nearby `highway=steps` ways when one is solving steps-related quests. This PR enables their highlighting. I've tested that it works.