### PR TITLE
Always show available map tiles

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
@@ -18,6 +18,13 @@ class MapTilesDownloadCacheConfig(context: Context) {
         .maxStale(DELETE_OLD_DATA_AFTER.toInt(), TimeUnit.MILLISECONDS)
         .build()
 
+    /* use separate cache control for tangram with large maxStale value to always show available
+    *  map tiles when panning the map, even without (or with bad) internet connection */
+    val tangramCacheControl = CacheControl.Builder()
+        .maxAge(12, TimeUnit.HOURS)
+        .maxStale(DELETE_OLD_DATA_AFTER.toInt(), TimeUnit.SECONDS)
+        .build()
+
     val cache: Cache?
 
     init {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/maptiles/MapTilesDownloadCacheConfig.kt
@@ -22,7 +22,7 @@ class MapTilesDownloadCacheConfig(context: Context) {
     *  map tiles when panning the map, even without (or with bad) internet connection */
     val tangramCacheControl = CacheControl.Builder()
         .maxAge(12, TimeUnit.HOURS)
-        .maxStale(DELETE_OLD_DATA_AFTER.toInt(), TimeUnit.SECONDS)
+        .maxStale(10 * 365, TimeUnit.DAYS) // ten years
         .build()
 
     val cache: Cache?

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -252,7 +252,7 @@ open class MapFragment :
         return object : DefaultHttpHandler(builder) {
             override fun configureRequest(url: HttpUrl, builder: Request.Builder) {
                 builder
-                    .cacheControl(cacheConfig.cacheControl)
+                    .cacheControl(cacheConfig.tangramCacheControl)
                     .header("User-Agent", ApplicationConstants.USER_AGENT + " / " + Version.userAgent())
             }
         }


### PR DESCRIPTION
fixes #4015 by using `CacheControl` with a very high `maxStale` in `MapFragment` (used to download tiles when panning the map).

When panning, all map tiles available offline are used, no matter how old (well, up to 14000 days).
Since `CacheControl` in `MapTilesDownloader` is unchanged, old tiles will be updated as part of downloading / scanning for quests.