### PR TITLE
Reorder crossing button over crossing vibration quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -268,8 +268,8 @@ fun questTypeRegistry(
     AddCrossingType(),
     AddTactilePavingCrosswalk(),
     AddTrafficSignalsSound(), // Sound needs to be done as or after you're crossing
-    AddTrafficSignalsVibration(),
     AddTrafficSignalsButton(),
+    AddTrafficSignalsVibration(),
 
     /* ↓ 2.solvable when right in front of it ----------------------------------------------- */
     AddInformationToTourism(), // OSM Carto


### PR DESCRIPTION
Crossing button is visable from further away and so should be asked
before vibration where you need to be closer.