### PR TITLE
Don't ask path smoothness for highway=pedestrian

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
@@ -58,5 +58,4 @@ class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
 }
 
 // smoothness is not asked for steps
-// "pedestrian" is in here so the path answers are shown instead of road answers (which focus on cars)
-val ALL_PATHS_EXCEPT_STEPS = listOf("footway", "cycleway", "path", "bridleway", "pedestrian")
+val ALL_PATHS_EXCEPT_STEPS = listOf("footway", "cycleway", "path", "bridleway")


### PR DESCRIPTION
fixes #4180

Smoothness for highway=pedestrian is already asked in the road smoothness quest.
According to the (now removed) comment, I added pedestrian to path smoothness with the idea of having the smoothness description text dependent on whether it's a path or a road. But anyway, looks like this wasn't implemented in the end.