### PR TITLE
Allows user to mark path as indoor=yes

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -47,6 +47,9 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
             is IsActuallyStepsAnswer -> {
                 tags["highway"] = "steps"
             }
+            is IsIndoorsAnswer -> {
+                tags["indoor"] = "yes"
+            }
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurfaceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurfaceForm.kt
@@ -13,6 +13,7 @@ class AddPathSurfaceForm : AImageListQuestForm<Surface, SurfaceOrIsStepsAnswer>(
 
     override val otherAnswers get() = listOfNotNull(
         createConvertToStepsAnswer(),
+        createMarkAsInsideAnswer(),
     )
 
     override val itemsPerRow = 3
@@ -40,6 +41,15 @@ class AddPathSurfaceForm : AImageListQuestForm<Surface, SurfaceOrIsStepsAnswer>(
 
         return AnswerItem(R.string.quest_generic_answer_is_actually_steps) {
             applyAnswer(IsActuallyStepsAnswer)
+        }
+    }
+
+    private fun createMarkAsInsideAnswer(): AnswerItem? {
+        val way = element as? Way ?: return null
+        if (way.isArea() || way.tags["inside"] == "yes") return null
+
+        return AnswerItem(R.string.quest_generic_answer_is_indoors) {
+            applyAnswer(IsIndoorsAnswer)
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurfaceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurfaceForm.kt
@@ -13,7 +13,7 @@ class AddPathSurfaceForm : AImageListQuestForm<Surface, SurfaceOrIsStepsAnswer>(
 
     override val otherAnswers get() = listOfNotNull(
         createConvertToStepsAnswer(),
-        createMarkAsInsideAnswer(),
+        createMarkAsIndoorsAnswer(),
     )
 
     override val itemsPerRow = 3
@@ -44,9 +44,9 @@ class AddPathSurfaceForm : AImageListQuestForm<Surface, SurfaceOrIsStepsAnswer>(
         }
     }
 
-    private fun createMarkAsInsideAnswer(): AnswerItem? {
+    private fun createMarkAsIndoorsAnswer(): AnswerItem? {
         val way = element as? Way ?: return null
-        if (way.isArea() || way.tags["inside"] == "yes") return null
+        if (way.isArea() || way.tags["indoor"] == "yes") return null
 
         return AnswerItem(R.string.quest_generic_answer_is_indoors) {
             applyAnswer(IsIndoorsAnswer)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 sealed interface SurfaceOrIsStepsAnswer
 object IsActuallyStepsAnswer : SurfaceOrIsStepsAnswer
+object IsIndoorsAnswer : SurfaceOrIsStepsAnswer
 
 data class SurfaceAnswer(val value: Surface, val note: String? = null) : SurfaceOrIsStepsAnswer
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="quest_generic_answer_noSign">There is no sign</string>
     <!-- e.g. "it is displayed as a footway on the map but actually these are steps" -->
     <string name="quest_generic_answer_is_actually_steps">"These are steps"</string>
+    <string name="quest_generic_answer_is_indoors">"This is indoors"</string>
 
     <!-- As in: "select ONE of the pictures below" -->
     <string name="quest_roofShape_select_one">"Select one:"</string>


### PR DESCRIPTION
When indoors path is not yet mapped with [indoor=yes](https://wiki.openstreetmap.org/wiki/Key:indoor), user will be asked for its surface (if it is already marked as `indoor=yes` we skip `surface` quest). However, we lack answers for many indoor surfaces (see linked issue).

This PR provides other answer `This is indoors` which marks the path as `indoor=yes`, so `surface` quest is skipped (or, if we later decide to cover indoor surfaces too, it would help offer right set of surfaces for indoor usage).

Fixes https://github.com/streetcomplete/StreetComplete/issues/4146