### PR TITLE
Fix TimePicker hour/minute deprecations

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/TimeRangePickerDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/TimeRangePickerDialog.kt
@@ -20,6 +20,9 @@ import de.westnordost.streetcomplete.databinding.DialogTimeRangePickerBinding
 import de.westnordost.streetcomplete.databinding.TimeRangePickerEndPickerBinding
 import de.westnordost.streetcomplete.databinding.TimeRangePickerStartPickerBinding
 import de.westnordost.streetcomplete.osm.opening_hours.model.TimeRange
+import de.westnordost.streetcomplete.util.ktx.hourCompat
+import de.westnordost.streetcomplete.util.ktx.minuteCompat
+import de.westnordost.streetcomplete.util.ktx.updateTime
 
 class TimeRangePickerDialog(
     context: Context,
@@ -38,9 +41,9 @@ class TimeRangePickerDialog(
 
     private val openEndCheckbox: CheckBox
 
-    private val minutesStart get() = startPicker.currentHour * 60 + startPicker.currentMinute
+    private val minutesStart get() = startPicker.hourCompat * 60 + startPicker.minuteCompat
 
-    private val minutesEnd get() = endPicker.currentHour * 60 + endPicker.currentMinute
+    private val minutesEnd get() = endPicker.hourCompat * 60 + endPicker.minuteCompat
 
     init {
         val inflater = LayoutInflater.from(context)
@@ -69,11 +72,8 @@ class TimeRangePickerDialog(
         endPicker = endPickerBinding.picker
         endPicker.setIs24HourView(is24HourView)
         if (timeRange != null) {
-            startPicker.currentHour = timeRange.start / 60
-            startPicker.currentMinute = timeRange.start % 60
-
-            endPicker.currentHour = timeRange.end / 60
-            endPicker.currentMinute = timeRange.end % 60
+            startPicker.updateTime(timeRange.start / 60, timeRange.start % 60)
+            endPicker.updateTime(timeRange.end / 60, timeRange.end % 60)
             openEndCheckbox.isChecked = timeRange.isOpenEnded
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/TimePicker.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/TimePicker.kt
@@ -1,0 +1,22 @@
+package de.westnordost.streetcomplete.util.ktx
+
+import android.os.Build
+import android.widget.TimePicker
+
+private val atLeastM
+    get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+
+@Suppress("DEPRECATION") // Can be removed when minSdk >= 23
+var TimePicker.hourCompat: Int
+    get() = if (atLeastM) hour else currentHour
+    set(value) = if (atLeastM) hour = value else currentHour = value
+
+@Suppress("DEPRECATION") // Can be removed when minSdk >= 23
+var TimePicker.minuteCompat: Int
+    get() = if (atLeastM) minute else currentMinute
+    set(value) = if (atLeastM) minute = value else currentMinute = value
+
+fun TimePicker.updateTime(hourOfDay: Int, minuteOfHour: Int) {
+    hourCompat = hourOfDay
+    minuteCompat = minuteOfHour
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/TimePickerDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/TimePickerDialog.kt
@@ -8,7 +8,9 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.TimePicker
 import androidx.appcompat.app.AlertDialog
-import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.util.ktx.hourCompat
+import de.westnordost.streetcomplete.util.ktx.minuteCompat
+import de.westnordost.streetcomplete.util.ktx.updateTime
 
 /** A dialog in which you can select a time */
 class TimePickerDialog(
@@ -26,7 +28,7 @@ class TimePickerDialog(
         setView(timePicker)
         setButton(BUTTON_POSITIVE, context.getString(android.R.string.ok)) { _, _ ->
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || timePicker.validateInput()) {
-                callback(timePicker.currentHour, timePicker.currentMinute)
+                callback(timePicker.hourCompat, timePicker.minuteCompat)
                 // Clearing focus forces the dialog to commit any pending
                 // changes, e.g. typed text in a NumberPicker.
                 timePicker.clearFocus()
@@ -37,19 +39,13 @@ class TimePickerDialog(
             cancel()
         }
         timePicker.setIs24HourView(is24HourView)
-        timePicker.currentHour = initialHourOfDay
-        timePicker.currentMinute = initialMinute
-    }
-
-    fun updateTime(hourOfDay: Int, minuteOfHour: Int) {
-        timePicker.currentHour = hourOfDay
-        timePicker.currentMinute = minuteOfHour
+        timePicker.updateTime(initialHourOfDay, initialMinute)
     }
 
     override fun onSaveInstanceState(): Bundle {
         val state = super.onSaveInstanceState()
-        state.putInt(HOUR, timePicker.currentHour)
-        state.putInt(MINUTE, timePicker.currentMinute)
+        state.putInt(HOUR, timePicker.hourCompat)
+        state.putInt(MINUTE, timePicker.minuteCompat)
         state.putBoolean(IS_24_HOUR, timePicker.is24HourView)
         return state
     }
@@ -59,8 +55,7 @@ class TimePickerDialog(
         val hour = savedInstanceState.getInt(HOUR)
         val minute = savedInstanceState.getInt(MINUTE)
         timePicker.setIs24HourView(savedInstanceState.getBoolean(IS_24_HOUR))
-        timePicker.currentHour = hour
-        timePicker.currentMinute = minute
+        timePicker.updateTime(hour, minute)
     }
 
     companion object {


### PR DESCRIPTION
`currentHour` and `currentMinute` are deprecated in API 23. This should fix that deprecation for now.