### PR TITLE
Add more negative tests for prefix usage with TagOlderThan

### DIFF
--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThanTest.kt
@@ -68,4 +68,12 @@ class TagOlderThanTest {
             "check_date:opening_hours" to newDate.toCheckDateString()
         ), newDate))
     }
+
+    @Test fun `does not match old element with tag only as a prefix`() {
+        assertFalse(c.matches(mapOf("opening_hours:signed" to "tag"), oldDate))
+    }
+
+    @Test fun `does not match new element with tag only as a prefix`() {
+        assertFalse(c.matches(mapOf("opening_hours:signed" to "tag"), newDate))
+    }
 }


### PR DESCRIPTION
To document and validate the current behaviour.

While doing some investigation of #3946