### PR TITLE
Smoking outside tuning

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
@@ -28,6 +28,7 @@ class AddSmoking : OsmFilterQuestType<SmokingAllowed>() {
              )
          )
          and takeaway != only
+         and !(indoor_seating = no and outdoor_seating = no)
          and (!smoking or smoking older today -8 years)
     """
     override val changesetComment = "Add smoking status"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/SmokingAllowedAnswerForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/SmokingAllowedAnswerForm.kt
@@ -15,10 +15,11 @@ class SmokingAllowedAnswerForm : AListQuestAnswerFragment<SmokingAllowed>() {
         val isAlreadyOutdoor =
             tags["leisure"] == "outdoor_seating" || tags["amenity"] == "biergarten" ||
             (tags["outdoor_seating"] == "yes" && tags["indoor_seating"] == "no")
+        val noOutdoorSeating = tags["outdoor_seating"] == "no"
 
         return listOfNotNull(
             TextItem(NO, R.string.quest_smoking_no),
-            if (isAlreadyOutdoor) null else TextItem(OUTSIDE, R.string.quest_smoking_outside),
+            if (isAlreadyOutdoor || noOutdoorSeating) null else TextItem(OUTSIDE, R.string.quest_smoking_outside),
             TextItem(SEPARATED, R.string.quest_smoking_separated),
             TextItem(YES, R.string.quest_smoking_yes),
         )


### PR DESCRIPTION
This PR tries to address superfluous `OUTSIDE` answer when it should be hidden, as reported in https://github.com/streetcomplete/StreetComplete/issues/3856

- do not show quest at all if there are neither indoor nor outdoor seating
- hide `OUTSIDE` answer if it is known that there is no outside seating
