### PR TITLE
Add more offices

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
@@ -96,6 +96,7 @@ fun isShopExpressionFragment(prefix: String? = null): String {
             ),
             "office" to arrayOf(
                 "insurance", "travel_agent", "tax_advisor", "estate_agent", "political_party",
+                "lawyer", "telecommunication", "it", "accountant"
             ),
             "craft" to arrayOf(
                 "shoemaker", "tailor", "photographer", "watchmaker", "optician",

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -79,6 +79,8 @@ class AddOpeningHours(
                 // common
                 "insurance", "government", "travel_agent", "tax_advisor", "religion",
                 "employment_agency", "diplomatic", "coworking",
+                "estate_agent", "lawyer", "telecommunication", "educational_institution",
+                "association", "ngo", "it", "accountant"
             ),
             "craft" to arrayOf(
                 // common

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -73,9 +73,11 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>() {
                 // common
                 "insurance", "government", "travel_agent", "tax_advisor", "religion",
                 "employment_agency", "diplomatic", "coworking",
+                "estate_agent", "lawyer", "telecommunication", "educational_institution",
+                "association", "ngo", "it", "accountant"
 
                 // name & wheelchair
-                "lawyer", "estate_agent", "political_party", "therapist"
+                "political_party", "therapist"
             ),
             "craft" to arrayOf(
                 // common


### PR DESCRIPTION
Added a few more `office` options to the Opening Hours and Wheelchair quests. Also added some that seemed appropriate to the `isShopExpressionFilter` function too.

The following were added because they had more than [10K instances from taginfo](https://taginfo.openstreetmap.org/keys/?key=office#values), and had decent current usage of opening_hours:

- estate_agent (was already in wheelchair and shop expression)
- lawyer (was already in wheelchair)
- telecommunication
- educational_institution
- association
- ngo
- it
- accountant

I only included telecommunication, it, lawyer and accountant in the shop expression, as the others seemed less likely to be present in usual retail environments.
