### PR TITLE
Don't update pins and elements if changes are outside viewed area

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -149,9 +149,8 @@ class QuestPinsManager(
             removed.forEach { if (questsInView.remove(it) != null) deletedAny = true }
             questsInView.values.flatten()
         }
-        if (!deletedAny && addedInView.isEmpty())
-            return
-        pinsMapComponent.set(pins)
+        if (deletedAny || addedInView.isNotEmpty())
+            pinsMapComponent.set(pins)
     }
 
     private fun initializeQuestTypeOrders() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
@@ -14,6 +14,7 @@ import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.screens.main.map.components.StyleableOverlayMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.StyledElement
 import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
+import de.westnordost.streetcomplete.util.math.intersect
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -138,13 +139,18 @@ class StyleableOverlayManager(
 
     private fun updateStyledElements(updated: MapDataWithGeometry, deleted: Collection<ElementKey>) {
         val layer = overlay ?: return
+        val displayedBBox = lastDisplayedRect?.asBoundingBox(TILES_ZOOM)
+        var changedAnything = false
         synchronized(mapDataInView) {
             createStyledElementsByKey(layer, updated).forEach { (key, styledElement) ->
                 if (styledElement != null) mapDataInView[key] = styledElement
                 else                       mapDataInView.remove(key)
+                if (!changedAnything && styledElement != null && displayedBBox?.intersect(styledElement.geometry.getBounds()) != false)
+                    changedAnything = true
             }
-            deleted.forEach { mapDataInView.remove(it) }
-            mapComponent.set(mapDataInView.values)
+            deleted.forEach { if (mapDataInView.remove(it) != null) changedAnything = true }
+            if (changedAnything)
+                mapComponent.set(mapDataInView.values)
         }
     }
 


### PR DESCRIPTION
This is the "straightforward useful" part of #4283, plus (more or less) the same thing for `StyleableOverlayManager`, as per https://github.com/streetcomplete/StreetComplete/pull/4283#pullrequestreview-1071963887.

I did *not yet* test this, other than whether it compiles.