### PR TITLE
Fix crash in aerial view

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -81,6 +81,7 @@ open class MapFragment :
         set(value) {
             if (field == value) return
             field = value
+            if (sceneMapComponent?.isAerialView == true) return
 
             val toggle = if (value) "true" else "false"
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
@@ -26,6 +26,9 @@ class SceneMapComponent(
         set(value) {
             field = value
             aerialViewChanged = true
+            if (value)
+                // remove keys referring to layers that don't exist in aerial view
+                sceneUpdates.keys.removeAll { it.startsWith("layers.buildings") }
         }
     private var aerialViewChanged: Boolean = false
 


### PR DESCRIPTION
Aerial view is currently not used, so this fix will not have any noticeable effect.
But in case aerial view is resurrected, it shouldn't crash when toggling `show3DBuildings` (happens because in aerial view there is no buildings layer where `extrude` could be toggled).