### PR TITLE
Don't set check_date:opening_hours unless surveyed

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -157,7 +157,7 @@ class AddOpeningHours(
     override fun applyAnswerTo(answer: OpeningHoursAnswer, tags: Tags, timestampEdited: Long) {
         if (answer is NoOpeningHoursSign) {
             tags["opening_hours:signed"] = "no"
-            tags.updateCheckDateForKey("opening_hours")
+            tags.updateCheckDateForKey("opening_hours:signed")
             // don't delete current opening hours: these may be the correct hours, they are just not visible anywhere on the door
         } else {
             val openingHoursString = when (answer) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -169,6 +169,7 @@ class AddOpeningHours(
             tags.updateWithCheckDate("opening_hours", openingHoursString)
             if (tags["opening_hours:signed"] == "no") {
                 tags.remove("opening_hours:signed")
+                tags.remove("check_date:opening_hours:signed")
             }
         }
     }


### PR DESCRIPTION
Fixes #4273 

Previously, when resurveying opening hours, if a user said there was no
opening hours sign then we'd update check_date:opening_hours to the
survey date. This implies that the opening hours are correct but the
user hasn't actually checked that.

Instead of doing that, we now update check_date:opening_hours:signed.
This means that the quest will be hidden again for a while but we avoid
marking the opening hours as recently checked if they haven't actually
been confirmed.