### PR TITLE
Fix the GPX filename timestamps

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmtracks/TracksApiImpl.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmtracks/TracksApiImpl.kt
@@ -25,7 +25,7 @@ class TracksApiImpl(osm: OsmConnection) : TracksApi {
         val name = DateTimeFormatter
             .ofPattern("yyyy_MM_dd'T'HH_mm_ss.SSSSSS'Z'")
             .withZone(ZoneOffset.UTC)
-            .format(Instant.ofEpochSecond(trackpoints[0].time)) + ".gpx"
+            .format(Instant.ofEpochMilli(trackpoints[0].time)) + ".gpx"
         val visibility = GpsTraceDetails.Visibility.IDENTIFIABLE
         val description = noteText ?: "Uploaded via ${ApplicationConstants.USER_AGENT}"
         val tags = listOf(ApplicationConstants.NAME.lowercase())


### PR DESCRIPTION
Entirely untested, but strongly assumed based on https://github.com/streetcomplete/StreetComplete/commit/47447504ea8cf40fff8b2cce6b6b14148a43559e and the fact it's currently clearly wrong:
https://www.openstreetmap.org/traces/tag/streetcomplete/

And a bit of maths :nerd_face: 