### PR TITLE
Simpler bbox for ElementPointGeometry

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometry.kt
@@ -31,6 +31,6 @@ data class ElementPolygonsGeometry(val polygons: List<List<LatLon>>, override va
 @Serializable
 @SerialName("point")
 data class ElementPointGeometry(override val center: LatLon) : ElementGeometry() {
-    private val bbox by lazy { listOf(center).enclosingBoundingBox() }
+    private val bbox by lazy { BoundingBox(center, center) }
     override fun getBounds(): BoundingBox = bbox
 }


### PR DESCRIPTION
When testing for #4125 I noticed that it's possible to save a surprising amount of memory by not storing node geometries.
I traced this to the (lazy) creation of bbox for the node, which creates two new `LatLon`s instead of re-using the node position.

I guess currently this change will not matter, but could be a slight improvement depending on how the cache will be done.