### PR TITLE
Load quest pins/dots up to zoom 14

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -111,6 +111,7 @@ class QuestPinsManager(
     fun onNewScreenPosition() {
         if (!isActive) return
         val zoom = ctrl.cameraPosition.zoom
+        // require zoom >= 14, which is the lowest zoom level where quests are shown
         if (zoom < 14) return
         val displayedArea = ctrl.screenAreaToBoundingBox(RectF()) ?: return
         val tilesRect = displayedArea.enclosingTilesRect(TILES_ZOOM)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -111,7 +111,7 @@ class QuestPinsManager(
     fun onNewScreenPosition() {
         if (!isActive) return
         val zoom = ctrl.cameraPosition.zoom
-        if (zoom < TILES_ZOOM) return
+        if (zoom < 14) return
         val displayedArea = ctrl.screenAreaToBoundingBox(RectF()) ?: return
         val tilesRect = displayedArea.enclosingTilesRect(TILES_ZOOM)
         // area too big -> skip (performance)


### PR DESCRIPTION
When changing `TILES_ZOOM` from 14 to 16, the zoom level necessary for loading new quest pins / dots was also changed from 14 to 16.
Since this change, dots (visible from between levels 16 and 14, see [here](https://github.com/streetcomplete/StreetComplete/blob/master/app/src/main/assets/map_theme/jawg/streetcomplete.yaml#L113)) are displayed, but never updated / loaded when panning the map without zooming in.

With this change, dots are now updated at zoom levels 14-15.999 too (if no more than 16 z16 tiles are visible, as per restriction a few lines below the change).