### PR TITLE
Improve performance when displaying pins

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -53,6 +53,9 @@ class QuestPinsManager(
 
     private val viewLifecycleScope: CoroutineScope = CoroutineScope(SupervisorJob())
 
+    private var updatePinsIsRunning = false
+    private var updatePinsAgain = false
+
     /** Switch active-ness of quest pins layer */
     var isActive: Boolean = false
         set(value) {
@@ -188,9 +191,19 @@ class QuestPinsManager(
     }
 
     private fun updatePins() {
+        if (updatePinsIsRunning) {
+            updatePinsAgain = true
+            return
+        }
         if (isActive) {
+            updatePinsIsRunning = true
             val pins = synchronized(quests) { quests.values.flatten() }
             pinsMapComponent.set(pins)
+            updatePinsIsRunning = false
+            if (updatePinsAgain) {
+                updatePinsAgain = false
+                updatePins()
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses two related performance issues I encounter way too often (maybe because of my slow phone).

1. The app gets noticeably slower over time, after scrolling the map a lot, because `updatePins` may take several seconds when `quests` holds several thousand quests. And `updatePins` is called every time a quest is solved, plus often when scrolling.
The improvement here is removing all quests not currently visible. I found that above roughly 10000 quests, getting quests from DB again is negligible compared to the time `updatePins` takes. The `retrievedTiles` size limit is added to avoid permanent cleanup in areas with high quest density.
I am not sure how reasonable the limits are for faster phones that have more memory and performance than my S4 mini, but I guess in that case loading from DB is also faster, and the changes will not be noticed.
2. When scrolling the map quickly in areas with many quests, it sometimes takes very long (30s) for the quest pins to appear after scrolling is done. This is partially caused by the amount of pins (already addressed), but also because `updatePins` is called multiple times in parallel, and takes very long to execute.
Since pins for all `quests` are loaded at once anyway (i.e. not incremental), slow loading and fast scrolling may lead to situations where the same list of quest pins is loaded multiple times, massively slowing down the app. My solution for avoiding calling `updatePins` multiple times in parallel may not be the best, but still I found large improvements when testing.
It may be called a second time after finishing because quest list could have changed meanwhile.