### PR TITLE
Show place name for seating quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
@@ -8,6 +8,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.ktx.arrayOfNotNull
+import de.westnordost.streetcomplete.ktx.containsAny
 import de.westnordost.streetcomplete.ktx.toYesNo
 
 class AddSeating : OsmFilterQuestType<Seating>() {
@@ -25,7 +27,16 @@ class AddSeating : OsmFilterQuestType<Seating>() {
     override val isReplaceShopEnabled = true
     override val questTypeAchievements = listOf(CITIZEN)
 
-    override fun getTitle(tags: Map<String, String>) = R.string.quest_seating_name_title
+    override fun getTitle(tags: Map<String, String>) =
+        if (hasProperName(tags))
+            R.string.quest_seating_has_name_title
+        else
+            R.string.quest_seating_name_title
+
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> {
+        val name = tags["name"] ?: tags["brand"]
+        return arrayOfNotNull(name)
+    }
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter(IS_SHOP_OR_DISUSED_SHOP_EXPRESSION)
@@ -37,4 +48,7 @@ class AddSeating : OsmFilterQuestType<Seating>() {
         tags["outdoor_seating"] = answer.hasOutdoorSeating.toYesNo()
         tags["indoor_seating"] = answer.hasIndoorSeating.toYesNo()
     }
+
+    private fun hasProperName(tags: Map<String, String>): Boolean =
+        tags.keys.containsAny(listOf("name", "brand"))
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
@@ -33,11 +33,6 @@ class AddSeating : OsmFilterQuestType<Seating>() {
         else
             R.string.quest_seating_name_title
 
-    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> {
-        val name = tags["name"] ?: tags["brand"]
-        return arrayOfNotNull(name)
-    }
-
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter(IS_SHOP_OR_DISUSED_SHOP_EXPRESSION)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1247,6 +1247,7 @@ Alternatively, you can leave a note (with a photo)."</string>
     <string name="quest_road_width_explanation">"The roadway width from curb to curb: This includes anything on the street surface like on-street parking or cycle lanes but excludes anything beyond it like cycle paths or parking beside the roadway."</string>
 
     <string name="quest_seating_name_title">What kind of seating does this place have?</string>
+    <string name="quest_seating_has_name_title">What kind of seating does %s have?</string>
     <string name="quest_seating_takeaway">Takeaway only</string>
     <string name="quest_seating_indoor_only">Indoor seating only</string>
     <string name="quest_seating_outdoor_only">Outdoor seating only</string>


### PR DESCRIPTION
fixes #3857 

The original string name without name is a bit misleading :`quest_seating_name_title`, if translations haven't yet started maybe it should be changed to `quest_seating_no_name_title`