### PR TITLE
comment correction

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmtracks/TracksApi.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmtracks/TracksApi.kt
@@ -14,7 +14,7 @@ interface TracksApi {
      * @param trackpoints history of recorded trackpoints
      * @param noteText optional text appended to the track
      *
-     * @throws AuthorizationException if this application is not authorized to write notes
+     * @throws AuthorizationException if this application is not authorized to write traces
      *                                (Permission.READ_GPS_TRACES, Permission.WRITE_GPS_TRACES)
      * @throws ConnectionException if a temporary network connection problem occurs
      *


### PR DESCRIPTION
track uploading fails if there are no permission for `tracks`, not `notes`