### PR TITLE
use fake map to pass properties to Tangram-ES

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -5,6 +5,7 @@ import com.mapzen.tangram.geometry.Point
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
 import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
+import de.westnordost.streetcomplete.util.ListMap
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
 class PinsMapComponent(ctrl: KtMapController) {
@@ -25,10 +26,7 @@ class PinsMapComponent(ctrl: KtMapController) {
                 "kind" to pin.iconName,
                 "importance" to pin.importance.toString()
             )
-            val properties = HashMap<String, String>()
-            properties.putAll(tangramProperties)
-            properties.putAll(pin.properties)
-            Point(pin.position.toLngLat(), properties)
+            Point(pin.position.toLngLat(), ListMap(tangramProperties + pin.properties))
         })
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SelectedPinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SelectedPinsMapComponent.kt
@@ -11,6 +11,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
 import de.westnordost.streetcomplete.screens.main.map.tangram.Marker
 import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
+import de.westnordost.streetcomplete.util.ListMap
 import de.westnordost.streetcomplete.util.ktx.getBitmapDrawable
 import de.westnordost.streetcomplete.util.ktx.pxToDp
 
@@ -50,10 +51,10 @@ class SelectedPinsMapComponent(private val ctx: Context, private val ctrl: KtMap
 
     private fun putSelectedPins(@DrawableRes iconResId: Int, pinPositions: Collection<LatLon>) {
         val points = pinPositions.map { position ->
-            Point(position.toLngLat(), mapOf(
+            Point(position.toLngLat(), ListMap(listOf(
                 "type" to "point",
                 "kind" to ctx.resources.getResourceEntryName(iconResId)
-            ))
+            )))
         }
         selectedPinsLayer.setFeatures(points)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
@@ -32,33 +32,33 @@ class StyleableOverlayMapComponent(private val resources: Resources, ctrl: KtMap
     /** Show given map data with each the given style */
     fun set(features: Collection<StyledElement>) {
         layer.setFeatures(features.flatMap { (element, geometry, style) ->
-            val props = HashMap<String, String>()
-            props[ELEMENT_ID] = element.id.toString()
-            props[ELEMENT_TYPE] = element.type.name
+            val props = ArrayList<Pair<String, String>>()
+            props.add(ELEMENT_ID to element.id.toString())
+            props.add(ELEMENT_TYPE to element.type.name)
             when (style) {
                 is PolygonStyle -> {
-                    getHeight(element.tags)?.let { props["height"] = it.toString() }
-                    props["color"] = style.color
-                    props["strokeColor"] = getDarkenedColor(style.color)
-                    style.label?.let { props["text"] = it }
+                    getHeight(element.tags)?.let { props.add("height" to it.toString()) }
+                    props.add("color" to style.color)
+                    props.add("strokeColor" to getDarkenedColor(style.color))
+                    style.label?.let { props.add("text" to it) }
                 }
                 is PolylineStyle -> {
-                    props["width"] = getLineWidth(element.tags).toString()
-                    style.colorLeft?.let { props["colorLeft"] = it }
-                    style.colorRight?.let { props["colorRight"] = it }
+                    props.add("width" to getLineWidth(element.tags).toString())
+                    style.colorLeft?.let { props.add("colorLeft" to it) }
+                    style.colorRight?.let { props.add("colorRight" to it) }
                     if (style.color != null) {
-                        props["color"] = style.color
-                        props["strokeColor"] = getDarkenedColor(style.color)
+                        props.add("color" to style.color)
+                        props.add("strokeColor" to getDarkenedColor(style.color))
                     } else if (style.colorLeft != null || style.colorRight != null) {
                         // must have a color for the center if left or right is defined because
                         // there are really ugly overlaps in tangram otherwise
-                        props["color"] = resources.getString(R.string.road_color)
-                        props["strokeColor"] = resources.getString(R.string.road_outline_color)
+                        props.add("color" to resources.getString(R.string.road_color))
+                        props.add("strokeColor" to resources.getString(R.string.road_outline_color))
                     }
-                    style.label?.let { props["text"] = it }
+                    style.label?.let { props.add("text" to it) }
                 }
                 is PointStyle -> {
-                    style.label?.let { props["text"] = it }
+                    style.label?.let { props.add("text" to it) }
                 }
             }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/TracksMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/TracksMapComponent.kt
@@ -5,6 +5,7 @@ import com.mapzen.tangram.LngLat
 import com.mapzen.tangram.geometry.Polyline
 import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
 import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
+import de.westnordost.streetcomplete.util.ListMap
 import kotlin.math.max
 
 /** Takes care of showing the path(s) walked on the map */
@@ -75,8 +76,8 @@ class TracksMapComponent(ctrl: KtMapController) {
 }
 
 private fun List<LngLat>.toPolyline(old: Boolean, record: Boolean) =
-    Polyline(this, listOfNotNull(
+    Polyline(this, ListMap(listOfNotNull(
         "type" to "line",
         "old" to old.toString(),
         if (record) ("record" to "true") else null
-    ).toMap())
+    )))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/TangramExtensions.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/TangramExtensions.kt
@@ -13,12 +13,13 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolygonsGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.util.ListMap
 import de.westnordost.streetcomplete.util.math.distanceTo
 
-fun ElementGeometry.toTangramGeometry(properties: Map<String, String> = emptyMap()): List<Geometry> = when (this) {
+fun ElementGeometry.toTangramGeometry(properties: List<Pair<String, String>> = emptyList()): List<Geometry> = when (this) {
     is ElementPolylinesGeometry -> {
         polylines.map { polyline ->
-            Polyline(polyline.map { it.toLngLat() }, properties + ("type" to "line"))
+            Polyline(polyline.map { it.toLngLat() }, ListMap(properties + ("type" to "line")))
         }
     }
     is ElementPolygonsGeometry -> {
@@ -27,12 +28,12 @@ fun ElementGeometry.toTangramGeometry(properties: Map<String, String> = emptyMap
                 polygons.map { polygon ->
                     polygon.map { it.toLngLat() }
                 },
-                properties + ("type" to "poly")
+                ListMap(properties + ("type" to "poly"))
             )
         )
     }
     is ElementPointGeometry -> {
-        listOf(Point(center.toLngLat(), properties + ("type" to "point")))
+        listOf(Point(center.toLngLat(), ListMap(properties + ("type" to "point"))))
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ArrayListMap.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ArrayListMap.kt
@@ -1,0 +1,28 @@
+package de.westnordost.streetcomplete.util
+
+/** A "Map" that is actually a list. Hence, DO NOT USE this except if you know exactly what you are
+ *  doing - the performance of any map-related operation except .entries will be O(n).
+ *
+ *  This class exists because some third-party interfaces expect a Map when the only thing they do
+ *  with it is to iterate through its entries and afterwards throw it away. If that happens en-masse
+ *  this is quite memory inefficient. */
+class ListMap<K,V>(list: List<Pair<K,V>>) : Map<K,V> {
+    override val entries: Set<Map.Entry<K, V>> = ListSet(list.map { Entry(it.first, it.second) })
+    override val keys: Set<K> get() = ListSet(entries.map { it.key })
+    override val size: Int = entries.size
+    override val values: Collection<V> get() = entries.map { it.value }
+    override fun containsKey(key: K): Boolean = entries.find { it.key == key } != null
+    override fun containsValue(value: V): Boolean = entries.find { it.value == value } != null
+    override fun get(key: K): V? = entries.find { it.key == key }?.value
+    override fun isEmpty(): Boolean = size == 0
+
+    private data class Entry<K,V>(override val key: K, override val value: V) : Map.Entry<K,V>
+
+    private class ListSet<E>(private val list: List<E>) : Set<E> {
+        override val size: Int get() = list.size
+        override fun contains(element: E): Boolean = list.contains(element)
+        override fun containsAll(elements: Collection<E>): Boolean = list.containsAll(elements)
+        override fun isEmpty(): Boolean = size == 0
+        override fun iterator(): Iterator<E> = list.iterator()
+    }
+}


### PR DESCRIPTION
Oftentimes there are thousands of quests to display. To display them, they are set as `Feature`s on a tangram-es `MapData` layer. Each `Feature` requires a `Map<String,String>` of properties to be passed in, which control how the particular feature will look on the map. Hence, when there are thousands of quests to display, thousands of `Map<String,String>` are created.

Additionally, when you solve or undo a quest, the whole tangram-es `MapData` layer must be re-set with all the pins that should be displayed. Hence, the above is done all the time (i.e. when solving a quest).

Finally, tangram-es does not actually do anything with the `Map<String,String>` other than iterating through it via `map.getEntries()`. Hence, we can just pass a `List` disguised as a `Map` and this is not slower, maybe a little faster. More importantly, it should reduce spikes in memory use (and thus GC activity) when solving a quest, which may incidentally also make it faster.

But now sure how much of a performance effect this would actually have. Asking @Helium314 for feedback.