### PR TITLE
update KEYS_THAT_SHOULD_BE_REMOVED_WHEN_SHOP_IS_REPLACED

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
@@ -9,7 +9,7 @@ val KEYS_THAT_SHOULD_BE_REMOVED_WHEN_SHOP_IS_REPLACED = listOf(
     // popular shop=* / craft=* subkeys
     "marketplace", "household", "swimming_pool", "telecommunication", "laundry", "golf", "sports",
     "ice_cream", "scooter", "music", "retail", "yes", "ticket", "health", "newsagent", "lighting",
-    "truck", "car_repair", "video", "fuel", "farm", "car", "ski", "sculptor", "hearing_aids",
+    "truck", "car_repair", "car_parts", "video", "fuel", "farm", "car", "ski", "sculptor", "hearing_aids",
     "surf", "photo", "boat", "gas", "kitchen", "anime", "builder", "hairdresser", "security",
     "bakery", "bakehouse", "fishing", "doors", "kiosk", "market", "bathroom", "lamps", "vacant",
     "insurance", "caravan", "gift", "bicycle", "insulation", "communication", "mall", "model",


### PR DESCRIPTION
(periodic) update with newest taginfo from https://github.com/mnalis/StreetComplete-taginfo-categorize/ (adding `car_parts` to list of tags to remove)