### PR TITLE
change AddSeating() quest position

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -324,6 +324,7 @@ whether the postbox is still there in countries in which it is enabled */
     SpecifyShopType(),
     CheckShopType(),
     AddOpeningHours(featureDictionaryFuture),
+    AddSeating(), // easily visible from outside, but only seasonally
 
     AddAtmOperator(),
 
@@ -389,7 +390,6 @@ whether the postbox is still there in countries in which it is enabled */
     AddKosher(),
     AddWheelchairAccessBusiness(), // used by wheelmap, OsmAnd, Organic Maps
     AddInternetAccess(), // used by OsmAnd
-    AddSeating(),
 
     AddFuelSelfService(),
 


### PR DESCRIPTION
show `Seating quest` earlier in list of quest, because:

- it is quicker and easier to determine than for example `AirConditioning` or `Smoking` quests (when the `Seating` quest is enabled seasonally)
- `Smoking` quest would benefit, as it will modify its behaviour if `Seating` data is available