### PR TITLE
Patch SnakeYAML dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,9 +105,15 @@ repositories {
 }
 
 configurations {
-    // it's already included in Android
     all {
+        // it's already included in Android
         exclude(group = "net.sf.kxml", module = "kxml2")
+
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("org.snakeyaml:snakeyaml-engine:2.3"))
+                .using(module("org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484"))
+                .because("https://github.com/streetcomplete/StreetComplete/issues/3889")
+        }
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ configurations {
         // it's already included in Android
         exclude(group = "net.sf.kxml", module = "kxml2")
 
+        // TODO remove substitution when `kaml` dependency uses newer version of `org.snakeyaml:snakeyaml-engine`
         resolutionStrategy.dependencySubstitution {
             substitute(module("org.snakeyaml:snakeyaml-engine:2.3"))
                 .using(module("org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://jitpack.io") }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO remove when dependency to org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484 is no longer needed
         maven { url = java.net.URI("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
Fixes #3889.

Running `../gradlew dependencies` in the `app` directory verifies that all occurrences of `org.snakeyaml:snakeyaml-engine` are indeed replaced with the patched `org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484` version from https://jitpack.io/#org.bitbucket.snakeyaml.snakeyaml-engine.src.master/

This compiles and works fine in the emulator with Android 11. @westnordost can you try to reproduce the issue in Android 5?