### PR TITLE
Fix street parking background calculation

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/StreetParkingDrawable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/street_parking/StreetParkingDrawable.kt
@@ -62,7 +62,7 @@ class StreetParkingDrawable(
             // drawing the street background
             if (backgroundResId != null) {
                 val background = context.getDrawable(backgroundResId)!!
-                val backgroundHeight = background.intrinsicHeight / background.intrinsicWidth * width
+                val backgroundHeight = (background.intrinsicHeight.toDouble() / background.intrinsicWidth * width).toInt()
                 background.setBounds(0, 0, width, backgroundHeight)
                 background.draw(canvas)
             }


### PR DESCRIPTION
Fixes #3854 

The calculations were all being done as Int, but my ratio of intrinsicHeight / intrinsicWidth was slightly less than 2, so got converted to 1.

This forces the calculations to be done as Double and then converts it to int at the end.

It now works on my phone and still works on the Pixel emulator.