### PR TITLE
Remove "the" from OpenStreetMap and add acronym

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
 
 This app finds missing map data in your vicinity and displays it on a map as quests. Solve each quest by visiting the location on-site and answering a simple question to update the map.
 
-The info you enter is directly added to the OpenStreetMap in your name, without the need to use another editor."</string>
+The info you enter is directly added to OpenStreetMap in your name, without the need to use another editor."</string>
 
 
     <!-- Main menu -->
@@ -310,7 +310,7 @@ Unfortunately, due to Google Play Store policy, no links leading to donations ma
     <string name="privacy_html">"&lt;p&gt;Ah, someone who cares about privacy, nice! I think I have only good news for you:&lt;/p&gt;
 &lt;p&gt;&lt;b&gt;Direct Contributions&lt;/b&gt;&lt;/p&gt;
 &lt;p&gt;
-First off, understand that with this app, you make actual and direct contributions to the OpenStreetMap.&lt;br/&gt;
+First off, understand that with this app, you make actual and direct contributions to OpenStreetMap (OSM).&lt;br/&gt;
 Anything you contribute in this app is directly added to the map, there is no third party in-between the app and OSM infrastructure.
 &lt;/p&gt;
 &lt;p&gt;


### PR DESCRIPTION
I can't find an official style guide, but I've never come across OSM referred to with "the".

Also, the acronym should be introduced as it is used later.