### PR TITLE
Add `amenity=food_court` to `isShopExpressionFragment`

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/meta/OsmTaggings.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/meta/OsmTaggings.kt
@@ -133,11 +133,11 @@ fun isShopExpressionFragment(prefix: String? = null): String {
         or """ +
         mapOf(
             "amenity" to arrayOf(
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "nightclub",
+                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court",
                 "bank", "bureau_de_change", "money_transfer", "post_office", "internet_cafe",
                 "pharmacy",
                 "driving_school",
-                "stripclub",
+                "nightclub", "stripclub",
             ),
             "leisure" to arrayOf(
                 "amusement_arcade", "adult_gaming_centre", "tanning_salon",


### PR DESCRIPTION
The following quests are asked for `amenity=food_court`:

* `AddAcceptsCash`
* `AddOpeningHours`
* `AddPlaceName`
* `AddSeating`
* `AddSmoking`
* `AddWheelchairAccessBusiness`

All these quests highlight all elements matching `IS_SHOP_OR_DISUSED_SHOP_EXPRESSION`, but that didn't contain `amenity=food_court` yet.

I'm opening this as a PR because the comment above this function says that https://github.com/mnalis/StreetComplete-taginfo-categorize/blob/master/Makefile should be re-run afterwards. So @mnalis could you run the script, please? Should this PR be merged first or afterwards?

*(Noticed during review of [`f292530` (#3758)](https://github.com/streetcomplete/StreetComplete/pull/3758/commits/f292530131e719801aa4a0f9b1a9eee921ac842e))*