### PR TITLE
this quests are useful also for cyclists

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnRoad.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierOnRoad.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.osm.Tags
@@ -27,7 +28,7 @@ class AddBarrierOnRoad : OsmElementQuestType<BarrierType> {
     override val changesetComment = "Specify how roads and barriers intersect"
     override val wikiLink = "Key:barrier"
     override val icon = R.drawable.ic_quest_barrier_on_road
-    override val achievements = listOf(CAR)
+    override val achievements = listOf(CAR, BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_barrier_road_intersection
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.osm.Tags
@@ -32,7 +33,7 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAnswer>() {
     override val changesetComment = "Specify road surfaces"
     override val wikiLink = "Key:surface"
     override val icon = R.drawable.ic_quest_street_surface
-    override val achievements = listOf(CAR)
+    override val achievements = listOf(CAR, BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) =
         if (tags["area"] == "yes") R.string.quest_streetSurface_square_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.tracktype
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.ANYTHING_UNPAVED
 import de.westnordost.streetcomplete.osm.Tags
@@ -23,7 +24,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
     override val changesetComment = "Specify tracktypes"
     override val wikiLink = "Key:tracktype"
     override val icon = R.drawable.ic_quest_tractor
-    override val achievements = listOf(CAR)
+    override val achievements = listOf(CAR, BICYCLIST)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_tracktype_title
 


### PR DESCRIPTION
Is there some design reason why it was not done before? Is it safe to just add achievement to quest in such way?

Especially `tracktype` and `surface` is more important to cyclists than car drivers.