### PR TITLE
Documenting the icon colors used (for creating new quest icons)

### DIFF
--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -320,13 +320,13 @@ A new icon can reuse the content of [other quest icons](res/graphics/quest), it 
 Keep similar style to existing ones and app in general. Note the background color of the icon marks its relation group:
 - magenta: bicycle traffic
 - blue: pedestrian traffic
-- green: pedestrian misc (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, summits, AED, toilets, backrest ...)
+- green: pedestrian misc (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, summits, AED, toilets, backrest...)
 - yellow: motor vehicles (car, motorcycles)
+- grey: contructions (building type/height/entrances/roof/address, power poles, bridges, fire hydrants...)
 
 FIXME:
 - gold: stile type/steps, trees/orchads
 - peach: survelience(?) and shop/money related (laundry, opening hours, shop types/seating, shop/atm names, shop level, aircondition, smoking, wlan, bicycle repair/shops, food, payment) 
-- grey: building type/height/entrances/roof/address, power poles, briges, fire hydrants
 
 - why is "Do you need to pay to enter here?" green instead of peach (it is about money)
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -320,13 +320,13 @@ A new icon can reuse the content of [other quest icons](res/graphics/quest), it 
 Keep similar style to existing ones and app in general. Note the background color of the icon marks its relation group:
 - magenta: bicycle traffic
 - blue: pedestrian traffic
-- green: pedestrian misc (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, summits, AED, toilets, backrest...)
 - yellow: motor vehicles (car, motorcycles)
 - grey: contructions (building type/height/entrances/roof/address, power poles, bridges, fire hydrants...)
+- peach: shop related (opening hours, shop types/seating, shop/atm names, shop level, airconditioning, smoking, internet access, payment, survelience) 
+- green: amenities (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, objects on summits, AED, toilets, backrest...)
 
 FIXME:
 - gold: stile type/steps, trees/orchads
-- peach: survelience(?) and shop/money related (laundry, opening hours, shop types/seating, shop/atm names, shop level, aircondition, smoking, wlan, bicycle repair/shops, food, payment) 
 
 - why is "Do you need to pay to enter here?" green instead of peach (it is about money)
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -323,12 +323,8 @@ Keep similar style to existing ones and app in general. Note the background colo
 - yellow: motor vehicles (car, motorcycles)
 - grey: contructions (building type/height/entrances/roof/address, power poles, bridges, fire hydrants...)
 - peach: shop related (opening hours, shop types/seating, shop/atm names, shop level, airconditioning, smoking, internet access, payment, survelience) 
-- green: amenities (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, objects on summits, AED, toilets, backrest...)
-
-FIXME:
-- gold: stile type/steps, trees/orchads
-
-- why is "Do you need to pay to enter here?" green instead of peach (it is about money)
+- green: amenities (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, objects on summits, AED, toilets, backrest, is entrance paid...)
+- brown: nature-related (stile type/steps, trees/orchads)
 
 Once the quest icon is ready:
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -322,7 +322,7 @@ Keep similar style to existing ones and app in general. Note the background colo
 - blue: pedestrian traffic
 - yellow: motor vehicles (car, motorcycles)
 - grey: contructions (building type/height/entrances/roof/address, power poles, bridges, fire hydrants...)
-- peach: shop related (opening hours, shop types/seating, shop/atm names, shop level, airconditioning, smoking, internet access, payment, survelience) 
+- light orange: shop related (opening hours, shop types/seating, shop/atm names, shop level, airconditioning, smoking, internet access, payment, survelience) 
 - green: amenities (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, objects on summits, AED, toilets, backrest, is entrance paid...)
 - brown: nature-related (stile type/steps, trees/orchads)
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -317,7 +317,20 @@ Note that there are some graphics which haven't been used yet, created for propo
 
 A new icon can reuse the content of [other quest icons](res/graphics/quest), it can be based on openly licensed graphics such as ones from [svgrepo.com](https://www.svgrepo.com/). See [the attribution file](res/graphics/authors.txt) for what was used so far.
 
-Keep similar style to existing ones and app in general. Once the quest icon is ready:
+Keep similar style to existing ones and app in general. Note the background color of the icon marks its relation group:
+- magenta: bicycle traffic
+- blue: pedestrian traffic
+- green: pedestrian misc (nature, picnic, sport, religion, recycling, police, postbox, wheelchair, summits, AED, toilets, backrest ...)
+- yellow: motor vehicles (car, motorcycles)
+
+FIXME:
+- gold: stile type/steps, trees/orchads
+- peach: survelience(?) and shop/money related (laundry, opening hours, shop types/seating, shop/atm names, shop level, aircondition, smoking, wlan, bicycle repair/shops, food, payment) 
+- grey: building type/height/entrances/roof/address, power poles, briges, fire hydrants
+
+- why is "Do you need to pay to enter here?" green instead of peach (it is about money)
+
+Once the quest icon is ready:
 
 - when using Inkscape, save as "Optimized SVG" to remove unnecessary cruft or use another tool for that, like [svgo](https://github.com/svg/svgo)
 - Put SVG into [`res/graphics/quest`](res/graphics/quest) folder


### PR DESCRIPTION
I did initial cataloguing going over https://wiki.openstreetmap.org/wiki/StreetComplete/Quests

Needs more work and more general descriptions, see `FIXME` section and `?` in entries that indicate strangeness/inconsistencies in coloring.

If someone could shed a light on those, it would be great.