### PR TITLE
add railStopRef quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -41,6 +41,7 @@ import de.westnordost.streetcomplete.quests.bus_stop_lit.AddBusStopLit
 import de.westnordost.streetcomplete.quests.bus_stop_name.AddBusStopName
 import de.westnordost.streetcomplete.quests.bus_stop_ref.AddBusStopRef
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter
+import de.westnordost.streetcomplete.quests.rail_stop_ref.AddRailStopRef
 import de.westnordost.streetcomplete.quests.camera_type.AddCameraType
 import de.westnordost.streetcomplete.quests.camping.AddCampDrinkingWater
 import de.westnordost.streetcomplete.quests.camping.AddCampPower
@@ -223,6 +224,8 @@ fun questTypeRegistry(
     AddBusStopName(), // requires text input
     AddBusStopRef(), // requires text input
     AddBusStopLit(), // at least during day requires to stand in it to see if there is a light in the shelter
+
+    AddRailStopRef(), // requires text input
 
     AddRailwayCrossingBarrier(), // useful for routing
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/AddRailStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/AddRailStopRef.kt
@@ -1,0 +1,34 @@
+package de.westnordost.streetcomplete.quests.rail_stop_ref
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.Tags
+
+class AddRailStopRef : OsmFilterQuestType<RailStopRefAnswer>() {
+
+    override val elementFilter = """
+        ways with
+        (
+          (railway = platform and public_transport = platform)
+        )
+        and !ref and noref != yes and ref:signed != no and !~"ref:.*"
+    """
+    override val enabledInCountries = NoCountriesExcept("DE", "FR", "CH")
+    override val changesetComment = "Determine Rail Platform refs"
+    override val wikiLink = "Tag:public_transport=platform"
+    override val icon = R.drawable.ic_quest_railway
+    override val achievements = listOf(PEDESTRIAN)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_railStopRef_title2
+
+    override fun createForm() = AddRailStopRefForm()
+
+    override fun applyAnswerTo(answer: RailStopRefAnswer, tags: Tags, timestampEdited: Long) {
+        when (answer) {
+            is NoRailStopRef -> tags["ref:signed"] = "no"
+            is RailStopRef ->   tags["ref"] = answer.ref
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/AddRailStopRefForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/AddRailStopRefForm.kt
@@ -1,0 +1,42 @@
+package de.westnordost.streetcomplete.quests.rail_stop_ref
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.core.widget.doAfterTextChanged
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.databinding.QuestRefBinding
+import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
+import de.westnordost.streetcomplete.quests.AnswerItem
+
+class AddRailStopRefForm : AbstractOsmQuestForm<RailStopRefAnswer>() {
+
+    override val contentLayoutResId = R.layout.quest_ref
+    private val binding by contentViewBinding(QuestRefBinding::bind)
+
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_ref_answer_noRef) { confirmNoRef() }
+    )
+
+    private val ref get() = binding.refInput.text?.toString().orEmpty().trim()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.refInput.doAfterTextChanged { checkIsFormComplete() }
+    }
+
+    override fun onClickOk() {
+        applyAnswer(RailStopRef(ref))
+    }
+
+    private fun confirmNoRef() {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.quest_generic_confirmation_title)
+            .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ -> applyAnswer(NoRailStopRef) }
+            .setNegativeButton(R.string.quest_generic_confirmation_no, null)
+            .show()
+    }
+
+    override fun isFormComplete() = ref.isNotEmpty()
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/RailStopRefAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/rail_stop_ref/RailStopRefAnswer.kt
@@ -1,0 +1,6 @@
+package de.westnordost.streetcomplete.quests.rail_stop_ref
+
+sealed interface RailStopRefAnswer
+
+object NoRailStopRef : RailStopRefAnswer
+data class RailStopRef(val ref: String) : RailStopRefAnswer

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,6 +831,7 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
     <string name="quest_busStopName_title2">"What’s the name of this stop?"</string>
     <!-- "stop" as in "bus stop". But could be a tram stop, railway stop etc. too -->
     <string name="quest_busStopRef_title2">"What number or code identifies this stop?"</string>
+    <string name="quest_railStopRef_title2">"What number or code identifies this rail platform?"</string>
     <!-- "stop" as in "bus stop". But could be a tram stop, railway stop etc. too -->
     <string name="quest_busStopShelter_title2">"Is there a shelter at this stop?"</string>
     <!-- "stop" as in "bus stop". But could be a tram stop, railway stop etc. too -->


### PR DESCRIPTION
Hello,

this PR adds a quest to fill out missing ref attributes on rail platforms. It's similar to https://github.com/streetcomplete/StreetComplete/issues/2126 for bus stops.
We limited the region of this quest to Germany, Switzerland and France for the moment because in other countries there could exist a reference, but it's not shown on a sign. As far as we know, if a reference exists, it is always shown on a platform sign in these three countries

**Checklist**
Checklist for quest suggestions (see guidelines):

* [x]  :construction: To be added tag is established and has a useful purpose: Yes, the attribute is used by many map applications
* [x]  :thinking: Any answer the user can give must have an equivalent tagging (Quest should not reappear to other users when solved by one): Yes, if there is no ref, the user can select "no number or Code visible"
* [x]  :chipmunk: Easily answerable by everyone from the outside but a survey is necessary: if there is a platform ref, it's there on a big sign
* [x]  :zzz: Not an overwhelming percentage of elements have the same answer (No spam)
* [x]  :clock4: Applies to a reasonable number of elements (Worth the effort)

**Background**
We are developers from German (DB), Swiss (CFF SBB) and French (SNCF) train companies working on train stations indoor mapping. We organized a OpenStreetMap hackathon in Strasbourg (France) in August 2022 to make together contributions to this topic. Within the frame of the hackathon, this quest was developed.

We just launched the Open Rail Foundation to promote collaborative open-source projects between European railway actors such as UIC, DB, CFF-SBB and SNCF because we have the same problems in all the countries. So, we think it’s worth sharing ideas, resources, code, data, and work on OpenStreetMap data and open source tools. We hope this contribution will be useful for routing inside stations. 