### PR TITLE
Ask for summit register more often

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -48,10 +48,10 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
         val hikingRoutes = mapData.relations
             .filter { it.tags["route"] == "hiking" }
             .mapNotNull { mapData.getRelationGeometry(it.id) as? ElementPolylinesGeometry }
-        if (hikingRoutes.isEmpty()) return emptyList()
 
         // yes, this is very inefficient, however, peaks are very rare
         return peaks.filter { peak ->
+            peak.tags["summit:cross"] == "yes" || peak.tags.containsKey("summit:register") ||
             hikingRoutes.any { hikingRoute ->
                 hikingRoute.polylines.any { ways ->
                     peak.position.distanceToArcs(ways) <= 10

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -52,6 +52,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
 
         // yes, this is very inefficient, however, peaks are very rare
         return peaks.filter { peak ->
+            peak.tags["summit:cross"] == "yes" || peak.tags.containsKey("summit:register") ||
             hikingPathsAndRoutes.any { hikingPath ->
                 hikingPath.polylines.any { ways ->
                     peak.position.distanceToArcs(ways) <= 10
@@ -67,7 +68,11 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
    """.toElementFilterExpression() }
 
     override fun isApplicableTo(element: Element): Boolean? =
-        if (!filter.matches(element)) false else null
+        when {
+            !filter.matches(element) -> false
+            element.tags["summit:cross"] == "yes" || element.tags.containsKey("summit:register") -> true
+            else -> null
+        }
 
     override fun createForm() = YesNoQuestAnswerFragment()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -61,7 +61,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
     private val hikingPathsFilter by lazy { """
         ways with
           highway = path
-          sac_scale ~ mountain_hiking|demanding_mountain_hiking|alpine_hiking|demanding_alpine_hiking|difficult_alpine_hiking
+          and sac_scale ~ mountain_hiking|demanding_mountain_hiking|alpine_hiking|demanding_alpine_hiking|difficult_alpine_hiking
    """.toElementFilterExpression() }
 
     override fun isApplicableTo(element: Element): Boolean? =

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -45,12 +45,14 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
         val peaks = mapData.nodes.filter { filter.matches(it) }
         if (peaks.isEmpty()) return emptyList()
 
-        val hikingPaths = mapData.ways.filter { hikingPathsFilter.matches(it) }
-            .mapNotNull { mapData.getWayGeometry(it.id) as? ElementPolylinesGeometry }
+        val hikingPathsAndRoutes = mapData.ways.filter { hikingPathsFilter.matches(it) }
+            .mapNotNull { mapData.getWayGeometry(it.id) as? ElementPolylinesGeometry } +
+            mapData.relations.filter {  it.tags["route"] == "hiking" }
+                .mapNotNull { mapData.getRelationGeometry(it.id) as? ElementPolylinesGeometry }
 
         // yes, this is very inefficient, however, peaks are very rare
         return peaks.filter { peak ->
-            hikingPaths.any { hikingPath ->
+            hikingPathsAndRoutes.any { hikingPath ->
                 hikingPath.polylines.any { ways ->
                     peak.position.distanceToArcs(ways) <= 10
                 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/summit_register/AddSummitRegister.kt
@@ -47,7 +47,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean> {
 
         val hikingPathsAndRoutes = mapData.ways.filter { hikingPathsFilter.matches(it) }
             .mapNotNull { mapData.getWayGeometry(it.id) as? ElementPolylinesGeometry } +
-            mapData.relations.filter {  it.tags["route"] == "hiking" }
+            mapData.relations.filter { it.tags["route"] == "hiking" }
                 .mapNotNull { mapData.getRelationGeometry(it.id) as? ElementPolylinesGeometry }
 
         // yes, this is very inefficient, however, peaks are very rare


### PR DESCRIPTION
Currently this quest is not asked because `route` relations are ignored.
With this PR, the quest is now asked for resurvey and if there is a summit cross (in my experience there is often a register if there is a cross).