### PR TITLE
Use sealed interfaces instead of "hacky" enum items

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/HousenumberAnswer.kt
@@ -1,11 +1,11 @@
 package de.westnordost.streetcomplete.quests.address
 
-sealed class HousenumberAnswer
+sealed interface HousenumberAnswer
 
-data class ConscriptionNumber(val number: String, val streetNumber: String? = null) : HousenumberAnswer()
-data class HouseNumber(val number: String) : HousenumberAnswer()
-data class HouseName(val name: String) : HousenumberAnswer()
-data class HouseNameAndHouseNumber(val name: String, val number: String) : HousenumberAnswer()
-data class HouseAndBlockNumber(val houseNumber: String, val blockNumber: String) : HousenumberAnswer()
-object NoHouseNumber : HousenumberAnswer()
-object WrongBuildingType : HousenumberAnswer()
+data class ConscriptionNumber(val number: String, val streetNumber: String? = null) : HousenumberAnswer
+data class HouseNumber(val number: String) : HousenumberAnswer
+data class HouseName(val name: String) : HousenumberAnswer
+data class HouseNameAndHouseNumber(val name: String, val number: String) : HousenumberAnswer
+data class HouseAndBlockNumber(val houseNumber: String, val blockNumber: String) : HousenumberAnswer
+object NoHouseNumber : HousenumberAnswer
+object WrongBuildingType : HousenumberAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -24,7 +24,7 @@ class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierTypeAnswer>() {
     override fun applyAnswerTo(answer: BicycleBarrierTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is BicycleBarrierType -> tags["cycle_barrier"] = answer.osmValue
-            DifferentBarrierType -> tags["barrier"] = "yes"
+            BarrierTypeIsNotBicycleBarrier -> tags["barrier"] = "yes"
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -6,9 +6,8 @@ import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.BLIND
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.WHEELCHAIR
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.NOT_CYCLE_BARRIER
 
-class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
+class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierTypeAnswer>() {
 
     override val elementFilter = "nodes with barrier = cycle_barrier and !cycle_barrier"
     override val changesetComment = "Add specific cycle barrier type"
@@ -22,10 +21,10 @@ class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierType>() {
 
     override fun createForm() = AddBicycleBarrierTypeForm()
 
-    override fun applyAnswerTo(answer: BicycleBarrierType, tags: Tags, timestampEdited: Long) {
+    override fun applyAnswerTo(answer: BicycleBarrierTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
-            NOT_CYCLE_BARRIER -> tags["barrier"] = "yes"
-            else -> tags["cycle_barrier"] = answer.osmValue
+            is BicycleBarrierType -> tags["cycle_barrier"] = answer.osmValue
+            DifferentBarrierType -> tags["barrier"] = "yes"
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
@@ -31,7 +31,7 @@ class AddBicycleBarrierTypeForm :
 
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_barrier_bicycle_type_not_cycle_barrier) {
-            applyAnswer(DifferentBarrierType)
+            applyAnswer(BarrierTypeIsNotBicycleBarrier)
         },
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
@@ -5,13 +5,13 @@ import de.westnordost.streetcomplete.quests.AImageListQuestAnswerFragment
 import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DIAGONAL
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DOUBLE
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.NOT_CYCLE_BARRIER
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.SINGLE
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TILTED
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TRIPLE
 import de.westnordost.streetcomplete.view.image_select.Item
 
-class AddBicycleBarrierTypeForm : AImageListQuestAnswerFragment<BicycleBarrierType, BicycleBarrierType>() {
+class AddBicycleBarrierTypeForm :
+    AImageListQuestAnswerFragment<BicycleBarrierType, BicycleBarrierTypeAnswer>() {
 
     override val items = listOf(
         Item(SINGLE, R.drawable.barrier_bicycle_barrier_single, R.string.quest_barrier_bicycle_type_single),
@@ -29,7 +29,9 @@ class AddBicycleBarrierTypeForm : AImageListQuestAnswerFragment<BicycleBarrierTy
         applyAnswer(selectedItems.single())
     }
 
-    override val otherAnswers get() = listOfNotNull(
-        AnswerItem(R.string.quest_barrier_bicycle_type_not_cycle_barrier) { applyAnswer(NOT_CYCLE_BARRIER) },
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_barrier_bicycle_type_not_cycle_barrier) {
+            applyAnswer(DifferentBarrierType)
+        },
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
@@ -10,4 +10,4 @@ enum class BicycleBarrierType(val osmValue: String) : BicycleBarrierTypeAnswer {
     TILTED("tilted"),
 }
 
-object DifferentBarrierType : BicycleBarrierTypeAnswer
+object BarrierTypeIsNotBicycleBarrier : BicycleBarrierTypeAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierType.kt
@@ -1,10 +1,13 @@
 package de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type
 
-enum class BicycleBarrierType(val osmValue: String) {
+sealed interface BicycleBarrierTypeAnswer
+
+enum class BicycleBarrierType(val osmValue: String) : BicycleBarrierTypeAnswer {
     SINGLE("single"),
     DOUBLE("double"),
     TRIPLE("triple"),
     DIAGONAL("diagonal"),
     TILTED("tilted"),
-    NOT_CYCLE_BARRIER("not_cycle_barrier"),
 }
+
+object DifferentBarrierType : BicycleBarrierTypeAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -9,9 +9,8 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CAR
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.LIFESAVER
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.NOT_BOLLARD
 
-class AddBollardType : OsmElementQuestType<BollardType> {
+class AddBollardType : OsmElementQuestType<BollardTypeAnswer> {
 
     private val bollardNodeFilter by lazy { """
         nodes with
@@ -53,10 +52,10 @@ class AddBollardType : OsmElementQuestType<BollardType> {
 
     override fun createForm() = AddBollardTypeForm()
 
-    override fun applyAnswerTo(answer: BollardType, tags: Tags, timestampEdited: Long) {
+    override fun applyAnswerTo(answer: BollardTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
-            NOT_BOLLARD -> tags["barrier"] = "yes"
-            else -> tags["bollard"] = answer.osmValue
+            is BollardType -> tags["bollard"] = answer.osmValue
+            DifferentBarrierType -> tags["barrier"] = "yes"
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardType.kt
@@ -55,7 +55,7 @@ class AddBollardType : OsmElementQuestType<BollardTypeAnswer> {
     override fun applyAnswerTo(answer: BollardTypeAnswer, tags: Tags, timestampEdited: Long) {
         when (answer) {
             is BollardType -> tags["bollard"] = answer.osmValue
-            DifferentBarrierType -> tags["barrier"] = "yes"
+            BarrierTypeIsNotBollard -> tags["barrier"] = "yes"
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
@@ -6,12 +6,11 @@ import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FIXED
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FLEXIBLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FOLDABLE
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.NOT_BOLLARD
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.REMOVABLE
 import de.westnordost.streetcomplete.quests.bollard_type.BollardType.RISING
 import de.westnordost.streetcomplete.view.image_select.Item
 
-class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardType>() {
+class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardTypeAnswer>() {
 
     override val items = listOf(
         Item(RISING,    R.drawable.bollard_rising,    R.string.quest_bollard_type_rising),
@@ -27,7 +26,7 @@ class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardTyp
         applyAnswer(selectedItems.single())
     }
 
-    override val otherAnswers get() = listOfNotNull(
-        AnswerItem(R.string.quest_bollard_type_not_bollard) { applyAnswer(NOT_BOLLARD) },
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_bollard_type_not_bollard) { applyAnswer(DifferentBarrierType) },
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
@@ -27,6 +27,8 @@ class AddBollardTypeForm : AImageListQuestAnswerFragment<BollardType, BollardTyp
     }
 
     override val otherAnswers = listOf(
-        AnswerItem(R.string.quest_bollard_type_not_bollard) { applyAnswer(DifferentBarrierType) },
+        AnswerItem(R.string.quest_bollard_type_not_bollard) {
+            applyAnswer(BarrierTypeIsNotBollard)
+        },
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
@@ -1,10 +1,13 @@
 package de.westnordost.streetcomplete.quests.bollard_type
 
-enum class BollardType(val osmValue: String) {
+sealed interface BollardTypeAnswer
+
+enum class BollardType(val osmValue: String) : BollardTypeAnswer {
     RISING("rising"),
     REMOVABLE("removable"),
     FOLDABLE("foldable"),
     FLEXIBLE("flexible"),
     FIXED("fixed"),
-    NOT_BOLLARD("not_bollard"),
 }
+
+object DifferentBarrierType : BollardTypeAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardType.kt
@@ -10,4 +10,4 @@ enum class BollardType(val osmValue: String) : BollardTypeAnswer {
     FIXED("fixed"),
 }
 
-object DifferentBarrierType : BollardTypeAnswer
+object BarrierTypeIsNotBollard : BollardTypeAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/BusStopNameAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/BusStopNameAnswer.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_name
 
 import de.westnordost.streetcomplete.quests.LocalizedName
 
-sealed class BusStopNameAnswer
+sealed interface BusStopNameAnswer
 
-object NoBusStopName : BusStopNameAnswer()
-data class BusStopName(val localizedNames: List<LocalizedName>) : BusStopNameAnswer()
+object NoBusStopName : BusStopNameAnswer
+data class BusStopName(val localizedNames: List<LocalizedName>) : BusStopNameAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/BusStopRefAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/BusStopRefAnswer.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.bus_stop_ref
 
-sealed class BusStopRefAnswer
+sealed interface BusStopRefAnswer
 
-object NoBusStopRef : BusStopRefAnswer()
-data class BusStopRef(val ref: String) : BusStopRefAnswer()
+object NoBusStopRef : BusStopRefAnswer
+data class BusStopRef(val ref: String) : BusStopRefAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/CompletedConstructionAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/CompletedConstructionAnswer.kt
@@ -2,6 +2,6 @@ package de.westnordost.streetcomplete.quests.construction
 
 import java.time.LocalDate
 
-sealed class CompletedConstructionAnswer
-data class StateAnswer(val value: Boolean) : CompletedConstructionAnswer()
-data class OpeningDateAnswer(val date: LocalDate) : CompletedConstructionAnswer()
+sealed interface CompletedConstructionAnswer
+data class StateAnswer(val value: Boolean) : CompletedConstructionAnswer
+data class OpeningDateAnswer(val date: LocalDate) : CompletedConstructionAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/LanesAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/LanesAnswer.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.quests.lanes
 
-sealed class LanesAnswer
+sealed interface LanesAnswer
 
-data class MarkedLanes(val count: Int) : LanesAnswer()
-object UnmarkedLanes : LanesAnswer()
-data class MarkedLanesSides(val forward: Int, val backward: Int, val centerLeftTurnLane: Boolean) : LanesAnswer()
+data class MarkedLanes(val count: Int) : LanesAnswer
+object UnmarkedLanes : LanesAnswer
+data class MarkedLanesSides(val forward: Int, val backward: Int, val centerLeftTurnLane: Boolean) : LanesAnswer
 
 val LanesAnswer.total: Int? get() = when (this) {
     is MarkedLanes -> count

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/MaxHeightAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/MaxHeightAnswer.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.max_height
 
 import de.westnordost.streetcomplete.osm.Length
 
-sealed class MaxHeightAnswer
+sealed interface MaxHeightAnswer
 
-data class MaxHeight(val value: Length) : MaxHeightAnswer()
-data class NoMaxHeightSign(val isTallEnough: Boolean) : MaxHeightAnswer()
+data class MaxHeight(val value: Length) : MaxHeightAnswer
+data class NoMaxHeightSign(val isTallEnough: Boolean) : MaxHeightAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/MaxSpeedAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/MaxSpeedAnswer.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.max_speed
 
-sealed class MaxSpeedAnswer
+sealed interface MaxSpeedAnswer
 
-data class MaxSpeedSign(val value: Speed) : MaxSpeedAnswer()
-data class MaxSpeedZone(val value: Speed, val countryCode: String, val roadType: String) : MaxSpeedAnswer()
-data class AdvisorySpeedSign(val value: Speed) : MaxSpeedAnswer()
-data class ImplicitMaxSpeed(val countryCode: String, val roadType: String, val lit: Boolean?) : MaxSpeedAnswer()
-object IsLivingStreet : MaxSpeedAnswer()
+data class MaxSpeedSign(val value: Speed) : MaxSpeedAnswer
+data class MaxSpeedZone(val value: Speed, val countryCode: String, val roadType: String) : MaxSpeedAnswer
+data class AdvisorySpeedSign(val value: Speed) : MaxSpeedAnswer
+data class ImplicitMaxSpeed(val countryCode: String, val roadType: String, val lit: Boolean?) : MaxSpeedAnswer
+object IsLivingStreet : MaxSpeedAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/MaxWeightAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/MaxWeightAnswer.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.max_weight
 
-sealed class MaxWeightAnswer
+sealed interface MaxWeightAnswer
 
-data class MaxWeight(val sign: MaxWeightSign, val weight: Weight) : MaxWeightAnswer()
-object NoMaxWeightSign : MaxWeightAnswer()
+data class MaxWeight(val sign: MaxWeightSign, val weight: Weight) : MaxWeightAnswer
+object NoMaxWeightSign : MaxWeightAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/OpeningHoursAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/OpeningHoursAnswer.kt
@@ -2,9 +2,9 @@ package de.westnordost.streetcomplete.quests.opening_hours
 
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 
-sealed class OpeningHoursAnswer
+sealed interface OpeningHoursAnswer
 
-data class RegularOpeningHours(val hours: OpeningHoursRuleList) : OpeningHoursAnswer()
-object AlwaysOpen : OpeningHoursAnswer()
-data class DescribeOpeningHours(val text: String) : OpeningHoursAnswer()
-object NoOpeningHoursSign : OpeningHoursAnswer()
+data class RegularOpeningHours(val hours: OpeningHoursRuleList) : OpeningHoursAnswer
+object AlwaysOpen : OpeningHoursAnswer
+data class DescribeOpeningHours(val text: String) : OpeningHoursAnswer
+object NoOpeningHoursSign : OpeningHoursAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/Fee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/Fee.kt
@@ -4,12 +4,12 @@ import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 
-sealed class Fee
+sealed interface Fee
 
-object HasFee : Fee()
-object HasNoFee : Fee()
-data class HasFeeAtHours(val hours: OpeningHoursRuleList) : Fee()
-data class HasFeeExceptAtHours(val hours: OpeningHoursRuleList) : Fee()
+object HasFee : Fee
+object HasNoFee : Fee
+data class HasFeeAtHours(val hours: OpeningHoursRuleList) : Fee
+data class HasFeeExceptAtHours(val hours: OpeningHoursRuleList) : Fee
 
 fun Fee.applyTo(tags: Tags) {
     when (this) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceNameAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/PlaceNameAnswer.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.place_name
 
 import de.westnordost.streetcomplete.quests.LocalizedName
 
-sealed class PlaceNameAnswer
+sealed interface PlaceNameAnswer
 
-data class PlaceName(val localizedNames: List<LocalizedName>) : PlaceNameAnswer()
-object NoPlaceNameSign : PlaceNameAnswer()
+data class PlaceName(val localizedNames: List<LocalizedName>) : PlaceNameAnswer
+object NoPlaceNameSign : PlaceNameAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAnswer.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.postbox_collection_times
 
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 
-sealed class CollectionTimesAnswer
+sealed interface CollectionTimesAnswer
 
-data class CollectionTimes(val times: OpeningHoursRuleList) : CollectionTimesAnswer()
-object NoCollectionTimesSign : CollectionTimesAnswer()
+data class CollectionTimes(val times: OpeningHoursRuleList) : CollectionTimesAnswer
+object NoCollectionTimesSign : CollectionTimesAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/PostboxRefAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_ref/PostboxRefAnswer.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.postbox_ref
 
-sealed class PostboxRefAnswer
+sealed interface PostboxRefAnswer
 
-data class Ref(val ref: String) : PostboxRefAnswer()
-object NoRefVisible : PostboxRefAnswer()
+data class Ref(val ref: String) : PostboxRefAnswer
+object NoRefVisible : PostboxRefAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/RecyclingContainerMaterialsAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/RecyclingContainerMaterialsAnswer.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.recycling_material
 
-sealed class RecyclingContainerMaterialsAnswer
+sealed interface RecyclingContainerMaterialsAnswer
 
-object IsWasteContainer : RecyclingContainerMaterialsAnswer()
-data class RecyclingMaterials(val materials: List<RecyclingMaterial>) : RecyclingContainerMaterialsAnswer()
+object IsWasteContainer : RecyclingContainerMaterialsAnswer
+data class RecyclingMaterials(val materials: List<RecyclingMaterial>) : RecyclingContainerMaterialsAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/RoadNameAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/RoadNameAnswer.kt
@@ -3,15 +3,15 @@ package de.westnordost.streetcomplete.quests.road_name
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.quests.LocalizedName
 
-sealed class RoadNameAnswer
+sealed interface RoadNameAnswer
 
 data class RoadName(
     val localizedNames: List<LocalizedName>,
     val wayId: Long,
     val wayGeometry: List<LatLon>
-) : RoadNameAnswer()
+) : RoadNameAnswer
 
-object NoRoadName : RoadNameAnswer()
-object RoadIsServiceRoad : RoadNameAnswer()
-object RoadIsTrack : RoadNameAnswer()
-object RoadIsLinkRoad : RoadNameAnswer()
+object NoRoadName : RoadNameAnswer
+object RoadIsServiceRoad : RoadNameAnswer
+object RoadIsTrack : RoadNameAnswer
+object RoadIsLinkRoad : RoadNameAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopTypeAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopTypeAnswer.kt
@@ -1,6 +1,6 @@
 package de.westnordost.streetcomplete.quests.shop_type
 
-sealed class ShopTypeAnswer
+sealed interface ShopTypeAnswer
 
-object IsShopVacant : ShopTypeAnswer()
-data class ShopType(val tags: Map<String, String>) : ShopTypeAnswer()
+object IsShopVacant : ShopTypeAnswer
+data class ShopType(val tags: Map<String, String>) : ShopTypeAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswer.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.quests.smoothness
 
-sealed class SmoothnessAnswer
+sealed interface SmoothnessAnswer
 
-data class SmoothnessValueAnswer(val value: Smoothness) : SmoothnessAnswer()
+data class SmoothnessValueAnswer(val value: Smoothness) : SmoothnessAnswer
 
-object IsActuallyStepsAnswer : SmoothnessAnswer()
-object WrongSurfaceAnswer : SmoothnessAnswer()
+object IsActuallyStepsAnswer : SmoothnessAnswer
+object WrongSurfaceAnswer : SmoothnessAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
@@ -4,10 +4,10 @@ import de.westnordost.streetcomplete.data.meta.removeCheckDatesForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 
-sealed class SurfaceOrIsStepsAnswer
-object IsActuallyStepsAnswer : SurfaceOrIsStepsAnswer()
+sealed interface SurfaceOrIsStepsAnswer
+object IsActuallyStepsAnswer : SurfaceOrIsStepsAnswer
 
-data class SurfaceAnswer(val value: Surface, val note: String? = null) : SurfaceOrIsStepsAnswer()
+data class SurfaceAnswer(val value: Surface, val note: String? = null) : SurfaceOrIsStepsAnswer
 
 fun SurfaceAnswer.applyTo(tags: Tags, key: String) {
     val osmValue = value.osmValue


### PR DESCRIPTION
In #3845 and #3846, the "other barrier type" answers were implemented as new enum items in `BollardType` and `BicycleBarrierType`. That's a bit hacky though, as it requires specifying a dummy `osmValue`. Also, it's not consistent with other quest answer types.

In this PR, the implementation is changed to introduce new sealed interfaces `BollardTypeAnswer` and `BicycleBarrierTypeAnswer`, from which the old enum classes extend. Also, new single objects (without an invalid `osmValue`) now extend from the sealed interfaces.

After some reading[^1], I still don't quite get the difference between sealed classes and sealed interfaces. I think that in this case, both should work the same. But since sealed interfaces are a bit more flexible and save two characters (`()`) per inheritance definition, I decided to use `sealed interface`. Also, I converted all the `*Answer` sealed classes to sealed interfaces as well, to be consistent.

If that was the wrong decision, and `BollardTypeAnswer` and `BicycleBarrierTypeAnswer` should be sealed classes instead, please let me know, and I will change it.

CC @mnalis

[^1]: nice blog post here: https://quickbirdstudios.com/blog/sealed-interfaces-kotlin/