### PR TITLE
Fix trace uploads

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.net.URLEncoder
 
 class NoteEditsUploader(
     private val noteEditsController: NoteEditsController,
@@ -125,7 +126,8 @@ class NoteEditsUploader(
     ): String {
         if (trackpoints.isEmpty()) return ""
         val track = tracksApi.create(trackpoints, noteText)
-        return "\n\nGPS Trace: \nhttps://www.openstreetmap.org/user/${track.userName}/traces/${track.id}"
+        val encodedUsername = URLEncoder.encode(track.userName, "utf-8")
+        return "\n\nGPS Trace: https://www.openstreetmap.org/user/$encodedUsername/traces/${track.id}\n"
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
@@ -126,7 +126,7 @@ class NoteEditsUploader(
     ): String {
         if (trackpoints.isEmpty()) return ""
         val track = tracksApi.create(trackpoints, noteText)
-        val encodedUsername = URLEncoder.encode(track.userName, "utf-8")
+        val encodedUsername = URLEncoder.encode(track.userName, "utf-8").replace("+", "%20")
         return "\n\nGPS Trace: https://www.openstreetmap.org/user/$encodedUsername/traces/${track.id}\n"
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/CreateNoteFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/CreateNoteFragment.kt
@@ -48,7 +48,7 @@ class CreateNoteFragment : AbstractCreateNoteFragment() {
 
     interface Listener {
         /** Called when the user wants to leave a note which is not related to a quest  */
-        fun onCreatedNote(note: String, imagePaths: List<String>, screenPosition: Point)
+        fun onCreatedNote(note: String, imagePaths: List<String>, screenPosition: Point, hasGpxAttached: Boolean = false)
     }
     private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
 
@@ -134,7 +134,7 @@ class CreateNoteFragment : AbstractCreateNoteFragment() {
 
         binding.markerCreateLayout.markerLayoutContainer.visibility = View.INVISIBLE
 
-        listener?.onCreatedNote(text, imagePaths, screenPos)
+        listener?.onCreatedNote(text, imagePaths, screenPos, hasGpxAttached)
     }
 
     companion object {


### PR DESCRIPTION
This fixes two issues:
1. On second notes, the GPX tracks are still being appended. I thought I tested this originally, but it seems to have slipped by, sorry. Now I explicitly send that the notes should attach the current tracks with the `hasGpxAttached` argument variable used to visualize the traces are going to be attached to the note. (you can see this issue [here](https://www.openstreetmap.org/traces/tag/streetcomplete))
2. Names with spaces are not handled properly. I encode the username so that the url is clickable from the note ([an example](https://www.openstreetmap.org/note/3211907)).