### PR TITLE
Fix Attached GPS Tracks

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateNoteFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateNoteFragment.kt
@@ -152,7 +152,8 @@ class CreateNoteFragment : AbstractCreateNoteFragment() {
         val fullText = "$text\n\nvia ${ApplicationConstants.USER_AGENT}"
         viewLifecycleScope.launch {
             withContext(Dispatchers.IO) {
-                val recordedTrack = listener?.getRecordedTrack().orEmpty()
+                val recordedTrack =
+                    if (hasGpxAttached) listener?.getRecordedTrack().orEmpty() else emptyList()
                 noteEditsController.add(0, NoteEditAction.CREATE, position, fullText, imagePaths, recordedTrack)
             }
         }


### PR DESCRIPTION
Enforce that GPS tracks should not be added if the note was not created after a track recording.
Should close issue #4199
