### PR TITLE
Add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Discussions
     url: https://github.com/streetcomplete/StreetComplete/discussions
-    about: For discussions about the usage of StreetComplete, asking questions or talking about visions.
+    about: For discussions about the usage of StreetComplete, asking questions or talking about ideas which are not yet actionable.
   - name: Translations
     url: https://poeditor.com/join/project/IE4GC127Ki
     about: For contributing and discussing translations of StreetComplete

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/streetcomplete/StreetComplete/discussions
+    about: For discussions about the usage of StreetComplete, asking questions or talking about visions.
+  - name: Translations
+    url: https://poeditor.com/join/project/IE4GC127Ki
+    about: For contributing and discussing translations of StreetComplete

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/streetcomplete/StreetComplete/discussions
     about: For discussions about the usage of StreetComplete, asking questions or talking about ideas which are not yet actionable.
   - name: Translations
-    url: https://poeditor.com/join/project/IE4GC127Ki
+    url: https://github.com/streetcomplete/StreetComplete/blob/master/CONTRIBUTING.md#translating-the-app
     about: For contributing and discussing translations of StreetComplete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Content:
 
 ## Translating the app
 
-You can translate StreetComplete at POEditor. You can add missing translations and improve existing ones.
+You can translate StreetComplete at POEditor. You can add missing translations and improve existing ones. Discuss translations or specific wording at POEditor and not at GitHub.
 
 The only required skills here are ability to read English text and write in your own language.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Content:
 
 ## Translating the app
 
-You can translate StreetComplete at POEditor. You can add missing translations and improve existing ones. Discuss translations or specific wording at POEditor and not at GitHub.
+You can translate StreetComplete at POEditor. You can add missing translations and improve existing ones. Discuss translations at POEditor.
 
 The only required skills here are ability to read English text and write in your own language.
 


### PR DESCRIPTION
Link to GitHub Discussions and translations via POEditor in the template chooser when creating a new GitHub issue.
Rationale: There's quite some issues that should either be a GitHub discussion or a discussion on POEditor. This change hopefully guides more users to the appropriate place.

See below how it will look approximately:

![Preview](https://user-images.githubusercontent.com/3404787/164261554-afd47ea1-1595-4a5f-9987-37b675e6411c.png)
