### PR TITLE
Ask wheelchair access for nameless businesses

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -13,8 +13,7 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-          (name or brand)
-          and access !~ no|private
+          access !~ no|private
           and !wheelchair
           and (
             shop and shop !~ no|vacant


### PR DESCRIPTION
According to https://github.com/streetcomplete/StreetComplete/issues/4120#issuecomment-1156437799

> most "name" requirements are relicts from when the feature name of each element was not always displayed.

So it looks like the `(name or brand)` requirement for the wheelchair quest is a leftover from earlier times and can be removed.