### PR TITLE
Put the most likely/popular options first for seating

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeatingForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeatingForm.kt
@@ -6,9 +6,9 @@ import de.westnordost.streetcomplete.quests.TextItem
 
 class AddSeatingForm : AListQuestAnswerFragment<Seating>() {
     override val items = listOf(
-        TextItem(Seating.NO, R.string.quest_seating_takeaway),
+        TextItem(Seating.INDOOR_AND_OUTDOOR, R.string.quest_seating_indoor_and_outdoor),
         TextItem(Seating.ONLY_INDOOR, R.string.quest_seating_indoor_only),
         TextItem(Seating.ONLY_OUTDOOR, R.string.quest_seating_outdoor_only),
-        TextItem(Seating.INDOOR_AND_OUTDOOR, R.string.quest_seating_indoor_and_outdoor),
+        TextItem(Seating.NO, R.string.quest_seating_takeaway),
     )
 }


### PR DESCRIPTION
To match the app behaviour across the board...

Yes there's a small risk of muscle memory with changing the order (although while I feel like I've done quite a few of these I've only actually done 81...).

More importantly it makes it consistent with the card quest and e.g. the surface ones, where the most popular/likely options are first (far more places will have indoor seating or both, than takeaway only).

Some progress on, but doesn't completely finish #3993 