### PR TITLE
Refactor: separate items from forms

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/lit/LitStatusItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/lit/LitStatusItem.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.view.image_select.Item
 fun LitStatus.asItem(): DisplayItem<LitStatus> =
     Item(this, iconResId, titleResId)
 
-val LitStatus.iconResId: Int get() = when (this) {
+private val LitStatus.iconResId: Int get() = when (this) {
     YES -> R.drawable.ic_lit_yes
     NO -> R.drawable.ic_lit_no
     AUTOMATIC -> R.drawable.ic_lit_automatic
@@ -20,7 +20,7 @@ val LitStatus.iconResId: Int get() = when (this) {
     UNSUPPORTED -> 0
 }
 
-val LitStatus.titleResId: Int get() = when (this) {
+private val LitStatus.titleResId: Int get() = when (this) {
     YES -> R.string.lit_value_yes
     NO -> R.string.lit_value_no
     AUTOMATIC -> R.string.lit_value_automatic

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkItem.kt
@@ -10,32 +10,6 @@ import de.westnordost.streetcomplete.view.controller.StreetSideItem
 import de.westnordost.streetcomplete.view.image_select.DisplayItem
 import de.westnordost.streetcomplete.view.image_select.Item
 
-val Sidewalk.iconResId get() = when (this) {
-    YES -> R.drawable.ic_sidewalk_yes
-    NO -> R.drawable.ic_bare_road_without_feature
-    SEPARATE -> R.drawable.ic_sidewalk_separate
-    else -> 0
-}
-
-val Sidewalk.imageResId get() = when (this) {
-    YES -> R.drawable.ic_sidewalk_illustration_yes
-    NO -> R.drawable.ic_sidewalk_illustration_no
-    SEPARATE -> R.drawable.ic_sidewalk_illustration_no
-    else -> 0
-}
-
-val Sidewalk.floatingIconResId get() = when (this) {
-    SEPARATE -> R.drawable.ic_sidewalk_floating_separate
-    else -> null
-}
-
-val Sidewalk.titleResId get() = when (this) {
-    YES -> R.string.quest_sidewalk_value_yes
-    NO -> R.string.quest_sidewalk_value_no
-    SEPARATE -> R.string.quest_sidewalk_value_separate
-    else -> 0
-}
-
 fun Sidewalk.asStreetSideItem(): StreetSideDisplayItem<Sidewalk>? =
     if (this == INVALID) null
     else StreetSideItem(this, imageResId, titleResId, iconResId, floatingIconResId)
@@ -43,3 +17,29 @@ fun Sidewalk.asStreetSideItem(): StreetSideDisplayItem<Sidewalk>? =
 fun Sidewalk.asItem(): DisplayItem<Sidewalk>? =
     if (this == INVALID) null
     else Item(this, iconResId, titleResId)
+
+private val Sidewalk.iconResId get() = when (this) {
+    YES -> R.drawable.ic_sidewalk_yes
+    NO -> R.drawable.ic_bare_road_without_feature
+    SEPARATE -> R.drawable.ic_sidewalk_separate
+    else -> 0
+}
+
+private val Sidewalk.imageResId get() = when (this) {
+    YES -> R.drawable.ic_sidewalk_illustration_yes
+    NO -> R.drawable.ic_sidewalk_illustration_no
+    SEPARATE -> R.drawable.ic_sidewalk_illustration_no
+    else -> 0
+}
+
+private val Sidewalk.floatingIconResId get() = when (this) {
+    SEPARATE -> R.drawable.ic_sidewalk_floating_separate
+    else -> null
+}
+
+private val Sidewalk.titleResId get() = when (this) {
+    YES -> R.string.quest_sidewalk_value_yes
+    NO -> R.string.quest_sidewalk_value_no
+    SEPARATE -> R.string.quest_sidewalk_value_separate
+    else -> 0
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumberForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumberForm.kt
@@ -18,6 +18,7 @@ import de.westnordost.streetcomplete.quests.building_type.BuildingType
 import de.westnordost.streetcomplete.quests.building_type.asItem
 import de.westnordost.streetcomplete.util.ktx.nonBlankTextOrNull
 import de.westnordost.streetcomplete.util.ktx.showKeyboard
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
 import de.westnordost.streetcomplete.view.image_select.ItemViewHolder
 
 class AddHousenumberForm : AbstractOsmQuestForm<HousenumberAnswer>() {
@@ -84,7 +85,7 @@ class AddHousenumberForm : AbstractOsmQuestForm<HousenumberAnswer>() {
 
     private fun onNoHouseNumber() {
         val buildingValue = element.tags["building"]!!
-        val buildingType = BuildingType.getByTag("building", buildingValue)
+        val buildingType = BuildingType.getByTag("building", buildingValue)?.asItem()
         if (buildingType != null) {
             showNoHousenumberDialog(buildingType)
         } else {
@@ -94,9 +95,9 @@ class AddHousenumberForm : AbstractOsmQuestForm<HousenumberAnswer>() {
         }
     }
 
-    private fun showNoHousenumberDialog(buildingType: BuildingType) {
+    private fun showNoHousenumberDialog(buildingType: DisplayItem<BuildingType>) {
         val dialogBinding = DialogQuestAddressNoHousenumberBinding.inflate(layoutInflater)
-        ItemViewHolder(dialogBinding.root).bind(buildingType.asItem())
+        ItemViewHolder(dialogBinding.root).bind(buildingType)
 
         AlertDialog.Builder(requireContext())
             .setView(dialogBinding.root)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierTypeForm.kt
@@ -3,26 +3,12 @@ package de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DIAGONAL
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.DOUBLE
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.SINGLE
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TILTED
-import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.TRIPLE
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBicycleBarrierTypeForm :
     AImageListQuestForm<BicycleBarrierType, BicycleBarrierTypeAnswer>() {
 
-    override val items = listOf(
-        Item(SINGLE, R.drawable.barrier_bicycle_barrier_single, R.string.quest_barrier_bicycle_type_single),
-        Item(DOUBLE, R.drawable.barrier_bicycle_barrier_double, R.string.quest_barrier_bicycle_type_double),
-        Item(TRIPLE, R.drawable.barrier_bicycle_barrier_triple, R.string.quest_barrier_bicycle_type_multiple),
-        Item(DIAGONAL, R.drawable.barrier_bicycle_barrier_diagonal, R.string.quest_barrier_bicycle_type_diagonal),
-        Item(TILTED, R.drawable.barrier_bicycle_barrier_tilted, R.string.quest_barrier_bicycle_type_tilted),
-    )
-
+    override val items = BicycleBarrierType.values().map { it.asItem() }
     override val itemsPerRow = 3
-
     override val moveFavoritesToFront = false
 
     override fun onClickOk(selectedItems: List<BicycleBarrierType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/BicycleBarrierTypeItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.BicycleBarrierType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun BicycleBarrierType.asItem() = Item(this, iconResId, titleResId)
+
+private val BicycleBarrierType.titleResId: Int get() = when (this) {
+    SINGLE ->   R.string.quest_barrier_bicycle_type_single
+    DOUBLE ->   R.string.quest_barrier_bicycle_type_double
+    TRIPLE ->   R.string.quest_barrier_bicycle_type_multiple
+    DIAGONAL -> R.string.quest_barrier_bicycle_type_diagonal
+    TILTED ->   R.string.quest_barrier_bicycle_type_tilted
+}
+
+private val BicycleBarrierType.iconResId: Int get() = when (this) {
+    SINGLE ->   R.drawable.barrier_bicycle_barrier_single
+    DOUBLE ->   R.drawable.barrier_bicycle_barrier_double
+    TRIPLE ->   R.drawable.barrier_bicycle_barrier_triple
+    DIAGONAL -> R.drawable.barrier_bicycle_barrier_diagonal
+    TILTED ->   R.drawable.barrier_bicycle_barrier_tilted
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierTypeForm.kt
@@ -1,59 +1,10 @@
 package de.westnordost.streetcomplete.quests.barrier_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.BICYCLE_BARRIER
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.BLOCK
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.BOLLARD
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.CATTLE_GRID
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.CHAIN
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.DEBRIS_PILE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.FULL_HEIGHT_TURNSTILE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.GATE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.HEIGHT_RESTRICTOR
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.JERSEY_BARRIER
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.KERB
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.KISSING_GATE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.LIFT_GATE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.LOG
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.PASSAGE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.ROPE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.STILE_LADDER
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.STILE_SQUEEZER
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.STILE_STEPOVER_STONE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.STILE_STEPOVER_WOODEN
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.SWING_GATE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.TURNSTILE
-import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.WIRE_GATE
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBarrierTypeForm : AImageListQuestForm<BarrierType, BarrierType>() {
 
-    override val items = listOf(
-        Item(PASSAGE, R.drawable.barrier_passage, R.string.quest_barrier_type_passage),
-        Item(GATE, R.drawable.barrier_gate, R.string.quest_barrier_type_gate_any_size),
-        Item(LIFT_GATE, R.drawable.barrier_lift_gate, R.string.quest_barrier_type_lift_gate),
-        Item(SWING_GATE, R.drawable.barrier_swing_gate, R.string.quest_barrier_type_swing_gate),
-        Item(BOLLARD, R.drawable.barrier_bollard, R.string.quest_barrier_type_bollard),
-        Item(CHAIN, R.drawable.barrier_chain, R.string.quest_barrier_type_chain),
-        Item(ROPE, R.drawable.barrier_rope, R.string.quest_barrier_type_rope),
-        Item(WIRE_GATE, R.drawable.barrier_wire_gate, R.string.quest_barrier_type_wire_gate),
-        Item(CATTLE_GRID, R.drawable.barrier_cattle_grid, R.string.quest_barrier_type_cattle_grid),
-        Item(BLOCK, R.drawable.barrier_block, R.string.quest_barrier_type_block),
-        Item(JERSEY_BARRIER, R.drawable.barrier_jersey_barrier, R.string.quest_barrier_jersey_barrier),
-        Item(LOG, R.drawable.barrier_log, R.string.quest_barrier_type_log),
-        Item(KERB, R.drawable.barrier_kerb, R.string.quest_barrier_type_kerb),
-        Item(HEIGHT_RESTRICTOR, R.drawable.barrier_height_restrictor, R.string.quest_barrier_type_height_restrictor),
-        Item(FULL_HEIGHT_TURNSTILE, R.drawable.barrier_full_height_turnstile, R.string.quest_barrier_full_height_turnstile),
-        Item(TURNSTILE, R.drawable.barrier_turnstile, R.string.quest_barrier_type_turnstile),
-        Item(DEBRIS_PILE, R.drawable.barrier_debris_pile, R.string.quest_barrier_type_debris_pile),
-        Item(STILE_SQUEEZER, R.drawable.barrier_stile_squeezer, R.string.quest_barrier_type_stile_squeezer),
-        Item(STILE_LADDER, R.drawable.barrier_stile_ladder, R.string.quest_barrier_type_stile_ladder),
-        Item(STILE_STEPOVER_WOODEN, R.drawable.barrier_stile_stepover_wooden, R.string.quest_barrier_type_stepover_wooden),
-        Item(STILE_STEPOVER_STONE, R.drawable.barrier_stile_stepover_stone, R.string.quest_barrier_type_stepover_stone),
-        Item(KISSING_GATE, R.drawable.barrier_kissing_gate, R.string.quest_barrier_type_kissing_gate), // more clear short description would be better :(
-        Item(BICYCLE_BARRIER, R.drawable.barrier_bicycle_barrier, R.string.quest_barrier_type_bicycle_barrier),
-    )
+    override val items = BarrierType.values().map { it.asItem() }
 
     override val itemsPerRow = 3
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeForm.kt
@@ -1,25 +1,13 @@
 package de.westnordost.streetcomplete.quests.barrier_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.barrier_type.StileType.LADDER
-import de.westnordost.streetcomplete.quests.barrier_type.StileType.SQUEEZER
-import de.westnordost.streetcomplete.quests.barrier_type.StileType.STEPOVER_STONE
-import de.westnordost.streetcomplete.quests.barrier_type.StileType.STEPOVER_WOODEN
-import de.westnordost.streetcomplete.view.image_select.DisplayItem
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddStileTypeForm : AImageListQuestForm<StileTypeAnswer, StileTypeAnswer>() {
 
-    override val items: List<DisplayItem<StileTypeAnswer>> = listOf(
-        Item(SQUEEZER, R.drawable.barrier_stile_squeezer, R.string.quest_barrier_type_stile_squeezer),
-        Item(LADDER, R.drawable.barrier_stile_ladder, R.string.quest_barrier_type_stile_ladder),
-        Item(STEPOVER_WOODEN, R.drawable.barrier_stile_stepover_wooden, R.string.quest_barrier_type_stepover_wooden),
-        Item(STEPOVER_STONE, R.drawable.barrier_stile_stepover_stone, R.string.quest_barrier_type_stepover_stone),
-        Item(ConvertedStile.KISSING_GATE, R.drawable.barrier_kissing_gate, R.string.quest_barrier_type_kissing_gate_conversion),
-        Item(ConvertedStile.PASSAGE, R.drawable.barrier_passage, R.string.quest_barrier_type_passage_conversion),
-        Item(ConvertedStile.GATE, R.drawable.barrier_gate_pedestrian, R.string.quest_barrier_type_gate_conversion),
-    )
+    override val items =
+        StileType.values().map { it.asItem() } +
+        ConvertedStile.values().map { it.asItem() }
+
     override val itemsPerRow = 2
 
     override fun onClickOk(selectedItems: List<StileTypeAnswer>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/BarrierTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/BarrierTypeItem.kt
@@ -1,0 +1,59 @@
+package de.westnordost.streetcomplete.quests.barrier_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.barrier_type.BarrierType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun BarrierType.asItem() = Item(this, iconResId, titleResId)
+
+private val BarrierType.titleResId: Int get() = when (this) {
+    PASSAGE ->               R.string.quest_barrier_type_passage
+    GATE ->                  R.string.quest_barrier_type_gate_any_size
+    LIFT_GATE ->             R.string.quest_barrier_type_lift_gate
+    SWING_GATE ->            R.string.quest_barrier_type_swing_gate
+    BOLLARD ->               R.string.quest_barrier_type_bollard
+    CHAIN ->                 R.string.quest_barrier_type_chain
+    ROPE ->                  R.string.quest_barrier_type_rope
+    WIRE_GATE ->             R.string.quest_barrier_type_wire_gate
+    CATTLE_GRID ->           R.string.quest_barrier_type_cattle_grid
+    BLOCK ->                 R.string.quest_barrier_type_block
+    JERSEY_BARRIER ->        R.string.quest_barrier_jersey_barrier
+    LOG ->                   R.string.quest_barrier_type_log
+    KERB ->                  R.string.quest_barrier_type_kerb
+    HEIGHT_RESTRICTOR ->     R.string.quest_barrier_type_height_restrictor
+    FULL_HEIGHT_TURNSTILE -> R.string.quest_barrier_full_height_turnstile
+    TURNSTILE ->             R.string.quest_barrier_type_turnstile
+    DEBRIS_PILE ->           R.string.quest_barrier_type_debris_pile
+    STILE_SQUEEZER ->        R.string.quest_barrier_type_stile_squeezer
+    STILE_LADDER ->          R.string.quest_barrier_type_stile_ladder
+    STILE_STEPOVER_WOODEN -> R.string.quest_barrier_type_stepover_wooden
+    STILE_STEPOVER_STONE ->  R.string.quest_barrier_type_stepover_stone
+    KISSING_GATE ->          R.string.quest_barrier_type_kissing_gate
+    BICYCLE_BARRIER ->       R.string.quest_barrier_type_bicycle_barrier
+}
+
+private val BarrierType.iconResId: Int get() = when (this) {
+    PASSAGE ->               R.drawable.barrier_passage
+    GATE ->                  R.drawable.barrier_gate
+    LIFT_GATE ->             R.drawable.barrier_lift_gate
+    SWING_GATE ->            R.drawable.barrier_swing_gate
+    BOLLARD ->               R.drawable.barrier_bollard
+    CHAIN ->                 R.drawable.barrier_chain
+    ROPE ->                  R.drawable.barrier_rope
+    WIRE_GATE ->             R.drawable.barrier_wire_gate
+    CATTLE_GRID ->           R.drawable.barrier_cattle_grid
+    BLOCK ->                 R.drawable.barrier_block
+    JERSEY_BARRIER ->        R.drawable.barrier_jersey_barrier
+    LOG ->                   R.drawable.barrier_log
+    KERB ->                  R.drawable.barrier_kerb
+    HEIGHT_RESTRICTOR ->     R.drawable.barrier_height_restrictor
+    FULL_HEIGHT_TURNSTILE -> R.drawable.barrier_full_height_turnstile
+    TURNSTILE ->             R.drawable.barrier_turnstile
+    DEBRIS_PILE ->           R.drawable.barrier_debris_pile
+    STILE_SQUEEZER ->        R.drawable.barrier_stile_squeezer
+    STILE_LADDER ->          R.drawable.barrier_stile_ladder
+    STILE_STEPOVER_WOODEN -> R.drawable.barrier_stile_stepover_wooden
+    STILE_STEPOVER_STONE ->  R.drawable.barrier_stile_stepover_stone
+    KISSING_GATE ->          R.drawable.barrier_kissing_gate
+    BICYCLE_BARRIER ->       R.drawable.barrier_bicycle_barrier
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/StileTypeAnswerItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_type/StileTypeAnswerItem.kt
@@ -1,0 +1,26 @@
+package de.westnordost.streetcomplete.quests.barrier_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun StileTypeAnswer.asItem() = Item(this, iconResId, titleResId)
+
+private val StileTypeAnswer.titleResId: Int get() = when (this) {
+    ConvertedStile.KISSING_GATE -> R.string.quest_barrier_type_kissing_gate_conversion
+    ConvertedStile.PASSAGE ->      R.string.quest_barrier_type_passage_conversion
+    ConvertedStile.GATE ->         R.string.quest_barrier_type_gate_conversion
+    StileType.SQUEEZER ->          R.string.quest_barrier_type_stile_squeezer
+    StileType.LADDER ->            R.string.quest_barrier_type_stile_ladder
+    StileType.STEPOVER_WOODEN ->   R.string.quest_barrier_type_stepover_wooden
+    StileType.STEPOVER_STONE ->    R.string.quest_barrier_type_stepover_stone
+}
+
+private val StileTypeAnswer.iconResId: Int get() = when (this) {
+    ConvertedStile.KISSING_GATE -> R.drawable.barrier_kissing_gate
+    ConvertedStile.PASSAGE ->      R.drawable.barrier_passage
+    ConvertedStile.GATE ->         R.drawable.barrier_gate_pedestrian
+    StileType.SQUEEZER ->          R.drawable.barrier_stile_squeezer
+    StileType.LADDER ->            R.drawable.barrier_stile_ladder
+    StileType.STEPOVER_WOODEN ->   R.drawable.barrier_stile_stepover_wooden
+    StileType.STEPOVER_STONE ->    R.drawable.barrier_stile_stepover_stone
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingTypeForm.kt
@@ -1,26 +1,10 @@
 package de.westnordost.streetcomplete.quests.bike_parking_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.BUILDING
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.HANDLEBAR_HOLDER
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.LOCKERS
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.SHED
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.STANDS
-import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.WALL_LOOPS
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBikeParkingTypeForm : AImageListQuestForm<BikeParkingType, BikeParkingType>() {
 
-    override val items = listOf(
-        Item(STANDS, R.drawable.bicycle_parking_type_stand, R.string.quest_bicycle_parking_type_stand),
-        Item(WALL_LOOPS, R.drawable.bicycle_parking_type_wheelbenders, R.string.quest_bicycle_parking_type_wheelbender),
-        Item(SHED, R.drawable.bicycle_parking_type_shed, R.string.quest_bicycle_parking_type_shed),
-        Item(LOCKERS, R.drawable.bicycle_parking_type_lockers, R.string.quest_bicycle_parking_type_locker),
-        Item(BUILDING, R.drawable.bicycle_parking_type_building, R.string.quest_bicycle_parking_type_building),
-        Item(HANDLEBAR_HOLDER, R.drawable.bicycle_parking_type_handlebarholder, R.string.quest_bicycle_parking_type_handlebarholder)
-    )
-
+    override val items = BikeParkingType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<BikeParkingType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/BikeParkingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/BikeParkingTypeItem.kt
@@ -1,0 +1,25 @@
+package de.westnordost.streetcomplete.quests.bike_parking_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.bike_parking_type.BikeParkingType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun BikeParkingType.asItem() = Item(this, iconResId, titleResId)
+
+private val BikeParkingType.titleResId: Int get() = when (this) {
+    STANDS ->           R.string.quest_bicycle_parking_type_stand
+    WALL_LOOPS ->       R.string.quest_bicycle_parking_type_wheelbender
+    SHED ->             R.string.quest_bicycle_parking_type_shed
+    LOCKERS ->          R.string.quest_bicycle_parking_type_locker
+    BUILDING ->         R.string.quest_bicycle_parking_type_building
+    HANDLEBAR_HOLDER -> R.string.quest_bicycle_parking_type_handlebarholder
+}
+
+private val BikeParkingType.iconResId: Int get() = when (this) {
+    STANDS ->           R.drawable.bicycle_parking_type_stand
+    WALL_LOOPS ->       R.drawable.bicycle_parking_type_wheelbenders
+    SHED ->             R.drawable.bicycle_parking_type_shed
+    LOCKERS ->          R.drawable.bicycle_parking_type_lockers
+    BUILDING ->         R.drawable.bicycle_parking_type_building
+    HANDLEBAR_HOLDER -> R.drawable.bicycle_parking_type_handlebarholder
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_rental_type/AddBikeRentalTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_rental_type/AddBikeRentalTypeForm.kt
@@ -1,21 +1,10 @@
 package de.westnordost.streetcomplete.quests.bike_rental_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.bike_rental_type.BikeRentalType.DOCKING_STATION
-import de.westnordost.streetcomplete.quests.bike_rental_type.BikeRentalType.DROPOFF_POINT
-import de.westnordost.streetcomplete.quests.bike_rental_type.BikeRentalType.HUMAN
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBikeRentalTypeForm : AImageListQuestForm<BikeRentalTypeAnswer, BikeRentalTypeAnswer>() {
 
-    override val items: List<Item<BikeRentalTypeAnswer>> = listOf(
-        Item(DOCKING_STATION, R.drawable.bicycle_rental_docking_station, R.string.quest_bicycle_rental_type_docking_station),
-        Item(DROPOFF_POINT, R.drawable.bicycle_rental_dropoff_point, R.string.quest_bicycle_rental_type_dropoff_point),
-        Item(HUMAN, R.drawable.bicycle_rental_human, R.string.quest_bicycle_rental_type_human),
-        Item(BikeShopWithRental, R.drawable.bicycle_rental_shop_with_rental, R.string.quest_bicycle_rental_type_shop_with_rental),
-    )
-
+    override val items = BikeRentalType.values().map { it.asItem() } + BikeShopWithRental.asItem()
     override val itemsPerRow = 2
     override val moveFavoritesToFront = false
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_rental_type/BikeRentalTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_rental_type/BikeRentalTypeItem.kt
@@ -1,0 +1,21 @@
+package de.westnordost.streetcomplete.quests.bike_rental_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.bike_rental_type.BikeRentalType.*
+
+fun BikeRentalTypeAnswer.asItem() = Item(this, iconResId, titleResId)
+
+private val BikeRentalTypeAnswer.titleResId: Int get() = when (this) {
+    DOCKING_STATION ->    R.string.quest_bicycle_rental_type_docking_station
+    DROPOFF_POINT ->      R.string.quest_bicycle_rental_type_dropoff_point
+    HUMAN ->              R.string.quest_bicycle_rental_type_human
+    BikeShopWithRental -> R.string.quest_bicycle_rental_type_shop_with_rental
+}
+
+private val BikeRentalTypeAnswer.iconResId: Int get() = when (this) {
+    DOCKING_STATION ->     R.drawable.bicycle_rental_docking_station
+    DROPOFF_POINT ->       R.drawable.bicycle_rental_dropoff_point
+    HUMAN ->               R.drawable.bicycle_rental_human
+    BikeShopWithRental ->  R.drawable.bicycle_rental_shop_with_rental
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailabilityForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailabilityForm.kt
@@ -3,13 +3,14 @@ package de.westnordost.streetcomplete.quests.bike_shop
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.TextItem
+import de.westnordost.streetcomplete.quests.bike_shop.SecondHandBicycleAvailability.*
 
 class AddSecondHandBicycleAvailabilityForm : AListQuestForm<SecondHandBicycleAvailability>() {
 
     override val items = listOf(
-        TextItem(SecondHandBicycleAvailability.ONLY_NEW, R.string.quest_bicycle_shop_second_hand_only_new),
-        TextItem(SecondHandBicycleAvailability.NEW_AND_SECOND_HAND, R.string.quest_bicycle_shop_second_hand_new_and_used),
-        TextItem(SecondHandBicycleAvailability.ONLY_SECOND_HAND, R.string.quest_bicycle_shop_second_hand_only_used),
-        TextItem(SecondHandBicycleAvailability.NO_BICYCLES_SOLD, R.string.quest_bicycle_shop_second_hand_no_bicycles),
+        TextItem(ONLY_NEW, R.string.quest_bicycle_shop_second_hand_only_new),
+        TextItem(NEW_AND_SECOND_HAND, R.string.quest_bicycle_shop_second_hand_new_and_used),
+        TextItem(ONLY_SECOND_HAND, R.string.quest_bicycle_shop_second_hand_only_used),
+        TextItem(NO_BICYCLES_SOLD, R.string.quest_bicycle_shop_second_hand_no_bicycles),
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/AddBollardTypeForm.kt
@@ -3,23 +3,10 @@ package de.westnordost.streetcomplete.quests.bollard_type
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FIXED
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FLEXIBLE
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.FOLDABLE
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.REMOVABLE
-import de.westnordost.streetcomplete.quests.bollard_type.BollardType.RISING
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBollardTypeForm : AImageListQuestForm<BollardType, BollardTypeAnswer>() {
 
-    override val items = listOf(
-        Item(RISING,    R.drawable.bollard_rising,    R.string.quest_bollard_type_rising),
-        Item(REMOVABLE, R.drawable.bollard_removable, R.string.quest_bollard_type_removable),
-        Item(FOLDABLE,  R.drawable.bollard_foldable,  R.string.quest_bollard_type_foldable2),
-        Item(FLEXIBLE,  R.drawable.bollard_flexible,  R.string.quest_bollard_type_flexible),
-        Item(FIXED,     R.drawable.bollard_fixed,     R.string.quest_bollard_type_fixed),
-    )
-
+    override val items = BollardType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<BollardType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bollard_type/BollardTypeItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.bollard_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.bollard_type.BollardType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun BollardType.asItem() = Item(this, iconResId, titleResId)
+
+private val BollardType.titleResId: Int get() = when (this) {
+    RISING ->    R.string.quest_bollard_type_rising
+    REMOVABLE -> R.string.quest_bollard_type_removable
+    FOLDABLE ->  R.string.quest_bollard_type_foldable2
+    FLEXIBLE ->  R.string.quest_bollard_type_flexible
+    FIXED ->     R.string.quest_bollard_type_fixed
+}
+
+private val BollardType.iconResId: Int get() = when (this) {
+    RISING ->    R.drawable.bollard_rising
+    REMOVABLE -> R.drawable.bollard_removable
+    FOLDABLE ->  R.drawable.bollard_foldable
+    FLEXIBLE ->  R.drawable.bollard_flexible
+    FIXED ->     R.drawable.bollard_fixed
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructureForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/AddBridgeStructureForm.kt
@@ -1,33 +1,10 @@
 package de.westnordost.streetcomplete.quests.bridge_structure
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.ARCH
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.BEAM
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.CABLE_STAYED
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.FLOATING
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.HUMPBACK
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.SIMPLE_SUSPENSION
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.SUSPENSION
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.TIED_ARCH
-import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.TRUSS
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddBridgeStructureForm : AImageListQuestForm<BridgeStructure, BridgeStructure>() {
 
-    // structures sorted highest to lowest amount of values on taginfo, footbridge-types last
-    override val items = listOf(
-        Item(BEAM, R.drawable.ic_bridge_structure_beam),
-        Item(SUSPENSION, R.drawable.ic_bridge_structure_suspension),
-        Item(ARCH, R.drawable.ic_bridge_structure_arch),
-        Item(TIED_ARCH, R.drawable.ic_bridge_structure_tied_arch),
-        Item(TRUSS, R.drawable.ic_bridge_structure_truss),
-        Item(CABLE_STAYED, R.drawable.ic_bridge_structure_cablestayed),
-        Item(HUMPBACK, R.drawable.ic_bridge_structure_humpback),
-        Item(SIMPLE_SUSPENSION, R.drawable.ic_bridge_structure_simple_suspension),
-        Item(FLOATING, R.drawable.ic_bridge_structure_floating)
-    )
-
+    override val items = BridgeStructure.values().map { it.asItem() }
     override val itemsPerRow = 2
 
     override fun onClickOk(selectedItems: List<BridgeStructure>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/BridgeStructure.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/BridgeStructure.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.quests.bridge_structure
 
+// structures sorted highest to lowest amount of values on taginfo, footbridge-types last
 enum class BridgeStructure(val osmValue: String) {
     BEAM("beam"),
     SUSPENSION("suspension"),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/BridgeStructureItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bridge_structure/BridgeStructureItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.bridge_structure
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.bridge_structure.BridgeStructure.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun BridgeStructure.asItem() = Item(this, iconResId)
+
+private val BridgeStructure.iconResId: Int get() = when (this) {
+    BEAM ->              R.drawable.ic_bridge_structure_beam
+    SUSPENSION ->        R.drawable.ic_bridge_structure_suspension
+    ARCH ->              R.drawable.ic_bridge_structure_arch
+    TIED_ARCH ->         R.drawable.ic_bridge_structure_tied_arch
+    TRUSS ->             R.drawable.ic_bridge_structure_truss
+    CABLE_STAYED ->      R.drawable.ic_bridge_structure_cablestayed
+    HUMPBACK ->          R.drawable.ic_bridge_structure_humpback
+    SIMPLE_SUSPENSION -> R.drawable.ic_bridge_structure_simple_suspension
+    FLOATING ->          R.drawable.ic_bridge_structure_floating
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
@@ -6,16 +6,16 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AGroupedImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
 
-class AddBuildingTypeForm : AGroupedImageListQuestForm<BuildingType?, BuildingType>() {
+class AddBuildingTypeForm : AGroupedImageListQuestForm<BuildingType, BuildingType>() {
 
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_buildingType_answer_multiple_types) { showMultipleTypesHint() },
         AnswerItem(R.string.quest_buildingType_answer_construction_site) { applyAnswer(BuildingType.CONSTRUCTION) }
     )
 
-    override val topItems = topBuildingTypes.toItems()
+    override val topItems = BuildingType.topSelectableValues.toItems()
 
-    override val allItems = buildingCategories.toItems()
+    override val allItems = BuildingTypeCategory.values().toItems()
 
     override val itemsPerRow = 1
 
@@ -25,10 +25,8 @@ class AddBuildingTypeForm : AGroupedImageListQuestForm<BuildingType?, BuildingTy
         imageSelector.cellLayoutId = R.layout.cell_labeled_icon_select_with_description
     }
 
-    override fun onClickOk(value: BuildingType?) {
-        // we can be sure that `value` is not null here because
-        // AGroupedImageListQuestAnswerFragment.onClickOk checks for that case
-        applyAnswer(value!!)
+    override fun onClickOk(value: BuildingType) {
+        applyAnswer(value)
     }
 
     private fun showMultipleTypesHint() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingType.kt
@@ -1,63 +1,5 @@
 package de.westnordost.streetcomplete.quests.building_type
 
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ABANDONED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ALLOTMENT_HOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.APARTMENTS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BOATHOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BRIDGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BUNGALOW
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BUNKER
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CARPORT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CATHEDRAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CHAPEL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CHURCH
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.COLLEGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.DETACHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.DORMITORY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FARM
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FARM_AUXILIARY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FIRE_STATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GARAGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GARAGES
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GOVERNMENT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GRANDSTAND
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GREENHOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HANGAR
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HISTORIC
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOSPITAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOTEL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOUSEBOAT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HUT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.INDUSTRIAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.KINDERGARTEN
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.KIOSK
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.MOSQUE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.OFFICE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.PAGODA
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.PARKING
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RETAIL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ROOF
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RUINS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SCHOOL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SEMI_DETACHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SERVICE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SHRINE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SILO
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SPORTS_CENTRE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STADIUM
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STATIC_CARAVAN
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STORAGE_TANK
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SYNAGOGUE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TEMPLE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TERRACE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TOILETS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TRAIN_STATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TRANSPORTATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.UNIVERSITY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.WAREHOUSE
-
 enum class BuildingType(val osmKey: String, val osmValue: String) {
     HOUSE           ("building", "house"),
     APARTMENTS      ("building", "apartments"),
@@ -135,36 +77,7 @@ enum class BuildingType(val osmKey: String, val osmValue: String) {
         fun getByTag(key: String, value: String): BuildingType? {
             return values().find { it.osmKey == key && it.osmValue == value }
         }
+
+        val topSelectableValues = listOf(DETACHED, APARTMENTS, HOUSE, GARAGE, SHED, HUT)
     }
 }
-
-val topBuildingTypes = listOf(DETACHED, APARTMENTS, HOUSE, GARAGE, SHED, HUT)
-
-enum class BuildingTypeCategory(val type: BuildingType?, val subTypes: List<BuildingType>) {
-    RESIDENTIAL(BuildingType.RESIDENTIAL, listOf(
-        DETACHED, APARTMENTS, SEMI_DETACHED, TERRACE, HOUSE, FARM, HUT, BUNGALOW, HOUSEBOAT,
-        STATIC_CARAVAN, DORMITORY
-    )),
-    COMMERCIAL(BuildingType.COMMERCIAL, listOf(
-        OFFICE, INDUSTRIAL, RETAIL, WAREHOUSE, KIOSK, HOTEL, STORAGE_TANK, BUNGALOW, BRIDGE
-    )),
-    CIVIC(BuildingType.CIVIC, listOf(
-        SCHOOL, UNIVERSITY, HOSPITAL, KINDERGARTEN, SPORTS_CENTRE, TRAIN_STATION, TRANSPORTATION,
-        COLLEGE, GOVERNMENT, STADIUM, FIRE_STATION, OFFICE, GRANDSTAND
-    )),
-    RELIGIOUS(BuildingType.RELIGIOUS, listOf(
-        CHURCH, CATHEDRAL, CHAPEL, MOSQUE, TEMPLE, PAGODA, SYNAGOGUE, SHRINE
-    )),
-    FOR_CARS(null, listOf(
-        GARAGE, GARAGES, CARPORT, PARKING
-    )),
-    FOR_FARMS(null, listOf(
-        FARM, FARM_AUXILIARY, SILO, GREENHOUSE, STORAGE_TANK, SHED, ALLOTMENT_HOUSE
-    )),
-    OTHER(null, listOf(
-        SHED, ROOF, BRIDGE, ALLOTMENT_HOUSE, SERVICE, HUT, TOILETS, HANGAR, BUNKER, HISTORIC, BOATHOUSE,
-        ABANDONED, RUINS
-    )),
-}
-
-val buildingCategories = BuildingTypeCategory.values()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeCategory.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeCategory.kt
@@ -1,0 +1,30 @@
+package de.westnordost.streetcomplete.quests.building_type
+
+import de.westnordost.streetcomplete.quests.building_type.BuildingType.*
+
+enum class BuildingTypeCategory(val type: BuildingType?, val subTypes: List<BuildingType>) {
+    RESIDENTIAL(BuildingType.RESIDENTIAL, listOf(
+        DETACHED, APARTMENTS, SEMI_DETACHED, TERRACE, HOUSE, FARM, HUT, BUNGALOW, HOUSEBOAT,
+        STATIC_CARAVAN, DORMITORY
+    )),
+    COMMERCIAL(BuildingType.COMMERCIAL, listOf(
+        OFFICE, INDUSTRIAL, RETAIL, WAREHOUSE, KIOSK, HOTEL, STORAGE_TANK, BUNGALOW, BRIDGE
+    )),
+    CIVIC(BuildingType.CIVIC, listOf(
+        SCHOOL, UNIVERSITY, HOSPITAL, KINDERGARTEN, SPORTS_CENTRE, TRAIN_STATION, TRANSPORTATION,
+        COLLEGE, GOVERNMENT, STADIUM, FIRE_STATION, OFFICE, GRANDSTAND
+    )),
+    RELIGIOUS(BuildingType.RELIGIOUS, listOf(
+        CHURCH, CATHEDRAL, CHAPEL, MOSQUE, TEMPLE, PAGODA, SYNAGOGUE, SHRINE
+    )),
+    FOR_CARS(null, listOf(
+        GARAGE, GARAGES, CARPORT, PARKING
+    )),
+    FOR_FARMS(null, listOf(
+        FARM, FARM_AUXILIARY, SILO, GREENHOUSE, STORAGE_TANK, SHED, ALLOTMENT_HOUSE
+    )),
+    OTHER(null, listOf(
+        SHED, ROOF, BRIDGE, ALLOTMENT_HOUSE, SERVICE, HUT, TOILETS, HANGAR, BUNKER, HISTORIC, BOATHOUSE,
+        ABANDONED, RUINS
+    )),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeCategoryItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeCategoryItem.kt
@@ -1,0 +1,38 @@
+package de.westnordost.streetcomplete.quests.building_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.building_type.BuildingTypeCategory.*
+import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
+
+fun Array<BuildingTypeCategory>.toItems() = map { it.asItem() }
+
+fun BuildingTypeCategory.asItem(): GroupableDisplayItem<BuildingType> =
+    Item(type, iconResId, titleResId, descriptionResId, subTypes.toItems())
+
+private val BuildingTypeCategory.titleResId: Int get() = when (this) {
+    RESIDENTIAL -> R.string.quest_buildingType_residential
+    COMMERCIAL ->  R.string.quest_buildingType_commercial
+    CIVIC ->       R.string.quest_buildingType_civic
+    RELIGIOUS ->   R.string.quest_buildingType_religious
+    FOR_CARS ->    R.string.quest_buildingType_cars
+    FOR_FARMS ->   R.string.quest_buildingType_farm
+    OTHER ->       R.string.quest_buildingType_other
+}
+
+private val BuildingTypeCategory.descriptionResId: Int? get() = when (this) {
+    RESIDENTIAL -> R.string.quest_buildingType_residential_description
+    COMMERCIAL ->  R.string.quest_buildingType_commercial_generic_description
+    CIVIC ->       R.string.quest_buildingType_civic_description
+    else ->        null
+}
+
+private val BuildingTypeCategory.iconResId: Int get() = when (this) {
+    RESIDENTIAL -> R.drawable.ic_building_apartments
+    COMMERCIAL ->  R.drawable.ic_building_office
+    CIVIC ->       R.drawable.ic_building_civic
+    RELIGIOUS ->   R.drawable.ic_building_temple
+    FOR_CARS ->    R.drawable.ic_building_car
+    FOR_FARMS ->   R.drawable.ic_building_farm
+    OTHER ->       R.drawable.ic_building_other
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeItem.kt
@@ -1,170 +1,169 @@
 package de.westnordost.streetcomplete.quests.building_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ABANDONED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ALLOTMENT_HOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.APARTMENTS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BOATHOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BRIDGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BUNGALOW
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.BUNKER
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CARPORT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CATHEDRAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CHAPEL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CHURCH
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CIVIC
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.COLLEGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.COMMERCIAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.CONSTRUCTION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.DETACHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.DORMITORY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FARM
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FARM_AUXILIARY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.FIRE_STATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GARAGE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GARAGES
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GOVERNMENT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GRANDSTAND
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.GREENHOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HANGAR
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HISTORIC
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOSPITAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOTEL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOUSE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HOUSEBOAT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.HUT
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.INDUSTRIAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.KINDERGARTEN
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.KIOSK
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.MOSQUE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.OFFICE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.PAGODA
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.PARKING
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RELIGIOUS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RESIDENTIAL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RETAIL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.ROOF
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.RUINS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SCHOOL
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SEMI_DETACHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SERVICE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SHED
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SHRINE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SILO
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SPORTS_CENTRE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STADIUM
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STATIC_CARAVAN
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.STORAGE_TANK
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.SYNAGOGUE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TEMPLE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TERRACE
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TOILETS
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TRAIN_STATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.TRANSPORTATION
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.UNIVERSITY
-import de.westnordost.streetcomplete.quests.building_type.BuildingType.WAREHOUSE
+import de.westnordost.streetcomplete.quests.building_type.BuildingType.*
+import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
 import de.westnordost.streetcomplete.view.image_select.Item
 
-fun List<BuildingType>.toItems() = this.map { it.asItem() }
+fun List<BuildingType>.toItems() = mapNotNull { it.asItem() }
 
-fun BuildingType.asItem(): Item<BuildingType?> = when (this) {
-    HOUSE -> Item(this, R.drawable.ic_building_house, R.string.quest_buildingType_house, R.string.quest_buildingType_house_description2)
-    APARTMENTS -> Item(this, R.drawable.ic_building_apartments, R.string.quest_buildingType_apartments, R.string.quest_buildingType_apartments_description)
-    DETACHED -> Item(this, R.drawable.ic_building_detached, R.string.quest_buildingType_detached, R.string.quest_buildingType_detached_description)
-    SEMI_DETACHED -> Item(this, R.drawable.ic_building_semi_detached, R.string.quest_buildingType_semi_detached, R.string.quest_buildingType_semi_detached_description2)
-    TERRACE -> Item(this, R.drawable.ic_building_terrace, R.string.quest_buildingType_terrace2, R.string.quest_buildingType_terrace_description)
-    HOTEL -> Item(this, R.drawable.ic_building_hotel, R.string.quest_buildingType_hotel)
-    DORMITORY -> Item(this, R.drawable.ic_building_dormitory, R.string.quest_buildingType_dormitory)
-    HOUSEBOAT -> Item(this, R.drawable.ic_building_houseboat, R.string.quest_buildingType_houseboat)
-    BUNGALOW -> Item(this, R.drawable.ic_building_bungalow, R.string.quest_buildingType_bungalow, R.string.quest_buildingType_bungalow_description2)
-    STATIC_CARAVAN -> Item(this, R.drawable.ic_building_static_caravan, R.string.quest_buildingType_static_caravan)
-    HUT -> Item(this, R.drawable.ic_building_hut, R.string.quest_buildingType_hut, R.string.quest_buildingType_hut_description)
-
-    INDUSTRIAL -> Item(this, R.drawable.ic_building_industrial, R.string.quest_buildingType_industrial, R.string.quest_buildingType_industrial_description)
-    RETAIL -> Item(this, R.drawable.ic_building_retail, R.string.quest_buildingType_retail, R.string.quest_buildingType_retail_description)
-    OFFICE -> Item(this, R.drawable.ic_building_office, R.string.quest_buildingType_office)
-    WAREHOUSE -> Item(this, R.drawable.ic_building_warehouse, R.string.quest_buildingType_warehouse)
-    KIOSK -> Item(this, R.drawable.ic_building_kiosk, R.string.quest_buildingType_kiosk)
-    STORAGE_TANK -> Item(this, R.drawable.ic_building_storage_tank, R.string.quest_buildingType_storage_tank)
-
-    KINDERGARTEN -> Item(this, R.drawable.ic_building_kindergarten, R.string.quest_buildingType_kindergarten)
-    SCHOOL -> Item(this, R.drawable.ic_building_school, R.string.quest_buildingType_school)
-    COLLEGE -> Item(this, R.drawable.ic_building_college, R.string.quest_buildingType_college)
-    SPORTS_CENTRE -> Item(this, R.drawable.ic_sport_volleyball, R.string.quest_buildingType_sports_centre)
-    HOSPITAL -> Item(this, R.drawable.ic_building_hospital, R.string.quest_buildingType_hospital)
-    STADIUM -> Item(this, R.drawable.ic_sport_volleyball, R.string.quest_buildingType_stadium)
-    GRANDSTAND -> Item(this, R.drawable.ic_sport_volleyball, R.string.quest_buildingType_grandstand)
-    FIRE_STATION -> Item(this, R.drawable.ic_building_fire_truck, R.string.quest_buildingType_fire_station)
-    TRAIN_STATION -> Item(this, R.drawable.ic_building_train_station, R.string.quest_buildingType_train_station)
-    TRANSPORTATION -> Item(this, R.drawable.ic_building_transportation, R.string.quest_buildingType_transportation)
-    UNIVERSITY -> Item(this, R.drawable.ic_building_university, R.string.quest_buildingType_university)
-    GOVERNMENT -> Item(this, R.drawable.ic_building_historic, R.string.quest_buildingType_government)
-
-    CHURCH -> Item(this, R.drawable.ic_religion_christian, R.string.quest_buildingType_church)
-    CHAPEL -> Item(this, R.drawable.ic_religion_christian, R.string.quest_buildingType_chapel)
-    CATHEDRAL -> Item(this, R.drawable.ic_religion_christian, R.string.quest_buildingType_cathedral)
-    MOSQUE -> Item(this, R.drawable.ic_religion_muslim, R.string.quest_buildingType_mosque)
-    TEMPLE -> Item(this, R.drawable.ic_building_temple, R.string.quest_buildingType_temple)
-    PAGODA -> Item(this, R.drawable.ic_building_temple, R.string.quest_buildingType_pagoda)
-    SYNAGOGUE -> Item(this, R.drawable.ic_religion_jewish, R.string.quest_buildingType_synagogue)
-    SHRINE -> Item(this, R.drawable.ic_building_temple, R.string.quest_buildingType_shrine)
-
-    CARPORT -> Item(this, R.drawable.ic_building_carport, R.string.quest_buildingType_carport, R.string.quest_buildingType_carport_description)
-    GARAGE -> Item(this, R.drawable.ic_building_garage, R.string.quest_buildingType_garage)
-    GARAGES -> Item(this, R.drawable.ic_building_garages, R.string.quest_buildingType_garages, R.string.quest_buildingType_garages_description)
-    PARKING -> Item(this, R.drawable.ic_building_parking, R.string.quest_buildingType_parking)
-
-    FARM -> Item(this, R.drawable.ic_building_farm_house, R.string.quest_buildingType_farmhouse, R.string.quest_buildingType_farmhouse_description)
-    FARM_AUXILIARY -> Item(this, R.drawable.ic_building_barn, R.string.quest_buildingType_farm_auxiliary, R.string.quest_buildingType_farm_auxiliary_description)
-    SILO -> Item(this, R.drawable.ic_building_silo, R.string.quest_buildingType_silo)
-    GREENHOUSE -> Item(this, R.drawable.ic_building_greenhouse, R.string.quest_buildingType_greenhouse)
-
-    SHED -> Item(this, R.drawable.ic_building_shed, R.string.quest_buildingType_shed)
-    BOATHOUSE -> Item(this, R.drawable.ic_building_boathouse, R.string.quest_buildingType_boathouse)
-    ALLOTMENT_HOUSE -> Item(this, R.drawable.ic_building_allotment_house, R.string.quest_buildingType_allotment_house)
-    ROOF -> Item(this, R.drawable.ic_building_roof, R.string.quest_buildingType_roof)
-    BRIDGE -> Item(this, R.drawable.ic_building_bridge, R.string.quest_buildingType_bridge)
-    TOILETS -> Item(this, R.drawable.ic_building_toilets, R.string.quest_buildingType_toilets)
-    SERVICE -> Item(this, R.drawable.ic_building_service, R.string.quest_buildingType_service, R.string.quest_buildingType_service_description)
-    HANGAR -> Item(this, R.drawable.ic_building_hangar, R.string.quest_buildingType_hangar, R.string.quest_buildingType_hangar_description)
-    BUNKER -> Item(this, R.drawable.ic_building_bunker, R.string.quest_buildingType_bunker)
-    HISTORIC -> Item(this, R.drawable.ic_building_historic, R.string.quest_buildingType_historic, R.string.quest_buildingType_historic_description)
-    ABANDONED -> Item(this, R.drawable.ic_building_abandoned, R.string.quest_buildingType_abandoned, R.string.quest_buildingType_abandoned_description)
-    RUINS -> Item(this, R.drawable.ic_building_ruins, R.string.quest_buildingType_ruins, R.string.quest_buildingType_ruins_description)
-
-    RESIDENTIAL -> BuildingTypeCategory.RESIDENTIAL.asItem()
-    COMMERCIAL -> BuildingTypeCategory.COMMERCIAL.asItem()
-    CIVIC -> BuildingTypeCategory.CIVIC.asItem()
-    RELIGIOUS -> BuildingTypeCategory.RELIGIOUS.asItem()
-
-    CONSTRUCTION -> Item(null) // This does not need details, as it's part of "Other answers"
+fun BuildingType.asItem(): GroupableDisplayItem<BuildingType>? {
+    val iconResId = iconResId ?: return null
+    val titleResId = titleResId ?: return null
+    return Item(this, iconResId, titleResId, descriptionResId)
 }
 
-fun Array<BuildingTypeCategory>.toItems() = this.map { it.asItem() }
+private val BuildingType.titleResId: Int? get() = when (this) {
+    HOUSE ->           R.string.quest_buildingType_house
+    APARTMENTS ->      R.string.quest_buildingType_apartments
+    DETACHED ->        R.string.quest_buildingType_detached
+    SEMI_DETACHED ->   R.string.quest_buildingType_semi_detached
+    TERRACE ->         R.string.quest_buildingType_terrace2
+    HOTEL ->           R.string.quest_buildingType_hotel
+    DORMITORY ->       R.string.quest_buildingType_dormitory
+    HOUSEBOAT ->       R.string.quest_buildingType_houseboat
+    BUNGALOW ->        R.string.quest_buildingType_bungalow
+    STATIC_CARAVAN ->  R.string.quest_buildingType_static_caravan
+    HUT ->             R.string.quest_buildingType_hut
+    INDUSTRIAL ->      R.string.quest_buildingType_industrial
+    RETAIL ->          R.string.quest_buildingType_retail
+    OFFICE ->          R.string.quest_buildingType_office
+    WAREHOUSE ->       R.string.quest_buildingType_warehouse
+    KIOSK ->           R.string.quest_buildingType_kiosk
+    STORAGE_TANK ->    R.string.quest_buildingType_storage_tank
+    KINDERGARTEN ->    R.string.quest_buildingType_kindergarten
+    SCHOOL ->          R.string.quest_buildingType_school
+    COLLEGE ->         R.string.quest_buildingType_college
+    SPORTS_CENTRE ->   R.string.quest_buildingType_sports_centre
+    HOSPITAL ->        R.string.quest_buildingType_hospital
+    STADIUM ->         R.string.quest_buildingType_stadium
+    GRANDSTAND ->      R.string.quest_buildingType_grandstand
+    TRAIN_STATION ->   R.string.quest_buildingType_train_station
+    TRANSPORTATION ->  R.string.quest_buildingType_transportation
+    FIRE_STATION ->    R.string.quest_buildingType_fire_station
+    UNIVERSITY ->      R.string.quest_buildingType_university
+    GOVERNMENT ->      R.string.quest_buildingType_government
+    CHURCH ->          R.string.quest_buildingType_church
+    CHAPEL ->          R.string.quest_buildingType_chapel
+    CATHEDRAL ->       R.string.quest_buildingType_cathedral
+    MOSQUE ->          R.string.quest_buildingType_mosque
+    TEMPLE ->          R.string.quest_buildingType_temple
+    PAGODA ->          R.string.quest_buildingType_pagoda
+    SYNAGOGUE ->       R.string.quest_buildingType_synagogue
+    SHRINE ->          R.string.quest_buildingType_shrine
+    CARPORT ->         R.string.quest_buildingType_carport
+    GARAGE ->          R.string.quest_buildingType_garage
+    GARAGES ->         R.string.quest_buildingType_garages
+    PARKING ->         R.string.quest_buildingType_parking
+    FARM ->            R.string.quest_buildingType_farmhouse
+    FARM_AUXILIARY ->  R.string.quest_buildingType_farm_auxiliary
+    SILO ->            R.string.quest_buildingType_silo
+    GREENHOUSE ->      R.string.quest_buildingType_greenhouse
+    SHED ->            R.string.quest_buildingType_shed
+    ALLOTMENT_HOUSE -> R.string.quest_buildingType_allotment_house
+    ROOF ->            R.string.quest_buildingType_roof
+    BRIDGE ->          R.string.quest_buildingType_bridge
+    TOILETS ->         R.string.quest_buildingType_toilets
+    SERVICE ->         R.string.quest_buildingType_service
+    HANGAR ->          R.string.quest_buildingType_hangar
+    BUNKER ->          R.string.quest_buildingType_bunker
+    BOATHOUSE ->       R.string.quest_buildingType_boathouse
+    HISTORIC ->        R.string.quest_buildingType_historic
+    ABANDONED ->       R.string.quest_buildingType_abandoned
+    RUINS ->           R.string.quest_buildingType_ruins
+    RESIDENTIAL ->     R.string.quest_buildingType_residential
+    COMMERCIAL ->      R.string.quest_buildingType_commercial
+    CIVIC ->           R.string.quest_buildingType_civic
+    RELIGIOUS ->       R.string.quest_buildingType_religious
+    CONSTRUCTION ->    null
+}
 
-fun BuildingTypeCategory.asItem(): Item<BuildingType?> = when (this) {
-    BuildingTypeCategory.RESIDENTIAL -> Item(this.type, R.drawable.ic_building_apartments,
-        R.string.quest_buildingType_residential, R.string.quest_buildingType_residential_description,
-        this.subTypes.toItems()
-    )
-    BuildingTypeCategory.COMMERCIAL -> Item(this.type, R.drawable.ic_building_office,
-        R.string.quest_buildingType_commercial, R.string.quest_buildingType_commercial_generic_description,
-        this.subTypes.toItems()
-    )
-    BuildingTypeCategory.CIVIC -> Item(this.type, R.drawable.ic_building_civic,
-        R.string.quest_buildingType_civic, R.string.quest_buildingType_civic_description,
-        this.subTypes.toItems()
-    )
-    BuildingTypeCategory.RELIGIOUS -> Item(this.type, R.drawable.ic_building_temple,
-        R.string.quest_buildingType_religious, null, this.subTypes.toItems()
-    )
-    BuildingTypeCategory.FOR_CARS -> Item(this.type, R.drawable.ic_building_car,
-        R.string.quest_buildingType_cars, null, this.subTypes.toItems()
-    )
-    BuildingTypeCategory.FOR_FARMS -> Item(this.type, R.drawable.ic_building_farm,
-        R.string.quest_buildingType_farm, null, this.subTypes.toItems()
-    )
-    BuildingTypeCategory.OTHER -> Item(this.type, R.drawable.ic_building_other,
-        R.string.quest_buildingType_other, null, this.subTypes.toItems()
-    )
+private val BuildingType.descriptionResId: Int? get() = when (this) {
+    HOUSE ->           R.string.quest_buildingType_house_description2
+    APARTMENTS ->      R.string.quest_buildingType_apartments_description
+    DETACHED ->        R.string.quest_buildingType_detached_description
+    SEMI_DETACHED ->   R.string.quest_buildingType_semi_detached_description2
+    TERRACE ->         R.string.quest_buildingType_terrace_description
+    BUNGALOW ->        R.string.quest_buildingType_bungalow_description2
+    HUT ->             R.string.quest_buildingType_hut_description
+    INDUSTRIAL ->      R.string.quest_buildingType_industrial_description
+    RETAIL ->          R.string.quest_buildingType_retail_description
+    CARPORT ->         R.string.quest_buildingType_carport_description
+    GARAGES ->         R.string.quest_buildingType_garages_description
+    FARM ->            R.string.quest_buildingType_farmhouse_description
+    FARM_AUXILIARY ->  R.string.quest_buildingType_farm_auxiliary_description
+    SERVICE ->         R.string.quest_buildingType_service_description
+    HANGAR ->          R.string.quest_buildingType_hangar_description
+    HISTORIC ->        R.string.quest_buildingType_historic_description
+    ABANDONED ->       R.string.quest_buildingType_abandoned_description
+    RUINS ->           R.string.quest_buildingType_ruins_description
+    RESIDENTIAL ->     R.string.quest_buildingType_residential_description
+    COMMERCIAL ->      R.string.quest_buildingType_commercial_generic_description
+    CIVIC ->           R.string.quest_buildingType_civic_description
+    else ->            null
+}
+
+private val BuildingType.iconResId: Int? get() = when (this) {
+    HOUSE ->           R.drawable.ic_building_house
+    APARTMENTS ->      R.drawable.ic_building_apartments
+    DETACHED ->        R.drawable.ic_building_detached
+    SEMI_DETACHED ->   R.drawable.ic_building_semi_detached
+    TERRACE ->         R.drawable.ic_building_terrace
+    HOTEL ->           R.drawable.ic_building_hotel
+    DORMITORY ->       R.drawable.ic_building_dormitory
+    HOUSEBOAT ->       R.drawable.ic_building_houseboat
+    BUNGALOW ->        R.drawable.ic_building_bungalow
+    STATIC_CARAVAN ->  R.drawable.ic_building_static_caravan
+    HUT ->             R.drawable.ic_building_hut
+    INDUSTRIAL ->      R.drawable.ic_building_industrial
+    RETAIL ->          R.drawable.ic_building_retail
+    OFFICE ->          R.drawable.ic_building_office
+    WAREHOUSE ->       R.drawable.ic_building_warehouse
+    KIOSK ->           R.drawable.ic_building_kiosk
+    STORAGE_TANK ->    R.drawable.ic_building_storage_tank
+    KINDERGARTEN ->    R.drawable.ic_building_kindergarten
+    SCHOOL ->          R.drawable.ic_building_school
+    COLLEGE ->         R.drawable.ic_building_college
+    SPORTS_CENTRE ->   R.drawable.ic_sport_volleyball
+    HOSPITAL ->        R.drawable.ic_building_hospital
+    STADIUM ->         R.drawable.ic_sport_volleyball
+    GRANDSTAND ->      R.drawable.ic_sport_volleyball
+    TRAIN_STATION ->   R.drawable.ic_building_train_station
+    TRANSPORTATION ->  R.drawable.ic_building_transportation
+    FIRE_STATION ->    R.drawable.ic_building_fire_truck
+    UNIVERSITY ->      R.drawable.ic_building_university
+    GOVERNMENT ->      R.drawable.ic_building_historic
+    CHURCH ->          R.drawable.ic_religion_christian
+    CHAPEL ->          R.drawable.ic_religion_christian
+    CATHEDRAL ->       R.drawable.ic_religion_christian
+    MOSQUE ->          R.drawable.ic_religion_muslim
+    TEMPLE ->          R.drawable.ic_building_temple
+    PAGODA ->          R.drawable.ic_building_temple
+    SYNAGOGUE ->       R.drawable.ic_religion_jewish
+    SHRINE ->          R.drawable.ic_building_temple
+    CARPORT ->         R.drawable.ic_building_carport
+    GARAGE ->          R.drawable.ic_building_garage
+    GARAGES ->         R.drawable.ic_building_garages
+    PARKING ->         R.drawable.ic_building_parking
+    FARM ->            R.drawable.ic_building_farm_house
+    FARM_AUXILIARY ->  R.drawable.ic_building_barn
+    SILO ->            R.drawable.ic_building_silo
+    GREENHOUSE ->      R.drawable.ic_building_greenhouse
+    SHED ->            R.drawable.ic_building_shed
+    ALLOTMENT_HOUSE -> R.drawable.ic_building_allotment_house
+    ROOF ->            R.drawable.ic_building_roof
+    BRIDGE ->          R.drawable.ic_building_bridge
+    TOILETS ->         R.drawable.ic_building_toilets
+    SERVICE ->         R.drawable.ic_building_service
+    HANGAR ->          R.drawable.ic_building_hangar
+    BUNKER ->          R.drawable.ic_building_bunker
+    BOATHOUSE ->       R.drawable.ic_building_boathouse
+    HISTORIC ->        R.drawable.ic_building_historic
+    ABANDONED ->       R.drawable.ic_building_abandoned
+    RUINS ->           R.drawable.ic_building_ruins
+    RESIDENTIAL ->     R.drawable.ic_building_apartments
+    COMMERCIAL ->      R.drawable.ic_building_office
+    CIVIC ->           R.drawable.ic_building_civic
+    RELIGIOUS ->       R.drawable.ic_building_temple
+    CONSTRUCTION ->    null
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/AddCameraTypeForm.kt
@@ -3,19 +3,10 @@ package de.westnordost.streetcomplete.quests.camera_type
 import android.os.Bundle
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.camera_type.CameraType.DOME
-import de.westnordost.streetcomplete.quests.camera_type.CameraType.FIXED
-import de.westnordost.streetcomplete.quests.camera_type.CameraType.PANNING
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddCameraTypeForm : AImageListQuestForm<CameraType, CameraType>() {
 
-    override val items = listOf(
-        Item(DOME, R.drawable.ic_camera_type_dome, R.string.quest_camera_type_dome),
-        Item(FIXED, R.drawable.ic_camera_type_fixed, R.string.quest_camera_type_fixed),
-        Item(PANNING, R.drawable.ic_camera_type_panning, R.string.quest_camera_type_panning)
-    )
-
+    override val items = CameraType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/CameraTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camera_type/CameraTypeItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.camera_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.camera_type.CameraType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun CameraType.asItem() = Item(this, iconResId, titleResId)
+
+private val CameraType.titleResId: Int get() = when (this) {
+    DOME ->    R.string.quest_camera_type_dome
+    FIXED ->   R.string.quest_camera_type_fixed
+    PANNING -> R.string.quest_camera_type_panning
+}
+
+private val CameraType.iconResId: Int get() = when (this) {
+    DOME ->    R.drawable.ic_camera_type_dome
+    FIXED ->   R.drawable.ic_camera_type_fixed
+    PANNING -> R.drawable.ic_camera_type_panning
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeForm.kt
@@ -1,20 +1,10 @@
 package de.westnordost.streetcomplete.quests.car_wash_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.AUTOMATED
-import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.SELF_SERVICE
-import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.SERVICE
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddCarWashTypeForm : AImageListQuestForm<CarWashType, List<CarWashType>>() {
 
-    override val items = listOf(
-        Item(AUTOMATED, R.drawable.car_wash_automated, R.string.quest_carWashType_automated),
-        Item(SELF_SERVICE, R.drawable.car_wash_self_service, R.string.quest_carWashType_selfService),
-        Item(SERVICE, R.drawable.car_wash_service, R.string.quest_carWashType_service)
-    )
-
+    override val items = CarWashType.values().map { it.asItem() }
     override val itemsPerRow = 3
     override val maxSelectableItems = -1
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/CarWashTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/CarWashTypeItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.car_wash_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun CarWashType.asItem() = Item(this, iconResId, titleResId)
+
+private val CarWashType.titleResId: Int get() = when (this) {
+    AUTOMATED ->    R.string.quest_carWashType_automated
+    SELF_SERVICE -> R.string.quest_carWashType_selfService
+    SERVICE ->      R.string.quest_carWashType_service
+}
+
+private val CarWashType.iconResId: Int get() = when (this) {
+    AUTOMATED ->    R.drawable.car_wash_automated
+    SELF_SERVICE -> R.drawable.car_wash_self_service
+    SERVICE ->      R.drawable.car_wash_service
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
@@ -1,20 +1,10 @@
 package de.westnordost.streetcomplete.quests.crossing_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.MARKED
-import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.TRAFFIC_SIGNALS
-import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.UNMARKED
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddCrossingTypeForm : AImageListQuestForm<CrossingType, CrossingType>() {
 
-    override val items = listOf(
-        Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals_controlled),
-        Item(MARKED, R.drawable.crossing_type_zebra, R.string.quest_crossing_type_marked),
-        Item(UNMARKED, R.drawable.crossing_type_unmarked, R.string.quest_crossing_type_unmarked)
-    )
-
+    override val items = CrossingType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<CrossingType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/CrossingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/CrossingTypeItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.crossing_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun CrossingType.asItem() = Item(this, iconResId, titleResId)
+
+private val CrossingType.titleResId: Int get() = when (this) {
+    TRAFFIC_SIGNALS -> R.string.quest_crossing_type_signals_controlled
+    MARKED ->          R.string.quest_crossing_type_marked
+    UNMARKED ->        R.string.quest_crossing_type_unmarked
+}
+
+private val CrossingType.iconResId: Int get() = when (this) {
+    TRAFFIC_SIGNALS -> R.drawable.crossing_type_signals
+    MARKED ->          R.drawable.crossing_type_zebra
+    UNMARKED ->        R.drawable.crossing_type_unmarked
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/CyclewayItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/CyclewayItem.kt
@@ -76,56 +76,56 @@ private fun Cycleway.getIconResId(isLeftHandTraffic: Boolean): Int =
     if (isLeftHandTraffic) getLeftHandTrafficIconResId() else getRightHandTrafficIconResId()
 
 private fun Cycleway.getRightHandTrafficIconResId(): Int = when (this) {
-    UNSPECIFIED_LANE -> R.drawable.ic_cycleway_lane
-    EXCLUSIVE_LANE -> R.drawable.ic_cycleway_lane
-    ADVISORY_LANE -> R.drawable.ic_cycleway_shared_lane
-    SUGGESTION_LANE -> R.drawable.ic_cycleway_suggestion_lane
-    TRACK -> R.drawable.ic_cycleway_track
-    NONE -> R.drawable.ic_cycleway_none
-    NONE_NO_ONEWAY -> R.drawable.ic_cycleway_none_no_oneway
-    PICTOGRAMS -> R.drawable.ic_cycleway_pictograms
+    UNSPECIFIED_LANE ->  R.drawable.ic_cycleway_lane
+    EXCLUSIVE_LANE ->    R.drawable.ic_cycleway_lane
+    ADVISORY_LANE ->     R.drawable.ic_cycleway_shared_lane
+    SUGGESTION_LANE ->   R.drawable.ic_cycleway_suggestion_lane
+    TRACK ->             R.drawable.ic_cycleway_track
+    NONE ->              R.drawable.ic_cycleway_none
+    NONE_NO_ONEWAY ->    R.drawable.ic_cycleway_none_no_oneway
+    PICTOGRAMS ->        R.drawable.ic_cycleway_pictograms
     SIDEWALK_EXPLICIT -> R.drawable.ic_cycleway_sidewalk_explicit
-    DUAL_LANE -> R.drawable.ic_cycleway_lane_dual
-    DUAL_TRACK -> R.drawable.ic_cycleway_track_dual
-    BUSWAY -> R.drawable.ic_cycleway_bus_lane
-    SEPARATE -> R.drawable.ic_cycleway_none
+    DUAL_LANE ->         R.drawable.ic_cycleway_lane_dual
+    DUAL_TRACK ->        R.drawable.ic_cycleway_track_dual
+    BUSWAY ->            R.drawable.ic_cycleway_bus_lane
+    SEPARATE ->          R.drawable.ic_cycleway_none
     else -> 0
 }
 
 private fun Cycleway.getLeftHandTrafficIconResId(): Int = when (this) {
-    UNSPECIFIED_LANE -> R.drawable.ic_cycleway_lane_l
-    EXCLUSIVE_LANE -> R.drawable.ic_cycleway_lane_l
-    ADVISORY_LANE -> R.drawable.ic_cycleway_shared_lane_l
-    SUGGESTION_LANE -> R.drawable.ic_cycleway_suggestion_lane
-    TRACK -> R.drawable.ic_cycleway_track_l
-    NONE -> R.drawable.ic_cycleway_none
-    NONE_NO_ONEWAY -> R.drawable.ic_cycleway_none_no_oneway_l
-    PICTOGRAMS -> R.drawable.ic_cycleway_pictograms_l
+    UNSPECIFIED_LANE ->  R.drawable.ic_cycleway_lane_l
+    EXCLUSIVE_LANE ->    R.drawable.ic_cycleway_lane_l
+    ADVISORY_LANE ->     R.drawable.ic_cycleway_shared_lane_l
+    SUGGESTION_LANE ->   R.drawable.ic_cycleway_suggestion_lane
+    TRACK ->             R.drawable.ic_cycleway_track_l
+    NONE ->              R.drawable.ic_cycleway_none
+    NONE_NO_ONEWAY ->    R.drawable.ic_cycleway_none_no_oneway_l
+    PICTOGRAMS ->        R.drawable.ic_cycleway_pictograms_l
     SIDEWALK_EXPLICIT -> R.drawable.ic_cycleway_sidewalk_explicit_l
-    DUAL_LANE -> R.drawable.ic_cycleway_lane_dual_l
-    DUAL_TRACK -> R.drawable.ic_cycleway_track_dual_l
-    BUSWAY -> R.drawable.ic_cycleway_bus_lane_l
-    SEPARATE -> R.drawable.ic_cycleway_none
+    DUAL_LANE ->         R.drawable.ic_cycleway_lane_dual_l
+    DUAL_TRACK ->        R.drawable.ic_cycleway_track_dual_l
+    BUSWAY ->            R.drawable.ic_cycleway_bus_lane_l
+    SEPARATE ->          R.drawable.ic_cycleway_none
     else -> 0
 }
 
 private fun Cycleway.getTitleResId(isContraflowInOneway: Boolean): Int = when (this) {
-    UNSPECIFIED_LANE -> R.string.quest_cycleway_value_lane
-    EXCLUSIVE_LANE -> R.string.quest_cycleway_value_lane
-    ADVISORY_LANE -> R.string.quest_cycleway_value_lane_soft
-    SUGGESTION_LANE -> R.string.quest_cycleway_value_suggestion_lane
-    TRACK -> R.string.quest_cycleway_value_track
+    UNSPECIFIED_LANE ->  R.string.quest_cycleway_value_lane
+    EXCLUSIVE_LANE ->    R.string.quest_cycleway_value_lane
+    ADVISORY_LANE ->     R.string.quest_cycleway_value_lane_soft
+    SUGGESTION_LANE ->   R.string.quest_cycleway_value_suggestion_lane
+    TRACK ->             R.string.quest_cycleway_value_track
     NONE -> {
         if (isContraflowInOneway) R.string.quest_cycleway_value_none_and_oneway
-        else R.string.quest_cycleway_value_none
+        else                      R.string.quest_cycleway_value_none
     }
-    NONE_NO_ONEWAY -> R.string.quest_cycleway_value_none_but_no_oneway
-    PICTOGRAMS -> R.string.quest_cycleway_value_shared
+    NONE_NO_ONEWAY ->    R.string.quest_cycleway_value_none_but_no_oneway
+    PICTOGRAMS ->        R.string.quest_cycleway_value_shared
     SIDEWALK_EXPLICIT -> R.string.quest_cycleway_value_sidewalk
-    DUAL_LANE -> R.string.quest_cycleway_value_lane_dual
-    DUAL_TRACK -> R.string.quest_cycleway_value_track_dual
-    BUSWAY -> R.string.quest_cycleway_value_bus_lane
-    SEPARATE -> R.string.quest_cycleway_value_separate
+    DUAL_LANE ->         R.string.quest_cycleway_value_lane_dual
+    DUAL_TRACK ->        R.string.quest_cycleway_value_track_dual
+    BUSWAY ->            R.string.quest_cycleway_value_bus_lane
+    SEPARATE ->          R.string.quest_cycleway_value_separate
     else -> 0
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantTypeForm.kt
@@ -1,22 +1,10 @@
 package de.westnordost.streetcomplete.quests.fire_hydrant
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.fire_hydrant.FireHydrantType.PILLAR
-import de.westnordost.streetcomplete.quests.fire_hydrant.FireHydrantType.POND
-import de.westnordost.streetcomplete.quests.fire_hydrant.FireHydrantType.UNDERGROUND
-import de.westnordost.streetcomplete.quests.fire_hydrant.FireHydrantType.WALL
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddFireHydrantTypeForm : AImageListQuestForm<FireHydrantType, FireHydrantType>() {
 
-    override val items = listOf(
-        Item(PILLAR, R.drawable.fire_hydrant_pillar, R.string.quest_fireHydrant_type_pillar),
-        Item(UNDERGROUND, R.drawable.fire_hydrant_underground, R.string.quest_fireHydrant_type_underground),
-        Item(WALL, R.drawable.fire_hydrant_wall, R.string.quest_fireHydrant_type_wall),
-        Item(POND, R.drawable.fire_hydrant_pond, R.string.quest_fireHydrant_type_pond)
-    )
-
+    override val items = FireHydrantType.values().map { it.asItem() }
     override val itemsPerRow = 2
 
     override fun onClickOk(selectedItems: List<FireHydrantType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/FireHydrantTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/FireHydrantTypeItem.kt
@@ -1,0 +1,21 @@
+package de.westnordost.streetcomplete.quests.fire_hydrant
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.fire_hydrant.FireHydrantType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun FireHydrantType.asItem() = Item(this, iconResId, titleResId)
+
+private val FireHydrantType.titleResId: Int get() = when (this) {
+    PILLAR ->      R.string.quest_fireHydrant_type_pillar
+    UNDERGROUND -> R.string.quest_fireHydrant_type_underground
+    WALL ->        R.string.quest_fireHydrant_type_wall
+    POND ->        R.string.quest_fireHydrant_type_pond
+}
+
+private val FireHydrantType.iconResId: Int get() = when (this) {
+    PILLAR ->      R.drawable.fire_hydrant_pillar
+    UNDERGROUND -> R.drawable.fire_hydrant_underground
+    WALL ->        R.drawable.fire_hydrant_wall
+    POND ->        R.drawable.fire_hydrant_pond
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPositionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPositionForm.kt
@@ -1,31 +1,14 @@
 package de.westnordost.streetcomplete.quests.fire_hydrant_position
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.fire_hydrant_position.FireHydrantPosition.GREEN
-import de.westnordost.streetcomplete.quests.fire_hydrant_position.FireHydrantPosition.LANE
-import de.westnordost.streetcomplete.quests.fire_hydrant_position.FireHydrantPosition.PARKING_LOT
-import de.westnordost.streetcomplete.quests.fire_hydrant_position.FireHydrantPosition.SIDEWALK
-import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
 
 class AddFireHydrantPositionForm : AImageListQuestForm<FireHydrantPosition, FireHydrantPosition>() {
 
-    override val items
-        get() = if (element.tags["fire_hydrant:type"] == "pillar") {
-            listOf(
-                Item(GREEN, R.drawable.fire_hydrant_position_pillar_green, R.string.quest_fireHydrant_position_green),
-                Item(LANE, R.drawable.fire_hydrant_position_pillar_lane, R.string.quest_fireHydrant_position_lane),
-                Item(SIDEWALK, R.drawable.fire_hydrant_position_pillar_sidewalk, R.string.quest_fireHydrant_position_sidewalk),
-                Item(PARKING_LOT, R.drawable.fire_hydrant_position_pillar_parking, R.string.quest_fireHydrant_position_parking_lot)
-            )
-        } else {
-            listOf(
-                Item(GREEN, R.drawable.fire_hydrant_position_underground_green, R.string.quest_fireHydrant_position_green),
-                Item(LANE, R.drawable.fire_hydrant_position_underground_lane, R.string.quest_fireHydrant_position_lane),
-                Item(SIDEWALK, R.drawable.fire_hydrant_position_underground_sidewalk, R.string.quest_fireHydrant_position_sidewalk),
-                Item(PARKING_LOT, R.drawable.fire_hydrant_position_underground_parking, R.string.quest_fireHydrant_position_parking_lot)
-            )
-        }
+    override val items: List<DisplayItem<FireHydrantPosition>> get() {
+        val isPillar = element.tags["fire_hydrant:type"] == "pillar"
+        return FireHydrantPosition.values().map { it.asItem(isPillar) }
+    }
 
     override val itemsPerRow = 2
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/FireHydrantPositionItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/FireHydrantPositionItem.kt
@@ -1,0 +1,29 @@
+package de.westnordost.streetcomplete.quests.fire_hydrant_position
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.fire_hydrant_position.FireHydrantPosition.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun FireHydrantPosition.asItem(isPillar: Boolean) =
+    Item(this, if (isPillar) pillarIconResId else undergroundIconResId, titleResId)
+
+private val FireHydrantPosition.titleResId: Int get() = when (this) {
+    GREEN ->       R.string.quest_fireHydrant_position_green
+    LANE ->        R.string.quest_fireHydrant_position_lane
+    SIDEWALK ->    R.string.quest_fireHydrant_position_sidewalk
+    PARKING_LOT -> R.string.quest_fireHydrant_position_parking_lot
+}
+
+private val FireHydrantPosition.pillarIconResId: Int get() = when (this) {
+    GREEN ->       R.drawable.fire_hydrant_position_pillar_green
+    LANE ->        R.drawable.fire_hydrant_position_pillar_lane
+    SIDEWALK ->    R.drawable.fire_hydrant_position_pillar_sidewalk
+    PARKING_LOT -> R.drawable.fire_hydrant_position_pillar_parking
+}
+
+private val FireHydrantPosition.undergroundIconResId: Int get() = when (this) {
+    GREEN ->       R.drawable.fire_hydrant_position_underground_green
+    LANE ->        R.drawable.fire_hydrant_position_underground_lane
+    SIDEWALK ->    R.drawable.fire_hydrant_position_underground_sidewalk
+    PARKING_LOT -> R.drawable.fire_hydrant_position_underground_parking
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeightForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/AddKerbHeightForm.kt
@@ -1,24 +1,10 @@
 package de.westnordost.streetcomplete.quests.kerb_height
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.FLUSH
-import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.KERB_RAMP
-import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.LOWERED
-import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.NO_KERB
-import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.RAISED
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddKerbHeightForm : AImageListQuestForm<KerbHeight, KerbHeight>() {
 
-    override val items = listOf(
-        Item(RAISED, R.drawable.kerb_height_raised, R.string.quest_kerb_height_raised),
-        Item(LOWERED, R.drawable.kerb_height_lowered, R.string.quest_kerb_height_lowered),
-        Item(FLUSH, R.drawable.kerb_height_flush, R.string.quest_kerb_height_flush),
-        Item(KERB_RAMP, R.drawable.kerb_height_lowered_ramp, R.string.quest_kerb_height_lowered_ramp),
-        Item(NO_KERB, R.drawable.kerb_height_no, R.string.quest_kerb_height_no)
-    )
-
+    override val items = KerbHeight.values().map { it.asItem() }
     override val itemsPerRow = 2
     override val moveFavoritesToFront = false
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/KerbHeightItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/kerb_height/KerbHeightItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.kerb_height
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.kerb_height.KerbHeight.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun KerbHeight.asItem() = Item(this, iconResId, titleResId)
+
+private val KerbHeight.titleResId: Int get() = when (this) {
+    RAISED ->    R.string.quest_kerb_height_raised
+    LOWERED ->   R.string.quest_kerb_height_lowered
+    FLUSH ->     R.string.quest_kerb_height_flush
+    KERB_RAMP -> R.string.quest_kerb_height_lowered_ramp
+    NO_KERB ->   R.string.quest_kerb_height_no
+}
+
+private val KerbHeight.iconResId: Int get() = when (this) {
+    RAISED ->    R.drawable.kerb_height_raised
+    LOWERED ->   R.drawable.kerb_height_lowered
+    FLUSH ->     R.drawable.kerb_height_flush
+    KERB_RAMP -> R.drawable.kerb_height_lowered_ramp
+    NO_KERB ->   R.drawable.kerb_height_no
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafTypeForm.kt
@@ -1,20 +1,11 @@
 package de.westnordost.streetcomplete.quests.leaf_detail
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.leaf_detail.ForestLeafType.BROADLEAVED
-import de.westnordost.streetcomplete.quests.leaf_detail.ForestLeafType.MIXED
-import de.westnordost.streetcomplete.quests.leaf_detail.ForestLeafType.NEEDLELEAVED
-import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.police_type.asItem
 
 class AddForestLeafTypeForm : AImageListQuestForm<ForestLeafType, ForestLeafType>() {
 
-    override val items = listOf(
-        Item(NEEDLELEAVED, R.drawable.leaf_type_needleleaved, R.string.quest_leaf_type_needles),
-        Item(BROADLEAVED, R.drawable.leaf_type_broadleaved, R.string.quest_leaf_type_broadleaved),
-        Item(MIXED, R.drawable.leaf_type_mixed, R.string.quest_leaf_type_mixed)
-    )
-
+    override val items = ForestLeafType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<ForestLeafType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/ForestLeafTimeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/leaf_detail/ForestLeafTimeItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.leaf_detail
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.leaf_detail.ForestLeafType.*
+
+fun ForestLeafType.asItem() = Item(this, iconResId, titleResId)
+
+private val ForestLeafType.titleResId: Int get() = when (this) {
+    NEEDLELEAVED -> R.string.quest_leaf_type_needles
+    BROADLEAVED ->  R.string.quest_leaf_type_broadleaved
+    MIXED ->        R.string.quest_leaf_type_mixed
+}
+
+private val ForestLeafType.iconResId: Int get() = when (this) {
+    NEEDLELEAVED -> R.drawable.leaf_type_needleleaved
+    BROADLEAVED ->  R.drawable.leaf_type_broadleaved
+    MIXED ->        R.drawable.leaf_type_mixed
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/memorial_type/AddMemorialTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/memorial_type/AddMemorialTypeForm.kt
@@ -1,33 +1,10 @@
 package de.westnordost.streetcomplete.quests.memorial_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.BUST
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.OBELISK
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.PLAQUE
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.SCULPTURE
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.STATUE
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.STONE
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.STONE_STELE
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.WAR_MEMORIAL
-import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.WOODEN_STELE
-import de.westnordost.streetcomplete.view.image_select.DisplayItem
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddMemorialTypeForm : AImageListQuestForm<MemorialType, MemorialType>() {
 
-    override val items: List<DisplayItem<MemorialType>> = listOf(
-        Item(STATUE, R.drawable.memorial_type_statue, R.string.quest_memorialType_statue),
-        Item(BUST, R.drawable.memorial_type_bust, R.string.quest_memorialType_bust),
-        Item(PLAQUE, R.drawable.memorial_type_plaque, R.string.quest_memorialType_plaque),
-        Item(WAR_MEMORIAL, R.drawable.memorial_type_war_memorial, R.string.quest_memorialType_war_memorial),
-        Item(STONE, R.drawable.memorial_type_stone, R.string.quest_memorialType_stone),
-        Item(OBELISK, R.drawable.memorial_type_obelisk, R.string.quest_memorialType_obelisk),
-        Item(WOODEN_STELE, R.drawable.memorial_type_stele_wooden, R.string.quest_memorialType_stele_wooden),
-        Item(STONE_STELE, R.drawable.memorial_type_stele_stone, R.string.quest_memorialType_stele_stone),
-        Item(SCULPTURE, R.drawable.memorial_type_sculpture, R.string.quest_memorialType_sculpture),
-    )
-
+    override val items = MemorialType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<MemorialType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/memorial_type/MemorialTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/memorial_type/MemorialTypeItem.kt
@@ -1,0 +1,31 @@
+package de.westnordost.streetcomplete.quests.memorial_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.memorial_type.MemorialType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun MemorialType.asItem() = Item(this, iconResId, titleResId)
+
+private val MemorialType.titleResId: Int get() = when (this) {
+    STATUE ->       R.string.quest_memorialType_statue
+    BUST ->         R.string.quest_memorialType_bust
+    PLAQUE ->       R.string.quest_memorialType_plaque
+    WAR_MEMORIAL -> R.string.quest_memorialType_war_memorial
+    STONE ->        R.string.quest_memorialType_stone
+    OBELISK ->      R.string.quest_memorialType_obelisk
+    WOODEN_STELE -> R.string.quest_memorialType_stele_wooden
+    STONE_STELE ->  R.string.quest_memorialType_stele_stone
+    SCULPTURE ->    R.string.quest_memorialType_sculpture
+}
+
+private val MemorialType.iconResId: Int get() = when (this) {
+    STATUE ->       R.drawable.memorial_type_statue
+    BUST ->         R.drawable.memorial_type_bust
+    PLAQUE ->       R.drawable.memorial_type_plaque
+    WAR_MEMORIAL -> R.drawable.memorial_type_war_memorial
+    STONE ->        R.drawable.memorial_type_stone
+    OBELISK ->      R.drawable.memorial_type_obelisk
+    WOODEN_STELE -> R.drawable.memorial_type_stele_wooden
+    STONE_STELE ->  R.drawable.memorial_type_stele_stone
+    SCULPTURE ->    R.drawable.memorial_type_sculpture
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOnewayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOnewayForm.kt
@@ -10,7 +10,7 @@ import kotlin.math.PI
 class AddOnewayForm : AImageListQuestForm<OnewayAnswer, OnewayAnswer>() {
 
     override val items get() =
-        OnewayAnswer.values().map { it.toItem(requireContext(), wayRotation + mapRotation) }
+        OnewayAnswer.values().map { it.asItem(requireContext(), wayRotation + mapRotation) }
 
     override val itemsPerRow = 3
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/OnewayAnswerItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/OnewayAnswerItem.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.view.RotatedCircleDrawable
 import de.westnordost.streetcomplete.view.image_select.DisplayItem
 import de.westnordost.streetcomplete.view.image_select.Item2
 
-fun OnewayAnswer.toItem(context: Context, rotation: Float): DisplayItem<OnewayAnswer> {
+fun OnewayAnswer.asItem(context: Context, rotation: Float): DisplayItem<OnewayAnswer> {
     val drawable = RotatedCircleDrawable(context.getDrawable(iconResId)!!)
     drawable.rotation = rotation
     return Item2(this, DrawableImage(drawable), ResText(titleResId))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduceForm.kt
@@ -1,126 +1,12 @@
 package de.westnordost.streetcomplete.quests.orchard_produce
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.AGAVE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.ALMOND
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.APPLE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.APRICOT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.ARECA_NUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.AVOCADO
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.BANANA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.BLUEBERRY
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.BRAZIL_NUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CACAO
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CASHEW
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CHERRY
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CHESTNUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CHILLI_PEPPER
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.COCONUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.COFFEE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.CRANBERRY
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.DATE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.FIG
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.GRAPE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.GRAPEFRUIT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.GUAVA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.HAZELNUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.HOP
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.JOJOBA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.KIWI
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.KOLA_NUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.LEMON
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.LIME
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.MANGO
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.MANGOSTEEN
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.MATE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.NUTMEG
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.OLIVE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.ORANGE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PALM_OIL
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PAPAYA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PEACH
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PEAR
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PEPPER
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PERSIMMON
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PINEAPPLE
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PISTACHIO
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.PLUM
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.RASPBERRY
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.RUBBER
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.SISAL
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.STRAWBERRY
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.SWEET_PEPPER
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.TEA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.TOMATO
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.TUNG_NUT
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.VANILLA
-import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.WALNUT
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddOrchardProduceForm : AImageListQuestForm<OrchardProduce, List<OrchardProduce>>() {
 
-    private val produces = listOf(
-        // ordered alphabetically here for overview. Produces are filtered and sorted by what is
-        // found in the the country metadata
-
-        Item(SISAL,         R.drawable.produce_sisal,       R.string.produce_sisal),
-        Item(GRAPE,         R.drawable.produce_grape,       R.string.produce_grapes),
-
-        Item(AGAVE,         R.drawable.produce_agave,       R.string.produce_agaves),
-        Item(ALMOND,        R.drawable.produce_almond,      R.string.produce_almonds),
-        Item(APPLE,         R.drawable.produce_apple,       R.string.produce_apples),
-        Item(APRICOT,       R.drawable.produce_apricot,     R.string.produce_apricots),
-        Item(ARECA_NUT,     R.drawable.produce_areca_nut,   R.string.produce_areca_nuts),
-        Item(AVOCADO,       R.drawable.produce_avocado,     R.string.produce_avocados),
-        Item(BANANA,        R.drawable.produce_banana,      R.string.produce_bananas),
-        Item(SWEET_PEPPER,  R.drawable.produce_bell_pepper, R.string.produce_sweet_peppers),
-        Item(BLUEBERRY,     R.drawable.produce_blueberry,   R.string.produce_blueberries),
-        Item(BRAZIL_NUT,    R.drawable.produce_brazil_nut,  R.string.produce_brazil_nuts),
-        Item(CACAO,         R.drawable.produce_cacao,       R.string.produce_cacao),
-        Item(CASHEW,        R.drawable.produce_cashew,      R.string.produce_cashew_nuts),
-        Item(CHERRY,        R.drawable.produce_cherry,      R.string.produce_cherries),
-        Item(CHESTNUT,      R.drawable.produce_chestnut,    R.string.produce_chestnuts),
-        Item(CHILLI_PEPPER, R.drawable.produce_chili,       R.string.produce_chili),
-        Item(COCONUT,       R.drawable.produce_coconut,     R.string.produce_coconuts),
-        Item(COFFEE,        R.drawable.produce_coffee,      R.string.produce_coffee),
-        Item(CRANBERRY,     R.drawable.produce_cranberry,   R.string.produce_cranberries),
-        Item(DATE,          R.drawable.produce_date,        R.string.produce_dates),
-        Item(FIG,           R.drawable.produce_fig,         R.string.produce_figs),
-        Item(GRAPEFRUIT,    R.drawable.produce_grapefruit,  R.string.produce_grapefruits),
-        Item(GUAVA,         R.drawable.produce_guava,       R.string.produce_guavas),
-        Item(HAZELNUT,      R.drawable.produce_hazelnut,    R.string.produce_hazelnuts),
-        Item(HOP,           R.drawable.produce_hop,         R.string.produce_hops),
-        Item(JOJOBA,        R.drawable.produce_jojoba,      R.string.produce_jojoba),
-        Item(KIWI,          R.drawable.produce_kiwi,        R.string.produce_kiwis),
-        Item(KOLA_NUT,      R.drawable.produce_kola_nut,    R.string.produce_kola_nuts),
-        Item(LEMON,         R.drawable.produce_lemon,       R.string.produce_lemons),
-        Item(LIME,          R.drawable.produce_lime,        R.string.produce_limes),
-        Item(MANGO,         R.drawable.produce_mango,       R.string.produce_mangos),
-        Item(MANGOSTEEN,    R.drawable.produce_mangosteen,  R.string.produce_mangosteen),
-        Item(MATE,          R.drawable.produce_mate,        R.string.produce_mate),
-        Item(NUTMEG,        R.drawable.produce_nutmeg,      R.string.produce_nutmeg),
-        Item(OLIVE,         R.drawable.produce_olive,       R.string.produce_olives),
-        Item(ORANGE,        R.drawable.produce_orange,      R.string.produce_oranges),
-        Item(PALM_OIL,      R.drawable.produce_palm_oil,    R.string.produce_oil_palms),
-        Item(PAPAYA,        R.drawable.produce_papaya,      R.string.produce_papayas),
-        Item(PEACH,         R.drawable.produce_peach,       R.string.produce_peaches),
-        Item(PEAR,          R.drawable.produce_pear,        R.string.produce_pears),
-        Item(PEPPER,        R.drawable.produce_pepper,      R.string.produce_pepper),
-        Item(PERSIMMON,     R.drawable.produce_persimmon,   R.string.produce_persimmons),
-        Item(PINEAPPLE,     R.drawable.produce_pineapple,   R.string.produce_pineapples),
-        Item(PISTACHIO,     R.drawable.produce_pistachio,   R.string.produce_pistachios),
-        Item(PLUM,          R.drawable.produce_plum,        R.string.produce_plums),
-        Item(RASPBERRY,     R.drawable.produce_raspberry,   R.string.produce_raspberries),
-        Item(RUBBER,        R.drawable.produce_rubber,      R.string.produce_rubber),
-        Item(STRAWBERRY,    R.drawable.produce_strawberry,  R.string.produce_strawberries),
-        Item(TEA,           R.drawable.produce_tea,         R.string.produce_tea),
-        Item(TOMATO,        R.drawable.produce_tomato,      R.string.produce_tomatoes),
-        Item(TUNG_NUT,      R.drawable.produce_tung_nut,    R.string.produce_tung_nuts),
-        Item(VANILLA,       R.drawable.produce_vanilla,     R.string.produce_vanilla),
-        Item(WALNUT,        R.drawable.produce_walnut,      R.string.produce_walnuts)
-    )
-    private val producesMap = produces.associateBy { it.value!!.osmValue }
+    private val producesMap = OrchardProduce.values()
+        .map { it.asItem() }
+        .associateBy { it.value!!.osmValue }
 
     // only include what is given for that country
     override val items get() = countryInfo.orchardProduces.mapNotNull { producesMap[it] }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/OrchardProduceItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/OrchardProduceItem.kt
@@ -1,0 +1,121 @@
+package de.westnordost.streetcomplete.quests.orchard_produce
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.orchard_produce.OrchardProduce.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun OrchardProduce.asItem() = Item(this, iconResId, titleResId)
+
+private val OrchardProduce.titleResId: Int get() = when (this) {
+    SISAL ->         R.string.produce_sisal
+    GRAPE ->         R.string.produce_grapes
+    AGAVE ->         R.string.produce_agaves
+    ALMOND ->        R.string.produce_almonds
+    APPLE ->         R.string.produce_apples
+    APRICOT ->       R.string.produce_apricots
+    ARECA_NUT ->     R.string.produce_areca_nuts
+    AVOCADO ->       R.string.produce_avocados
+    BANANA ->        R.string.produce_bananas
+    SWEET_PEPPER ->  R.string.produce_sweet_peppers
+    BLUEBERRY ->     R.string.produce_blueberries
+    BRAZIL_NUT ->    R.string.produce_brazil_nuts
+    CACAO ->         R.string.produce_cacao
+    CASHEW ->        R.string.produce_cashew_nuts
+    CHERRY ->        R.string.produce_cherries
+    CHESTNUT ->      R.string.produce_chestnuts
+    CHILLI_PEPPER -> R.string.produce_chili
+    COCONUT ->       R.string.produce_coconuts
+    COFFEE ->        R.string.produce_coffee
+    CRANBERRY ->     R.string.produce_cranberries
+    DATE ->          R.string.produce_dates
+    FIG ->           R.string.produce_figs
+    GRAPEFRUIT ->    R.string.produce_grapefruits
+    GUAVA ->         R.string.produce_guavas
+    HAZELNUT ->      R.string.produce_hazelnuts
+    HOP ->           R.string.produce_hops
+    JOJOBA ->        R.string.produce_jojoba
+    KIWI ->          R.string.produce_kiwis
+    KOLA_NUT ->      R.string.produce_kola_nuts
+    LEMON ->         R.string.produce_lemons
+    LIME ->          R.string.produce_limes
+    MANGO ->         R.string.produce_mangos
+    MANGOSTEEN ->    R.string.produce_mangosteen
+    MATE ->          R.string.produce_mate
+    NUTMEG ->        R.string.produce_nutmeg
+    OLIVE ->         R.string.produce_olives
+    ORANGE ->        R.string.produce_oranges
+    PALM_OIL ->      R.string.produce_oil_palms
+    PAPAYA ->        R.string.produce_papayas
+    PEACH ->         R.string.produce_peaches
+    PEAR ->          R.string.produce_pears
+    PEPPER ->        R.string.produce_pepper
+    PERSIMMON ->     R.string.produce_persimmons
+    PINEAPPLE ->     R.string.produce_pineapples
+    PISTACHIO ->     R.string.produce_pistachios
+    PLUM ->          R.string.produce_plums
+    RASPBERRY ->     R.string.produce_raspberries
+    RUBBER ->        R.string.produce_rubber
+    STRAWBERRY ->    R.string.produce_strawberries
+    TEA ->           R.string.produce_tea
+    TOMATO ->        R.string.produce_tomatoes
+    TUNG_NUT ->      R.string.produce_tung_nuts
+    VANILLA ->       R.string.produce_vanilla
+    WALNUT ->        R.string.produce_walnuts
+}
+
+private val OrchardProduce.iconResId: Int get() = when (this) {
+    SISAL ->         R.drawable.produce_sisal
+    GRAPE ->         R.drawable.produce_grape
+    AGAVE ->         R.drawable.produce_agave
+    ALMOND ->        R.drawable.produce_almond
+    APPLE ->         R.drawable.produce_apple
+    APRICOT ->       R.drawable.produce_apricot
+    ARECA_NUT ->     R.drawable.produce_areca_nut
+    AVOCADO ->       R.drawable.produce_avocado
+    BANANA ->        R.drawable.produce_banana
+    SWEET_PEPPER ->  R.drawable.produce_bell_pepper
+    BLUEBERRY ->     R.drawable.produce_blueberry
+    BRAZIL_NUT ->    R.drawable.produce_brazil_nut
+    CACAO ->         R.drawable.produce_cacao
+    CASHEW ->        R.drawable.produce_cashew
+    CHERRY ->        R.drawable.produce_cherry
+    CHESTNUT ->      R.drawable.produce_chestnut
+    CHILLI_PEPPER -> R.drawable.produce_chili
+    COCONUT ->       R.drawable.produce_coconut
+    COFFEE ->        R.drawable.produce_coffee
+    CRANBERRY ->     R.drawable.produce_cranberry
+    DATE ->          R.drawable.produce_date
+    FIG ->           R.drawable.produce_fig
+    GRAPEFRUIT ->    R.drawable.produce_grapefruit
+    GUAVA ->         R.drawable.produce_guava
+    HAZELNUT ->      R.drawable.produce_hazelnut
+    HOP ->           R.drawable.produce_hop
+    JOJOBA ->        R.drawable.produce_jojoba
+    KIWI ->          R.drawable.produce_kiwi
+    KOLA_NUT ->      R.drawable.produce_kola_nut
+    LEMON ->         R.drawable.produce_lemon
+    LIME ->          R.drawable.produce_lime
+    MANGO ->         R.drawable.produce_mango
+    MANGOSTEEN ->    R.drawable.produce_mangosteen
+    MATE ->          R.drawable.produce_mate
+    NUTMEG ->        R.drawable.produce_nutmeg
+    OLIVE ->         R.drawable.produce_olive
+    ORANGE ->        R.drawable.produce_orange
+    PALM_OIL ->      R.drawable.produce_palm_oil
+    PAPAYA ->        R.drawable.produce_papaya
+    PEACH ->         R.drawable.produce_peach
+    PEAR ->          R.drawable.produce_pear
+    PEPPER ->        R.drawable.produce_pepper
+    PERSIMMON ->     R.drawable.produce_persimmon
+    PINEAPPLE ->     R.drawable.produce_pineapple
+    PISTACHIO ->     R.drawable.produce_pistachio
+    PLUM ->          R.drawable.produce_plum
+    RASPBERRY ->     R.drawable.produce_raspberry
+    RUBBER ->        R.drawable.produce_rubber
+    STRAWBERRY ->    R.drawable.produce_strawberry
+    TEA ->           R.drawable.produce_tea
+    TOMATO ->        R.drawable.produce_tomato
+    TUNG_NUT ->      R.drawable.produce_tung_nut
+    VANILLA ->       R.drawable.produce_vanilla
+    WALNUT ->        R.drawable.produce_walnut
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingTypeForm.kt
@@ -1,24 +1,10 @@
 package de.westnordost.streetcomplete.quests.parking_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.parking_type.ParkingType.LANE
-import de.westnordost.streetcomplete.quests.parking_type.ParkingType.MULTI_STOREY
-import de.westnordost.streetcomplete.quests.parking_type.ParkingType.STREET_SIDE
-import de.westnordost.streetcomplete.quests.parking_type.ParkingType.SURFACE
-import de.westnordost.streetcomplete.quests.parking_type.ParkingType.UNDERGROUND
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddParkingTypeForm : AImageListQuestForm<ParkingType, ParkingType>() {
 
-    override val items = listOf(
-        Item(SURFACE,      R.drawable.parking_type_surface,     R.string.quest_parkingType_surface),
-        Item(STREET_SIDE,  R.drawable.parking_type_street_side, R.string.quest_parkingType_street_side),
-        Item(LANE,         R.drawable.parking_type_lane,        R.string.quest_parkingType_lane),
-        Item(UNDERGROUND,  R.drawable.parking_type_underground, R.string.quest_parkingType_underground),
-        Item(MULTI_STOREY, R.drawable.parking_type_multistorey, R.string.quest_parkingType_multiStorage)
-    )
-
+    override val items = ParkingType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<ParkingType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/ParkingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/ParkingTypeItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.parking_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.parking_type.ParkingType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun ParkingType.asItem() = Item(this, iconResId, titleResId)
+
+private val ParkingType.titleResId: Int get() = when (this) {
+    SURFACE ->      R.string.quest_parkingType_surface
+    STREET_SIDE ->  R.string.quest_parkingType_street_side
+    LANE ->         R.string.quest_parkingType_lane
+    UNDERGROUND ->  R.string.quest_parkingType_underground
+    MULTI_STOREY -> R.string.quest_parkingType_multiStorage
+}
+
+private val ParkingType.iconResId: Int get() = when (this) {
+    SURFACE ->      R.drawable.parking_type_surface
+    STREET_SIDE ->  R.drawable.parking_type_street_side
+    LANE ->         R.drawable.parking_type_lane
+    UNDERGROUND ->  R.drawable.parking_type_underground
+    MULTI_STOREY -> R.drawable.parking_type_multistorey
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/AddPoliceTypeForm.kt
@@ -3,19 +3,11 @@ package de.westnordost.streetcomplete.quests.police_type
 import android.os.Bundle
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.leaf_detail.asItem
 
 class AddPoliceTypeForm : AImageListQuestForm<PoliceType, PoliceType>() {
 
-    override val items = listOf(
-        Item(PoliceType.CARABINIERI,            R.drawable.ic_italian_police_type_carabinieri, R.string.quest_policeType_type_it_carabinieri),
-        Item(PoliceType.POLIZIA_DI_STATO,       R.drawable.ic_italian_police_type_polizia,     R.string.quest_policeType_type_it_polizia_di_stato),
-        Item(PoliceType.POLIZIA_MUNICIPALE,     R.drawable.ic_italian_police_type_municipale,  R.string.quest_policeType_type_it_polizia_municipale),
-        Item(PoliceType.POLIZIA_LOCALE,         R.drawable.ic_italian_police_type_locale,      R.string.quest_policeType_type_it_polizia_locale),
-        Item(PoliceType.GUARDIA_DI_FINANZA,     R.drawable.ic_italian_police_type_finanza,     R.string.quest_policeType_type_it_guardia_di_finanza),
-        Item(PoliceType.GUARDIA_COSTIERA,       R.drawable.ic_italian_police_type_costiera,    R.string.quest_policeType_type_it_guardia_costiera)
-    )
-
+    override val items = PoliceType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/PoliceTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/police_type/PoliceTypeItem.kt
@@ -1,0 +1,25 @@
+package de.westnordost.streetcomplete.quests.police_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+import de.westnordost.streetcomplete.quests.police_type.PoliceType.*
+
+fun PoliceType.asItem() = Item(this, iconResId, titleResId)
+
+private val PoliceType.titleResId: Int get() = when (this) {
+    CARABINIERI ->        R.string.quest_policeType_type_it_carabinieri
+    POLIZIA_DI_STATO ->   R.string.quest_policeType_type_it_polizia_di_stato
+    GUARDIA_DI_FINANZA -> R.string.quest_policeType_type_it_guardia_di_finanza
+    POLIZIA_MUNICIPALE -> R.string.quest_policeType_type_it_polizia_municipale
+    POLIZIA_LOCALE ->     R.string.quest_policeType_type_it_polizia_locale
+    GUARDIA_COSTIERA ->   R.string.quest_policeType_type_it_guardia_costiera
+}
+
+private val PoliceType.iconResId: Int get() = when (this) {
+    CARABINIERI ->        R.drawable.ic_italian_police_type_carabinieri
+    POLIZIA_DI_STATO ->   R.drawable.ic_italian_police_type_polizia
+    GUARDIA_DI_FINANZA -> R.drawable.ic_italian_police_type_finanza
+    POLIZIA_MUNICIPALE -> R.drawable.ic_italian_police_type_municipale
+    POLIZIA_LOCALE ->     R.drawable.ic_italian_police_type_locale
+    GUARDIA_COSTIERA ->   R.drawable.ic_italian_police_type_costiera
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypherForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypherForm.kt
@@ -5,25 +5,15 @@ import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddPostboxRoyalCypherForm : AImageListQuestForm<PostboxRoyalCypher, PostboxRoyalCypher>() {
 
-    override val items = listOf(
-        Item(PostboxRoyalCypher.ELIZABETH_II,   R.drawable.ic_postbox_royal_cypher_eiir,           R.string.quest_postboxRoyalCypher_type_eiir),
-        Item(PostboxRoyalCypher.GEORGE_V,       R.drawable.ic_postbox_royal_cypher_gr,             R.string.quest_postboxRoyalCypher_type_gr),
-        Item(PostboxRoyalCypher.GEORGE_VI,      R.drawable.ic_postbox_royal_cypher_gvir,           R.string.quest_postboxRoyalCypher_type_gvir),
-        Item(PostboxRoyalCypher.VICTORIA,       R.drawable.ic_postbox_royal_cypher_vr,             R.string.quest_postboxRoyalCypher_type_vr),
-        Item(PostboxRoyalCypher.EDWARD_VII,     R.drawable.ic_postbox_royal_cypher_eviir,          R.string.quest_postboxRoyalCypher_type_eviir),
-        Item(PostboxRoyalCypher.SCOTTISH_CROWN, R.drawable.ic_postbox_royal_cypher_scottish_crown, R.string.quest_postboxRoyalCypher_type_scottish_crown),
-        Item(PostboxRoyalCypher.EDWARD_VIII,    R.drawable.ic_postbox_royal_cypher_eviiir,         R.string.quest_postboxRoyalCypher_type_eviiir),
-    )
+    override val items = PostboxRoyalCypher.values().mapNotNull { it.asItem() }
+    override val itemsPerRow = 3
 
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_postboxRoyalCypher_type_none) { confirmNoCypher() }
     )
-
-    override val itemsPerRow = 3
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/PostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/PostboxRoyalCypher.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.quests.postbox_royal_cypher
 
 enum class PostboxRoyalCypher(val osmValue: String) {
+    ELIZABETH_II("EIIR"),
+    GEORGE_V("GR"),
+    GEORGE_VI("GVIR"),
     VICTORIA("VR"),
     EDWARD_VII("EVIIR"),
-    GEORGE_V("GR"),
-    EDWARD_VIII("EVIIIR"),
-    GEORGE_VI("GVIR"),
-    ELIZABETH_II("EIIR"),
     SCOTTISH_CROWN("scottish_crown"),
+    EDWARD_VIII("EVIIIR"),
     NONE("no")
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/PostboxRoyalCypherItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/PostboxRoyalCypherItem.kt
@@ -1,0 +1,34 @@
+package de.westnordost.streetcomplete.quests.postbox_royal_cypher
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.postbox_royal_cypher.PostboxRoyalCypher.*
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun PostboxRoyalCypher.asItem(): DisplayItem<PostboxRoyalCypher>? {
+    val iconResId = iconResId ?: return null
+    val titleResId = titleResId ?: return null
+    return Item(this, iconResId, titleResId)
+}
+
+private val PostboxRoyalCypher.titleResId: Int? get() = when (this) {
+    ELIZABETH_II ->   R.string.quest_postboxRoyalCypher_type_eiir
+    GEORGE_V ->       R.string.quest_postboxRoyalCypher_type_gr
+    GEORGE_VI ->      R.string.quest_postboxRoyalCypher_type_gvir
+    VICTORIA ->       R.string.quest_postboxRoyalCypher_type_vr
+    EDWARD_VII ->     R.string.quest_postboxRoyalCypher_type_eviir
+    SCOTTISH_CROWN -> R.string.quest_postboxRoyalCypher_type_scottish_crown
+    EDWARD_VIII ->    R.string.quest_postboxRoyalCypher_type_eviiir
+    NONE ->           null
+}
+
+private val PostboxRoyalCypher.iconResId: Int? get() = when (this) {
+    ELIZABETH_II ->   R.drawable.ic_postbox_royal_cypher_eiir
+    GEORGE_V ->       R.drawable.ic_postbox_royal_cypher_gr
+    GEORGE_VI ->      R.drawable.ic_postbox_royal_cypher_gvir
+    VICTORIA ->       R.drawable.ic_postbox_royal_cypher_vr
+    EDWARD_VII ->     R.drawable.ic_postbox_royal_cypher_eviir
+    SCOTTISH_CROWN -> R.drawable.ic_postbox_royal_cypher_scottish_crown
+    EDWARD_VIII ->    R.drawable.ic_postbox_royal_cypher_eviiir
+    NONE ->           null
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterialForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterialForm.kt
@@ -9,12 +9,7 @@ import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddPowerPolesMaterialForm : AImageListQuestForm<PowerPolesMaterial, PowerPolesMaterial>() {
 
-    override val items = listOf(
-        Item(WOOD, R.drawable.power_pole_wood, R.string.quest_powerPolesMaterial_wood),
-        Item(STEEL, R.drawable.power_pole_steel, R.string.quest_powerPolesMaterial_metal),
-        Item(CONCRETE, R.drawable.power_pole_concrete, R.string.quest_powerPolesMaterial_concrete)
-    )
-
+    override val items = PowerPolesMaterial.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<PowerPolesMaterial>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/PowerPolesMaterialItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/PowerPolesMaterialItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.powerpoles_material
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.powerpoles_material.PowerPolesMaterial.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun PowerPolesMaterial.asItem() = Item(this, iconResId, titleResId)
+
+private val PowerPolesMaterial.titleResId: Int get() = when (this) {
+    WOOD ->     R.string.quest_powerPolesMaterial_wood
+    STEEL ->    R.string.quest_powerPolesMaterial_metal
+    CONCRETE -> R.string.quest_powerPolesMaterial_concrete
+}
+
+private val PowerPolesMaterial.iconResId: Int get() = when (this) {
+    WOOD ->     R.drawable.power_pole_wood
+    STEEL ->    R.drawable.power_pole_steel
+    CONCRETE -> R.drawable.power_pole_concrete
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrierForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrierForm.kt
@@ -1,20 +1,14 @@
 package de.westnordost.streetcomplete.quests.railway_crossing
 
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.CHICANE
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.DOUBLE_HALF
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.FULL
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.GATE
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.HALF
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.NO
 import de.westnordost.streetcomplete.view.image_select.DisplayItem
 
 class AddRailwayCrossingBarrierForm : AImageListQuestForm<RailwayCrossingBarrier, RailwayCrossingBarrier>() {
 
     override val items: List<DisplayItem<RailwayCrossingBarrier>> get() {
         val isPedestrian = element.tags["railway"] == "crossing"
-        val answers = if (isPedestrian) listOf(NO, CHICANE, GATE, FULL) else listOf(NO, HALF, DOUBLE_HALF, FULL)
-        return answers.toItems(countryInfo.isLeftHandTraffic)
+        return RailwayCrossingBarrier.getSelectableValues(isPedestrian)
+            .map { it.asItem(countryInfo.isLeftHandTraffic) }
     }
 
     override val itemsPerRow = 4

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/RailwayCrossingBarrier.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/RailwayCrossingBarrier.kt
@@ -12,5 +12,11 @@ enum class RailwayCrossingBarrier(val osmValue: String?) {
      * this allows to tag rare cases that have both barrier and chicane
      * (SC leaves crossing:chicane untagged for crossing with barriers)
      */
-    CHICANE(null)
+    CHICANE(null);
+
+    companion object {
+        fun getSelectableValues(isPedestrianCrossing: Boolean) =
+            if (isPedestrianCrossing) listOf(NO, CHICANE, GATE, FULL)
+            else                      listOf(NO, HALF, DOUBLE_HALF, FULL)
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/RailwayCrossingBarrierItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/railway_crossing/RailwayCrossingBarrierItem.kt
@@ -1,22 +1,22 @@
 package de.westnordost.streetcomplete.quests.railway_crossing
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.CHICANE
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.DOUBLE_HALF
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.FULL
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.GATE
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.HALF
-import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.NO
+import de.westnordost.streetcomplete.quests.railway_crossing.RailwayCrossingBarrier.*
 import de.westnordost.streetcomplete.view.image_select.Item
 
-fun List<RailwayCrossingBarrier>.toItems(isLeftHandTraffic: Boolean) =
-    map { it.asItem(isLeftHandTraffic) }
+fun RailwayCrossingBarrier.asItem(isLeftHandTraffic: Boolean): Item<RailwayCrossingBarrier> =
+    Item(this, getIconResId(isLeftHandTraffic), titleResId)
 
-fun RailwayCrossingBarrier.asItem(isLeftHandTraffic: Boolean): Item<RailwayCrossingBarrier> = when (this) {
-    NO -> Item(this, R.drawable.ic_railway_crossing_none, R.string.quest_railway_crossing_barrier_none2)
-    HALF -> Item(this, if (isLeftHandTraffic) R.drawable.ic_railway_crossing_half_l else R.drawable.ic_railway_crossing_half)
-    DOUBLE_HALF -> Item(this, R.drawable.ic_railway_crossing_double_half)
-    FULL -> Item(this, if (isLeftHandTraffic) R.drawable.ic_railway_crossing_full_l else R.drawable.ic_railway_crossing_full)
-    GATE -> Item(this, R.drawable.ic_railway_crossing_gate)
-    CHICANE -> Item(this, R.drawable.ic_railway_crossing_chicane)
+private val RailwayCrossingBarrier.titleResId: Int? get() = when (this) {
+    NO ->   R.string.quest_railway_crossing_barrier_none2
+    else -> null
+}
+
+private fun RailwayCrossingBarrier.getIconResId(isLeftHandTraffic: Boolean): Int = when (this) {
+    NO ->          R.drawable.ic_railway_crossing_none
+    HALF ->        if (isLeftHandTraffic) R.drawable.ic_railway_crossing_half_l else R.drawable.ic_railway_crossing_half
+    DOUBLE_HALF -> R.drawable.ic_railway_crossing_double_half
+    FULL ->        if (isLeftHandTraffic) R.drawable.ic_railway_crossing_full_l else R.drawable.ic_railway_crossing_full
+    GATE ->        R.drawable.ic_railway_crossing_gate
+    CHICANE ->     R.drawable.ic_railway_crossing_chicane
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeForm.kt
@@ -1,20 +1,10 @@
 package de.westnordost.streetcomplete.quests.recycling
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.recycling.RecyclingType.OVERGROUND_CONTAINER
-import de.westnordost.streetcomplete.quests.recycling.RecyclingType.RECYCLING_CENTRE
-import de.westnordost.streetcomplete.quests.recycling.RecyclingType.UNDERGROUND_CONTAINER
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddRecyclingTypeForm : AImageListQuestForm<RecyclingType, RecyclingType>() {
 
-    override val items = listOf(
-        Item(OVERGROUND_CONTAINER, R.drawable.recycling_container, R.string.overground_recycling_container),
-        Item(UNDERGROUND_CONTAINER, R.drawable.recycling_container_underground, R.string.underground_recycling_container),
-        Item(RECYCLING_CENTRE, R.drawable.recycling_centre, R.string.recycling_centre)
-    )
-
+    override val items = RecyclingType.values().map { it.asItem() }
     override val itemsPerRow = 3
 
     override fun onClickOk(selectedItems: List<RecyclingType>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/RecyclingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/RecyclingTypeItem.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.recycling
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.recycling.RecyclingType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun RecyclingType.asItem() = Item(this, iconResId, titleResId)
+
+private val RecyclingType.titleResId: Int get() = when (this) {
+    OVERGROUND_CONTAINER ->  R.string.overground_recycling_container
+    UNDERGROUND_CONTAINER -> R.string.underground_recycling_container
+    RECYCLING_CENTRE ->      R.string.recycling_centre
+}
+
+private val RecyclingType.iconResId: Int get() = when (this) {
+    OVERGROUND_CONTAINER ->  R.drawable.recycling_container
+    UNDERGROUND_CONTAINER -> R.drawable.recycling_container_underground
+    RECYCLING_CENTRE ->      R.drawable.recycling_centre
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterialsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterialsForm.kt
@@ -18,7 +18,7 @@ class AddRecyclingContainerMaterialsForm :
         AnswerItem(R.string.quest_recycling_materials_answer_waste) { confirmJustTrash() }
     )
 
-    override val items get() = RecyclingMaterial.selectableValues.map { it.toItem() }
+    override val items get() = RecyclingMaterial.selectableValues.map { it.asItem() }
 
     override val maxSelectableItems = -1
 
@@ -32,9 +32,9 @@ class AddRecyclingContainerMaterialsForm :
                 val value = imageSelector.items[index].value!!
 
                 if (value in RecyclingMaterial.selectablePlasticValues) {
-                    showPickItemForItemAtIndexDialog(index, RecyclingMaterial.selectablePlasticValues.map { it.toItem() })
+                    showPickItemForItemAtIndexDialog(index, RecyclingMaterial.selectablePlasticValues.map { it.asItem() })
                 } else if (isAnyGlassRecycleable && value in RecyclingMaterial.selectableGlassValues) {
-                    showPickItemForItemAtIndexDialog(index, RecyclingMaterial.selectableGlassValues.map { it.toItem() })
+                    showPickItemForItemAtIndexDialog(index, RecyclingMaterial.selectableGlassValues.map { it.asItem() })
                 }
             }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/RecyclingMaterialItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/RecyclingMaterialItem.kt
@@ -4,10 +4,10 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.recycling_material.RecyclingMaterial.*
 import de.westnordost.streetcomplete.view.image_select.Item
 
-fun RecyclingMaterial.toItem(): Item<List<RecyclingMaterial>> =
+fun RecyclingMaterial.asItem(): Item<List<RecyclingMaterial>> =
     Item(listOf(this), iconResId, titleResId)
 
-fun List<RecyclingMaterial>.toItem(): Item<List<RecyclingMaterial>> =
+fun List<RecyclingMaterial>.asItem(): Item<List<RecyclingMaterial>> =
     Item(this, iconResId, titleResId)
 
 private val RecyclingMaterial.iconResId: Int get() = when (this) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionForm.kt
@@ -4,21 +4,7 @@ import android.os.Bundle
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.religion.Religion.ANIMIST
-import de.westnordost.streetcomplete.quests.religion.Religion.BAHAI
-import de.westnordost.streetcomplete.quests.religion.Religion.BUDDHIST
-import de.westnordost.streetcomplete.quests.religion.Religion.CAODAISM
-import de.westnordost.streetcomplete.quests.religion.Religion.CHINESE_FOLK
-import de.westnordost.streetcomplete.quests.religion.Religion.CHRISTIAN
-import de.westnordost.streetcomplete.quests.religion.Religion.HINDU
-import de.westnordost.streetcomplete.quests.religion.Religion.JAIN
-import de.westnordost.streetcomplete.quests.religion.Religion.JEWISH
 import de.westnordost.streetcomplete.quests.religion.Religion.MULTIFAITH
-import de.westnordost.streetcomplete.quests.religion.Religion.MUSLIM
-import de.westnordost.streetcomplete.quests.religion.Religion.SHINTO
-import de.westnordost.streetcomplete.quests.religion.Religion.SIKH
-import de.westnordost.streetcomplete.quests.religion.Religion.TAOIST
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddReligionForm : AImageListQuestForm<Religion, Religion>() {
 
@@ -26,28 +12,9 @@ class AddReligionForm : AImageListQuestForm<Religion, Religion>() {
         AnswerItem(R.string.quest_religion_for_place_of_worship_answer_multi) { applyAnswer(MULTIFAITH) }
     )
 
-    override val items get() = listOf(
-        // sorted by worldwide usages, *minus* country specific ones
-        Item(CHRISTIAN,    R.drawable.ic_religion_christian, R.string.quest_religion_christian),
-        Item(MUSLIM,       R.drawable.ic_religion_muslim,    R.string.quest_religion_muslim),
-        Item(BUDDHIST,     R.drawable.ic_religion_buddhist,  R.string.quest_religion_buddhist),
-        Item(HINDU,        R.drawable.ic_religion_hindu,     R.string.quest_religion_hindu),
-
-        Item(JEWISH,       R.drawable.ic_religion_jewish,    R.string.quest_religion_jewish),
-        // difficult to get the numbers on this, as they are counted alternating as buddhists,
-        // taoists, confucianists, not religious or "folk religion" in statistics. See
-        // https://en.wikipedia.org/wiki/Chinese_folk_religion
-        // sorting relatively far up because there are many Chinese expats around the world
-        Item(CHINESE_FOLK, R.drawable.ic_religion_chinese_folk, R.string.quest_religion_chinese_folk),
-        Item(ANIMIST,      R.drawable.ic_religion_animist,   R.string.quest_religion_animist),
-        Item(BAHAI,        R.drawable.ic_religion_bahai,     R.string.quest_religion_bahai),
-        Item(SIKH,         R.drawable.ic_religion_sikh,      R.string.quest_religion_sikh),
-
-        Item(TAOIST,       R.drawable.ic_religion_taoist,    R.string.quest_religion_taoist),
-        Item(JAIN,         R.drawable.ic_religion_jain,      R.string.quest_religion_jain), // India
-        Item(SHINTO,       R.drawable.ic_religion_shinto,    R.string.quest_religion_shinto), // Japan
-        Item(CAODAISM,     R.drawable.ic_religion_caodaist,  R.string.quest_religion_caodaist) // Vietnam
-    ).sortedBy { religionPosition(it.value!!.osmValue) }
+    override val items get() = Religion.values()
+        .mapNotNull { it.asItem() }
+        .sortedBy { religionPosition(it.value!!.osmValue) }
 
     fun religionPosition(osmValue: String): Int {
         val position = countryInfo.popularReligions.indexOf(osmValue)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/ReligionItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/ReligionItem.kt
@@ -1,0 +1,46 @@
+package de.westnordost.streetcomplete.quests.religion
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.religion.Religion.*
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun Religion.asItem(): DisplayItem<Religion>? {
+    val iconResId = iconResId ?: return null
+    val titleResId = titleResId  ?: return null
+    return Item(this, iconResId, titleResId)
+}
+
+private val Religion.titleResId: Int? get() = when (this) {
+    CHRISTIAN ->    R.string.quest_religion_christian
+    MUSLIM ->       R.string.quest_religion_muslim
+    BUDDHIST ->     R.string.quest_religion_buddhist
+    HINDU ->        R.string.quest_religion_hindu
+    JEWISH ->       R.string.quest_religion_jewish
+    CHINESE_FOLK -> R.string.quest_religion_chinese_folk
+    ANIMIST ->      R.string.quest_religion_animist
+    BAHAI ->        R.string.quest_religion_bahai
+    SIKH ->         R.string.quest_religion_sikh
+    TAOIST ->       R.string.quest_religion_taoist
+    JAIN ->         R.string.quest_religion_jain
+    SHINTO ->       R.string.quest_religion_shinto
+    CAODAISM ->     R.string.quest_religion_caodaist
+    MULTIFAITH ->   null
+}
+
+private val Religion.iconResId: Int? get() = when (this) {
+    CHRISTIAN ->    R.drawable.ic_religion_christian
+    MUSLIM ->       R.drawable.ic_religion_muslim
+    BUDDHIST ->     R.drawable.ic_religion_buddhist
+    HINDU ->        R.drawable.ic_religion_hindu
+    JEWISH ->       R.drawable.ic_religion_jewish
+    CHINESE_FOLK -> R.drawable.ic_religion_chinese_folk
+    ANIMIST ->      R.drawable.ic_religion_animist
+    BAHAI ->        R.drawable.ic_religion_bahai
+    SIKH ->         R.drawable.ic_religion_sikh
+    TAOIST ->       R.drawable.ic_religion_taoist
+    JAIN ->         R.drawable.ic_religion_jain
+    SHINTO ->       R.drawable.ic_religion_shinto
+    CAODAISM ->     R.drawable.ic_religion_caodaist
+    MULTIFAITH ->   null
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeForm.kt
@@ -4,24 +4,7 @@ import android.os.Bundle
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.CONE
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.DOME
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.DOUBLE_SALTBOX
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.FLAT
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.GABLED
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.GAMBREL
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.HALF_HIPPED
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.HIPPED
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.MANSARD
 import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.MANY
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.ONION
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.PYRAMIDAL
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.QUADRUPLE_SALTBOX
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.ROUND
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.ROUND_GABLED
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.SALTBOX
-import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.SKILLION
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddRoofShapeForm : AImageListQuestForm<RoofShape, RoofShape>() {
 
@@ -29,27 +12,7 @@ class AddRoofShapeForm : AImageListQuestForm<RoofShape, RoofShape>() {
         AnswerItem(R.string.quest_roofShape_answer_many) { applyAnswer(MANY) }
     )
 
-    override val items = listOf(
-        Item(GABLED, R.drawable.ic_roof_gabled),
-        Item(HIPPED, R.drawable.ic_roof_hipped),
-        Item(FLAT, R.drawable.ic_roof_flat),
-        Item(PYRAMIDAL, R.drawable.ic_roof_pyramidal),
-
-        Item(HALF_HIPPED, R.drawable.ic_roof_half_hipped),
-        Item(SKILLION, R.drawable.ic_roof_skillion),
-        Item(GAMBREL, R.drawable.ic_roof_gambrel),
-        Item(ROUND, R.drawable.ic_roof_round),
-
-        Item(DOUBLE_SALTBOX, R.drawable.ic_roof_double_saltbox),
-        Item(SALTBOX, R.drawable.ic_roof_saltbox),
-        Item(MANSARD, R.drawable.ic_roof_mansard),
-        Item(DOME, R.drawable.ic_roof_dome),
-
-        Item(QUADRUPLE_SALTBOX, R.drawable.ic_roof_quadruple_saltbox),
-        Item(ROUND_GABLED, R.drawable.ic_roof_round_gabled),
-        Item(ONION, R.drawable.ic_roof_onion),
-        Item(CONE, R.drawable.ic_roof_cone)
-    )
+    override val items = RoofShape.values().mapNotNull { it.asItem() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/RoofShapeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/RoofShapeItem.kt
@@ -1,0 +1,31 @@
+package de.westnordost.streetcomplete.quests.roof_shape
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.roof_shape.RoofShape.*
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun RoofShape.asItem(): DisplayItem<RoofShape>? {
+    val iconResId = iconResId ?: return null
+    return Item(this, iconResId)
+}
+
+private val RoofShape.iconResId: Int? get() = when (this) {
+    GABLED ->            R.drawable.ic_roof_gabled
+    HIPPED ->            R.drawable.ic_roof_hipped
+    FLAT ->              R.drawable.ic_roof_flat
+    PYRAMIDAL ->         R.drawable.ic_roof_pyramidal
+    HALF_HIPPED ->       R.drawable.ic_roof_half_hipped
+    SKILLION ->          R.drawable.ic_roof_skillion
+    GAMBREL ->           R.drawable.ic_roof_gambrel
+    ROUND ->             R.drawable.ic_roof_round
+    DOUBLE_SALTBOX ->    R.drawable.ic_roof_double_saltbox
+    SALTBOX ->           R.drawable.ic_roof_saltbox
+    MANSARD ->           R.drawable.ic_roof_mansard
+    DOME ->              R.drawable.ic_roof_dome
+    QUADRUPLE_SALTBOX -> R.drawable.ic_roof_quadruple_saltbox
+    ROUND_GABLED ->      R.drawable.ic_roof_round_gabled
+    ONION ->             R.drawable.ic_roof_onion
+    CONE ->              R.drawable.ic_roof_cone
+    MANY ->              null
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeatingForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/seating/AddSeatingForm.kt
@@ -3,12 +3,13 @@ package de.westnordost.streetcomplete.quests.seating
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.TextItem
+import de.westnordost.streetcomplete.quests.seating.Seating.*
 
 class AddSeatingForm : AListQuestForm<Seating>() {
     override val items = listOf(
-        TextItem(Seating.INDOOR_AND_OUTDOOR, R.string.quest_seating_indoor_and_outdoor),
-        TextItem(Seating.ONLY_INDOOR, R.string.quest_seating_indoor_only),
-        TextItem(Seating.ONLY_OUTDOOR, R.string.quest_seating_outdoor_only),
-        TextItem(Seating.NO, R.string.quest_seating_takeaway),
+        TextItem(INDOOR_AND_OUTDOOR, R.string.quest_seating_indoor_and_outdoor),
+        TextItem(ONLY_INDOOR, R.string.quest_seating_indoor_only),
+        TextItem(ONLY_OUTDOOR, R.string.quest_seating_outdoor_only),
+        TextItem(NO, R.string.quest_seating_takeaway),
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
+class AddCyclewaySegregation : OsmFilterQuestType<CyclewaySegregation>() {
 
     override val elementFilter = """
         ways with
@@ -32,7 +32,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<Boolean>() {
 
     override fun createForm() = AddCyclewaySegregationForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
-        tags.updateWithCheckDate("segregated", answer.toYesNo())
+    override fun applyAnswerTo(answer: CyclewaySegregation, tags: Tags, timestampEdited: Long) {
+        tags.updateWithCheckDate("segregated", answer.value.toYesNo())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregationForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregationForm.kt
@@ -4,14 +4,12 @@ import android.os.Bundle
 import android.view.View
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.view.image_select.Item
 
-class AddCyclewaySegregationForm : AImageListQuestForm<Boolean, Boolean>() {
+class AddCyclewaySegregationForm : AImageListQuestForm<CyclewaySegregation, CyclewaySegregation>() {
 
-    override val items get() = listOf(
-        Item(true, if (countryInfo.isLeftHandTraffic) R.drawable.ic_path_segregated_l else R.drawable.ic_path_segregated, R.string.quest_segregated_separated),
-        Item(false, R.drawable.ic_path_segregated_no, R.string.quest_segregated_mixed)
-    )
+    override val items get() =
+        listOf(CyclewaySegregation(true), CyclewaySegregation(false))
+            .map { it.asItem(countryInfo.isLeftHandTraffic) }
 
     override val itemsPerRow = 2
 
@@ -20,7 +18,7 @@ class AddCyclewaySegregationForm : AImageListQuestForm<Boolean, Boolean>() {
         imageSelector.cellLayoutId = R.layout.cell_labeled_icon_select_right
     }
 
-    override fun onClickOk(selectedItems: List<Boolean>) {
+    override fun onClickOk(selectedItems: List<CyclewaySegregation>) {
         applyAnswer(selectedItems.single())
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/CyclewaySegregation.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/CyclewaySegregation.kt
@@ -1,0 +1,4 @@
+package de.westnordost.streetcomplete.quests.segregated
+
+@JvmInline
+value class CyclewaySegregation(val value: Boolean)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/CyclewaySegregationItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/segregated/CyclewaySegregationItem.kt
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.quests.segregated
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun CyclewaySegregation.asItem(isLeftHandTraffic: Boolean) =
+    Item(this, getIconResId(isLeftHandTraffic), titleResId)
+
+private val CyclewaySegregation.titleResId: Int get() = when (this.value) {
+    true -> R.string.quest_segregated_separated
+    false -> R.string.quest_segregated_mixed
+}
+
+private fun CyclewaySegregation.getIconResId(isLeftHandTraffic: Boolean): Int = when (this.value) {
+    true -> if (isLeftHandTraffic) R.drawable.ic_path_segregated_l else R.drawable.ic_path_segregated
+    false -> R.drawable.ic_path_segregated_no
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItem.kt
@@ -5,14 +5,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import androidx.annotation.DrawableRes
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.BAD
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.EXCELLENT
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.GOOD
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.HORRIBLE
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.IMPASSABLE
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.INTERMEDIATE
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.VERY_BAD
-import de.westnordost.streetcomplete.quests.smoothness.Smoothness.VERY_HORRIBLE
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.*
 import de.westnordost.streetcomplete.util.ktx.asImageSpan
 import de.westnordost.streetcomplete.view.CharSequenceText
 import de.westnordost.streetcomplete.view.ResImage

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
@@ -5,41 +5,7 @@ import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.sport.Sport.AMERICAN_FOOTBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.ARCHERY
-import de.westnordost.streetcomplete.quests.sport.Sport.ATHLETICS
-import de.westnordost.streetcomplete.quests.sport.Sport.AUSTRALIAN_FOOTBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.BADMINTON
-import de.westnordost.streetcomplete.quests.sport.Sport.BASEBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.BASKETBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.BEACHVOLLEYBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.BOULES
-import de.westnordost.streetcomplete.quests.sport.Sport.BOWLS
-import de.westnordost.streetcomplete.quests.sport.Sport.CANADIAN_FOOTBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.CRICKET
-import de.westnordost.streetcomplete.quests.sport.Sport.EQUESTRIAN
-import de.westnordost.streetcomplete.quests.sport.Sport.FIELD_HOCKEY
-import de.westnordost.streetcomplete.quests.sport.Sport.GAELIC_GAMES
-import de.westnordost.streetcomplete.quests.sport.Sport.GOLF
-import de.westnordost.streetcomplete.quests.sport.Sport.GYMNASTICS
-import de.westnordost.streetcomplete.quests.sport.Sport.HANDBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.ICE_HOCKEY
-import de.westnordost.streetcomplete.quests.sport.Sport.ICE_SKATING
 import de.westnordost.streetcomplete.quests.sport.Sport.MULTI
-import de.westnordost.streetcomplete.quests.sport.Sport.NETBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.PADDLE_TENNIS
-import de.westnordost.streetcomplete.quests.sport.Sport.RACQUET
-import de.westnordost.streetcomplete.quests.sport.Sport.ROLLER_SKATING
-import de.westnordost.streetcomplete.quests.sport.Sport.RUGBY
-import de.westnordost.streetcomplete.quests.sport.Sport.SEPAK_TAKRAW
-import de.westnordost.streetcomplete.quests.sport.Sport.SHOOTING
-import de.westnordost.streetcomplete.quests.sport.Sport.SKATEBOARD
-import de.westnordost.streetcomplete.quests.sport.Sport.SOCCER
-import de.westnordost.streetcomplete.quests.sport.Sport.SOFTBALL
-import de.westnordost.streetcomplete.quests.sport.Sport.TABLE_TENNIS
-import de.westnordost.streetcomplete.quests.sport.Sport.TENNIS
-import de.westnordost.streetcomplete.quests.sport.Sport.VOLLEYBALL
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddSportForm : AImageListQuestForm<Sport, List<Sport>>() {
 
@@ -47,46 +13,9 @@ class AddSportForm : AImageListQuestForm<Sport, List<Sport>>() {
         AnswerItem(R.string.quest_sport_answer_multi) { applyMultiAnswer() }
     )
 
-    override val items get() = listOf(
-        // sorted by ~worldwide usages, minus country specific ones
-        // 250k - 10k
-        Item(SOCCER,              R.drawable.ic_sport_soccer,              R.string.quest_sport_soccer),
-        Item(TENNIS,              R.drawable.ic_sport_tennis,              R.string.quest_sport_tennis),
-        Item(BASKETBALL,          R.drawable.ic_sport_basketball,          R.string.quest_sport_basketball),
-        Item(GOLF,                R.drawable.ic_sport_golf,                R.string.quest_sport_golf),
-        Item(VOLLEYBALL,          R.drawable.ic_sport_volleyball,          R.string.quest_sport_volleyball),
-        Item(BEACHVOLLEYBALL,     R.drawable.ic_sport_beachvolleyball,     R.string.quest_sport_beachvolleyball),
-        Item(SKATEBOARD,          R.drawable.ic_sport_skateboard,          R.string.quest_sport_skateboard),
-        Item(SHOOTING,            R.drawable.ic_sport_shooting,            R.string.quest_sport_shooting),
-        // 7k - 5k
-        Item(BASEBALL,            R.drawable.ic_sport_baseball,            R.string.quest_sport_baseball),
-        Item(ATHLETICS,           R.drawable.ic_sport_athletics,           R.string.quest_sport_athletics),
-        Item(TABLE_TENNIS,        R.drawable.ic_sport_table_tennis,        R.string.quest_sport_table_tennis),
-        Item(GYMNASTICS,          R.drawable.ic_sport_gymnastics,          R.string.quest_sport_gymnastics),
-        // 4k - 2k
-        Item(BOULES,              R.drawable.ic_sport_boules,              R.string.quest_sport_boules),
-        Item(HANDBALL,            R.drawable.ic_sport_handball,            R.string.quest_sport_handball),
-        Item(FIELD_HOCKEY,        R.drawable.ic_sport_field_hockey,        R.string.quest_sport_field_hockey),
-        Item(ICE_HOCKEY,          R.drawable.ic_sport_ice_hockey,          R.string.quest_sport_ice_hockey),
-        Item(AMERICAN_FOOTBALL,   R.drawable.ic_sport_american_football,   R.string.quest_sport_american_football),
-        Item(EQUESTRIAN,          R.drawable.ic_sport_equestrian,          R.string.quest_sport_equestrian),
-        Item(ARCHERY,             R.drawable.ic_sport_archery,             R.string.quest_sport_archery),
-        Item(ROLLER_SKATING,      R.drawable.ic_sport_roller_skating,      R.string.quest_sport_roller_skating),
-        // 1k - 0k
-        Item(BADMINTON,           R.drawable.ic_sport_badminton,           R.string.quest_sport_badminton),
-        Item(CRICKET,             R.drawable.ic_sport_cricket,             R.string.quest_sport_cricket),
-        Item(RUGBY,               R.drawable.ic_sport_rugby,               R.string.quest_sport_rugby),
-        Item(BOWLS,               R.drawable.ic_sport_bowls,               R.string.quest_sport_bowls),
-        Item(SOFTBALL,            R.drawable.ic_sport_softball,            R.string.quest_sport_softball),
-        Item(RACQUET,             R.drawable.ic_sport_racquet,             R.string.quest_sport_racquet),
-        Item(ICE_SKATING,         R.drawable.ic_sport_ice_skating,         R.string.quest_sport_ice_skating),
-        Item(PADDLE_TENNIS,       R.drawable.ic_sport_paddle_tennis,       R.string.quest_sport_paddle_tennis),
-        Item(AUSTRALIAN_FOOTBALL, R.drawable.ic_sport_australian_football, R.string.quest_sport_australian_football),
-        Item(CANADIAN_FOOTBALL,   R.drawable.ic_sport_canadian_football,   R.string.quest_sport_canadian_football),
-        Item(NETBALL,             R.drawable.ic_sport_netball,             R.string.quest_sport_netball),
-        Item(GAELIC_GAMES,        R.drawable.ic_sport_gaelic_games,        R.string.quest_sport_gaelic_games),
-        Item(SEPAK_TAKRAW,        R.drawable.ic_sport_sepak_takraw,        R.string.quest_sport_sepak_takraw)
-    ).sortedBy { countryInfo.popularSports.indexOf(it.value!!.osmValue) }
+    override val items get() = Sport.values()
+        .mapNotNull { it.asItem() }
+        .sortedBy { countryInfo.popularSports.indexOf(it.value!!.osmValue) }
 
     override val maxSelectableItems = -1
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/Sport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/Sport.kt
@@ -2,6 +2,8 @@ package de.westnordost.streetcomplete.quests.sport
 
 enum class Sport(val osmValue: String) {
     MULTI("multi"),
+    // sorted by ~worldwide usages, minus country specific ones
+    // 250k - 10k
     SOCCER("soccer"),
     TENNIS("tennis"),
     BASKETBALL("basketball"),
@@ -10,10 +12,12 @@ enum class Sport(val osmValue: String) {
     BEACHVOLLEYBALL("beachvolleyball"),
     SKATEBOARD("skateboard"),
     SHOOTING("shooting"),
+    // 7k - 5k
     BASEBALL("baseball"),
     ATHLETICS("athletics"),
     TABLE_TENNIS("table_tennis"),
     GYMNASTICS("gymnastics"),
+    // 4k - 2k
     BOULES("boules"),
     HANDBALL("handball"),
     FIELD_HOCKEY("field_hockey"),
@@ -22,6 +26,7 @@ enum class Sport(val osmValue: String) {
     EQUESTRIAN("equestrian"),
     ARCHERY("archery"),
     ROLLER_SKATING("roller_skating"),
+    // 1k - 0k
     BADMINTON("badminton"),
     CRICKET("cricket"),
     RUGBY("rugby"),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/SportItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/SportItem.kt
@@ -1,0 +1,86 @@
+package de.westnordost.streetcomplete.quests.sport
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.sport.Sport.*
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun Sport.asItem(): DisplayItem<Sport>? {
+    val iconResId = iconResId ?: return null
+    val titleResId = titleResId ?: return null
+    return Item(this, iconResId, titleResId)
+}
+
+val Sport.titleResId: Int? get() = when (this) {
+    MULTI ->               null
+    SOCCER ->              R.string.quest_sport_soccer
+    TENNIS ->              R.string.quest_sport_tennis
+    BASKETBALL ->          R.string.quest_sport_basketball
+    GOLF ->                R.string.quest_sport_golf
+    VOLLEYBALL ->          R.string.quest_sport_volleyball
+    BEACHVOLLEYBALL ->     R.string.quest_sport_beachvolleyball
+    SKATEBOARD ->          R.string.quest_sport_skateboard
+    SHOOTING ->            R.string.quest_sport_shooting
+    BASEBALL ->            R.string.quest_sport_baseball
+    ATHLETICS ->           R.string.quest_sport_athletics
+    TABLE_TENNIS ->        R.string.quest_sport_table_tennis
+    GYMNASTICS ->          R.string.quest_sport_gymnastics
+    BOULES ->              R.string.quest_sport_boules
+    HANDBALL ->            R.string.quest_sport_handball
+    FIELD_HOCKEY ->        R.string.quest_sport_field_hockey
+    ICE_HOCKEY ->          R.string.quest_sport_ice_hockey
+    AMERICAN_FOOTBALL ->   R.string.quest_sport_american_football
+    EQUESTRIAN ->          R.string.quest_sport_equestrian
+    ARCHERY ->             R.string.quest_sport_archery
+    ROLLER_SKATING ->      R.string.quest_sport_roller_skating
+    BADMINTON ->           R.string.quest_sport_badminton
+    CRICKET ->             R.string.quest_sport_cricket
+    RUGBY ->               R.string.quest_sport_rugby
+    BOWLS ->               R.string.quest_sport_bowls
+    SOFTBALL ->            R.string.quest_sport_softball
+    RACQUET ->             R.string.quest_sport_racquet
+    ICE_SKATING ->         R.string.quest_sport_ice_skating
+    PADDLE_TENNIS ->       R.string.quest_sport_paddle_tennis
+    AUSTRALIAN_FOOTBALL -> R.string.quest_sport_australian_football
+    CANADIAN_FOOTBALL ->   R.string.quest_sport_canadian_football
+    NETBALL ->             R.string.quest_sport_netball
+    GAELIC_GAMES ->        R.string.quest_sport_gaelic_games
+    SEPAK_TAKRAW ->        R.string.quest_sport_sepak_takraw
+}
+
+val Sport.iconResId: Int? get() = when (this) {
+    MULTI ->               null
+    SOCCER ->              R.drawable.ic_sport_soccer
+    TENNIS ->              R.drawable.ic_sport_tennis
+    BASKETBALL ->          R.drawable.ic_sport_basketball
+    GOLF ->                R.drawable.ic_sport_golf
+    VOLLEYBALL ->          R.drawable.ic_sport_volleyball
+    BEACHVOLLEYBALL ->     R.drawable.ic_sport_beachvolleyball
+    SKATEBOARD ->          R.drawable.ic_sport_skateboard
+    SHOOTING ->            R.drawable.ic_sport_shooting
+    BASEBALL ->            R.drawable.ic_sport_baseball
+    ATHLETICS ->           R.drawable.ic_sport_athletics
+    TABLE_TENNIS ->        R.drawable.ic_sport_table_tennis
+    GYMNASTICS ->          R.drawable.ic_sport_gymnastics
+    BOULES ->              R.drawable.ic_sport_boules
+    HANDBALL ->            R.drawable.ic_sport_handball
+    FIELD_HOCKEY ->        R.drawable.ic_sport_field_hockey
+    ICE_HOCKEY ->          R.drawable.ic_sport_ice_hockey
+    AMERICAN_FOOTBALL ->   R.drawable.ic_sport_american_football
+    EQUESTRIAN ->          R.drawable.ic_sport_equestrian
+    ARCHERY ->             R.drawable.ic_sport_archery
+    ROLLER_SKATING ->      R.drawable.ic_sport_roller_skating
+    BADMINTON ->           R.drawable.ic_sport_badminton
+    CRICKET ->             R.drawable.ic_sport_cricket
+    RUGBY ->               R.drawable.ic_sport_rugby
+    BOWLS ->               R.drawable.ic_sport_bowls
+    SOFTBALL ->            R.drawable.ic_sport_softball
+    RACQUET ->             R.drawable.ic_sport_racquet
+    ICE_SKATING ->         R.drawable.ic_sport_ice_skating
+    PADDLE_TENNIS ->       R.drawable.ic_sport_paddle_tennis
+    AUSTRALIAN_FOOTBALL -> R.drawable.ic_sport_australian_football
+    CANADIAN_FOOTBALL ->   R.drawable.ic_sport_canadian_football
+    NETBALL ->             R.drawable.ic_sport_netball
+    GAELIC_GAMES ->        R.drawable.ic_sport_gaelic_games
+    SEPAK_TAKRAW ->        R.drawable.ic_sport_sepak_takraw
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsInclineForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/AddStepsInclineForm.kt
@@ -10,7 +10,7 @@ import kotlin.math.PI
 class AddStepsInclineForm : AImageListQuestForm<StepsIncline, StepsIncline>() {
 
     override val items get() =
-        StepsIncline.values().map { it.toItem(requireContext(), wayRotation + mapRotation) }
+        StepsIncline.values().map { it.asItem(requireContext(), wayRotation + mapRotation) }
 
     override val itemsPerRow = 2
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/StepsInclineItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_incline/StepsInclineItem.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.view.RotatedCircleDrawable
 import de.westnordost.streetcomplete.view.image_select.DisplayItem
 import de.westnordost.streetcomplete.view.image_select.Item2
 
-fun StepsIncline.toItem(context: Context, rotation: Float): DisplayItem<StepsIncline> {
+fun StepsIncline.asItem(context: Context, rotation: Float): DisplayItem<StepsIncline> {
     val drawable = RotatedCircleDrawable(context.getDrawable(iconResId)!!)
     drawable.rotation = rotation
     return Item2(this, DrawableImage(drawable), ResText(titleResId))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampForm.kt
@@ -10,17 +10,10 @@ import de.westnordost.streetcomplete.quests.steps_ramp.StepsRamp.NONE
 import de.westnordost.streetcomplete.quests.steps_ramp.StepsRamp.STROLLER
 import de.westnordost.streetcomplete.quests.steps_ramp.StepsRamp.WHEELCHAIR
 import de.westnordost.streetcomplete.view.image_select.ImageSelectAdapter
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddStepsRampForm : AImageListQuestForm<StepsRamp, StepsRampAnswer>() {
 
-    override val items = listOf(
-        Item(NONE,       R.drawable.ramp_none,       R.string.quest_steps_ramp_none),
-        Item(BICYCLE,    R.drawable.ramp_bicycle,    R.string.quest_steps_ramp_bicycle),
-        Item(STROLLER,   R.drawable.ramp_stroller,   R.string.quest_steps_ramp_stroller),
-        Item(WHEELCHAIR, R.drawable.ramp_wheelchair, R.string.quest_steps_ramp_wheelchair)
-    )
-
+    override val items = StepsRamp.values().map { it.asItem() }
     override val itemsPerRow = 2
     override val maxSelectableItems = -1
     override val moveFavoritesToFront = false
@@ -84,5 +77,3 @@ class AddStepsRampForm : AImageListQuestForm<StepsRamp, StepsRampAnswer>() {
             .show()
     }
 }
-
-enum class StepsRamp { NONE, BICYCLE, STROLLER, WHEELCHAIR }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/StepsRamp.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/StepsRamp.kt
@@ -1,0 +1,3 @@
+package de.westnordost.streetcomplete.quests.steps_ramp
+
+enum class StepsRamp { NONE, BICYCLE, STROLLER, WHEELCHAIR }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/StepsRampItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/steps_ramp/StepsRampItem.kt
@@ -1,0 +1,21 @@
+package de.westnordost.streetcomplete.quests.steps_ramp
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.steps_ramp.StepsRamp.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun StepsRamp.asItem() = Item(this, iconResId, titleResId)
+
+private val StepsRamp.titleResId: Int get() = when (this) {
+    NONE ->       R.string.quest_steps_ramp_none
+    BICYCLE ->    R.string.quest_steps_ramp_bicycle
+    STROLLER ->   R.string.quest_steps_ramp_stroller
+    WHEELCHAIR -> R.string.quest_steps_ramp_wheelchair
+}
+
+private val StepsRamp.iconResId: Int get() = when (this) {
+    NONE ->       R.drawable.ramp_none
+    BICYCLE ->    R.drawable.ramp_bicycle
+    STROLLER ->   R.drawable.ramp_stroller
+    WHEELCHAIR -> R.drawable.ramp_wheelchair
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceItem.kt
@@ -2,34 +2,7 @@ package de.westnordost.streetcomplete.quests.surface
 
 import android.content.res.Resources
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.surface.Surface.ARTIFICIAL_TURF
-import de.westnordost.streetcomplete.quests.surface.Surface.ASPHALT
-import de.westnordost.streetcomplete.quests.surface.Surface.CLAY
-import de.westnordost.streetcomplete.quests.surface.Surface.COMPACTED
-import de.westnordost.streetcomplete.quests.surface.Surface.CONCRETE
-import de.westnordost.streetcomplete.quests.surface.Surface.CONCRETE_LANES
-import de.westnordost.streetcomplete.quests.surface.Surface.CONCRETE_PLATES
-import de.westnordost.streetcomplete.quests.surface.Surface.DIRT
-import de.westnordost.streetcomplete.quests.surface.Surface.FINE_GRAVEL
-import de.westnordost.streetcomplete.quests.surface.Surface.GRASS
-import de.westnordost.streetcomplete.quests.surface.Surface.GRASS_PAVER
-import de.westnordost.streetcomplete.quests.surface.Surface.GRAVEL
-import de.westnordost.streetcomplete.quests.surface.Surface.GROUND_AREA
-import de.westnordost.streetcomplete.quests.surface.Surface.GROUND_ROAD
-import de.westnordost.streetcomplete.quests.surface.Surface.METAL
-import de.westnordost.streetcomplete.quests.surface.Surface.PAVED_AREA
-import de.westnordost.streetcomplete.quests.surface.Surface.PAVED_ROAD
-import de.westnordost.streetcomplete.quests.surface.Surface.PAVING_STONES
-import de.westnordost.streetcomplete.quests.surface.Surface.PEBBLES
-import de.westnordost.streetcomplete.quests.surface.Surface.ROCK
-import de.westnordost.streetcomplete.quests.surface.Surface.SAND
-import de.westnordost.streetcomplete.quests.surface.Surface.SETT
-import de.westnordost.streetcomplete.quests.surface.Surface.TARTAN
-import de.westnordost.streetcomplete.quests.surface.Surface.UNHEWN_COBBLESTONE
-import de.westnordost.streetcomplete.quests.surface.Surface.UNPAVED_AREA
-import de.westnordost.streetcomplete.quests.surface.Surface.UNPAVED_ROAD
-import de.westnordost.streetcomplete.quests.surface.Surface.WOOD
-import de.westnordost.streetcomplete.quests.surface.Surface.WOODCHIPS
+import de.westnordost.streetcomplete.quests.surface.Surface.*
 import de.westnordost.streetcomplete.view.DrawableImage
 import de.westnordost.streetcomplete.view.ResImage
 import de.westnordost.streetcomplete.view.ResText
@@ -53,63 +26,63 @@ fun Surface.asStreetSideItem(resources: Resources): StreetSideDisplayItem<Surfac
     )
 
 private val Surface.titleResId: Int get() = when (this) {
-    ASPHALT -> R.string.quest_surface_value_asphalt
-    CONCRETE -> R.string.quest_surface_value_concrete
+    ASPHALT ->         R.string.quest_surface_value_asphalt
+    CONCRETE ->        R.string.quest_surface_value_concrete
     CONCRETE_PLATES -> R.string.quest_surface_value_concrete_plates
-    CONCRETE_LANES -> R.string.quest_surface_value_concrete_lanes
-    FINE_GRAVEL -> R.string.quest_surface_value_fine_gravel
-    PAVING_STONES -> R.string.quest_surface_value_paving_stones
-    COMPACTED -> R.string.quest_surface_value_compacted
-    DIRT -> R.string.quest_surface_value_dirt
-    SETT -> R.string.quest_surface_value_sett
+    CONCRETE_LANES ->  R.string.quest_surface_value_concrete_lanes
+    FINE_GRAVEL ->     R.string.quest_surface_value_fine_gravel
+    PAVING_STONES ->   R.string.quest_surface_value_paving_stones
+    COMPACTED ->       R.string.quest_surface_value_compacted
+    DIRT ->            R.string.quest_surface_value_dirt
+    SETT ->            R.string.quest_surface_value_sett
     UNHEWN_COBBLESTONE -> R.string.quest_surface_value_unhewn_cobblestone
-    GRASS_PAVER -> R.string.quest_surface_value_grass_paver
-    WOOD -> R.string.quest_surface_value_wood
-    WOODCHIPS -> R.string.quest_surface_value_woodchips
-    METAL -> R.string.quest_surface_value_metal
-    GRAVEL -> R.string.quest_surface_value_gravel
-    PEBBLES -> R.string.quest_surface_value_pebblestone
-    GRASS -> R.string.quest_surface_value_grass
-    SAND -> R.string.quest_surface_value_sand
-    ROCK -> R.string.quest_surface_value_rock
-    CLAY -> R.string.quest_surface_value_clay
+    GRASS_PAVER ->     R.string.quest_surface_value_grass_paver
+    WOOD ->            R.string.quest_surface_value_wood
+    WOODCHIPS ->       R.string.quest_surface_value_woodchips
+    METAL ->           R.string.quest_surface_value_metal
+    GRAVEL ->          R.string.quest_surface_value_gravel
+    PEBBLES ->         R.string.quest_surface_value_pebblestone
+    GRASS ->           R.string.quest_surface_value_grass
+    SAND ->            R.string.quest_surface_value_sand
+    ROCK ->            R.string.quest_surface_value_rock
+    CLAY ->            R.string.quest_surface_value_clay
     ARTIFICIAL_TURF -> R.string.quest_surface_value_artificial_turf
-    TARTAN -> R.string.quest_surface_value_tartan
-    PAVED_ROAD -> R.string.quest_surface_value_paved
-    UNPAVED_ROAD -> R.string.quest_surface_value_unpaved
-    GROUND_ROAD -> R.string.quest_surface_value_ground
-    PAVED_AREA -> R.string.quest_surface_value_paved
-    UNPAVED_AREA -> R.string.quest_surface_value_unpaved
-    GROUND_AREA -> R.string.quest_surface_value_ground
+    TARTAN ->          R.string.quest_surface_value_tartan
+    PAVED_ROAD ->      R.string.quest_surface_value_paved
+    UNPAVED_ROAD ->    R.string.quest_surface_value_unpaved
+    GROUND_ROAD ->     R.string.quest_surface_value_ground
+    PAVED_AREA ->      R.string.quest_surface_value_paved
+    UNPAVED_AREA ->    R.string.quest_surface_value_unpaved
+    GROUND_AREA ->     R.string.quest_surface_value_ground
 }
 
 private val Surface.iconResId: Int get() = when (this) {
-    ASPHALT -> R.drawable.surface_asphalt
-    CONCRETE -> R.drawable.surface_concrete
+    ASPHALT ->         R.drawable.surface_asphalt
+    CONCRETE ->        R.drawable.surface_concrete
     CONCRETE_PLATES -> R.drawable.surface_concrete_plates
-    CONCRETE_LANES -> R.drawable.surface_concrete_lanes
-    FINE_GRAVEL -> R.drawable.surface_fine_gravel
-    PAVING_STONES -> R.drawable.surface_paving_stones
-    COMPACTED -> R.drawable.surface_compacted
-    DIRT -> R.drawable.surface_dirt
-    SETT -> R.drawable.surface_sett
+    CONCRETE_LANES ->  R.drawable.surface_concrete_lanes
+    FINE_GRAVEL ->     R.drawable.surface_fine_gravel
+    PAVING_STONES ->   R.drawable.surface_paving_stones
+    COMPACTED ->       R.drawable.surface_compacted
+    DIRT ->            R.drawable.surface_dirt
+    SETT ->            R.drawable.surface_sett
     UNHEWN_COBBLESTONE -> R.drawable.surface_cobblestone
-    GRASS_PAVER -> R.drawable.surface_grass_paver
-    WOOD -> R.drawable.surface_wood
-    WOODCHIPS -> R.drawable.surface_woodchips
-    METAL -> R.drawable.surface_metal
-    GRAVEL -> R.drawable.surface_gravel
-    PEBBLES -> R.drawable.surface_pebblestone
-    GRASS -> R.drawable.surface_grass
-    SAND -> R.drawable.surface_sand
-    ROCK -> R.drawable.surface_rock
-    CLAY -> R.drawable.surface_tennis_clay
+    GRASS_PAVER ->     R.drawable.surface_grass_paver
+    WOOD ->            R.drawable.surface_wood
+    WOODCHIPS ->       R.drawable.surface_woodchips
+    METAL ->           R.drawable.surface_metal
+    GRAVEL ->          R.drawable.surface_gravel
+    PEBBLES ->         R.drawable.surface_pebblestone
+    GRASS ->           R.drawable.surface_grass
+    SAND ->            R.drawable.surface_sand
+    ROCK ->            R.drawable.surface_rock
+    CLAY ->            R.drawable.surface_tennis_clay
     ARTIFICIAL_TURF -> R.drawable.surface_artificial_turf
-    TARTAN -> R.drawable.surface_tartan
-    PAVED_ROAD -> R.drawable.path_surface_paved
-    UNPAVED_ROAD -> R.drawable.path_surface_unpaved
-    GROUND_ROAD -> R.drawable.surface_ground
-    PAVED_AREA -> R.drawable.surface_paved_area
-    UNPAVED_AREA -> R.drawable.surface_unpaved_area
-    GROUND_AREA -> R.drawable.surface_ground_area
+    TARTAN ->          R.drawable.surface_tartan
+    PAVED_ROAD ->      R.drawable.path_surface_paved
+    UNPAVED_ROAD ->    R.drawable.path_surface_unpaved
+    GROUND_ROAD ->     R.drawable.surface_ground
+    PAVED_AREA ->      R.drawable.surface_paved_area
+    UNPAVED_AREA ->    R.drawable.surface_unpaved_area
+    GROUND_AREA ->     R.drawable.surface_ground_area
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/AddInformationForm.kt
@@ -3,24 +3,12 @@ package de.westnordost.streetcomplete.quests.tourism_information
 import android.os.Bundle
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.BOARD
-import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.GUIDEPOST
-import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.MAP
-import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.OFFICE
-import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.TERMINAL
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddInformationForm : AImageListQuestForm<TourismInformation, TourismInformation>() {
 
     override val itemsPerRow = 2
 
-    override val items get() = listOf(
-        Item(OFFICE, R.drawable.tourism_information_office, R.string.quest_tourism_information_office),
-        Item(BOARD, R.drawable.tourism_information_board, R.string.quest_tourism_information_board),
-        Item(TERMINAL, R.drawable.tourism_information_terminal, R.string.quest_tourism_information_terminal),
-        Item(MAP, R.drawable.tourism_information_map, R.string.quest_tourism_information_map),
-        Item(GUIDEPOST, R.drawable.tourism_information_guidepost, R.string.quest_tourism_information_guidepost)
-    )
+    override val items = TourismInformation.values().map { it.asItem() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/TourismInformationItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tourism_information/TourismInformationItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.tourism_information
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.tourism_information.TourismInformation.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun TourismInformation.asItem() = Item(this, iconResId, titleResId)
+
+private val TourismInformation.titleResId: Int get() = when (this) {
+    OFFICE ->    R.string.quest_tourism_information_office
+    BOARD ->     R.string.quest_tourism_information_board
+    TERMINAL ->  R.string.quest_tourism_information_terminal
+    MAP ->       R.string.quest_tourism_information_map
+    GUIDEPOST -> R.string.quest_tourism_information_guidepost
+}
+
+private val TourismInformation.iconResId: Int get() = when (this) {
+    OFFICE ->    R.drawable.tourism_information_office
+    BOARD ->     R.drawable.tourism_information_board
+    TERMINAL ->  R.drawable.tourism_information_terminal
+    MAP ->       R.drawable.tourism_information_map
+    GUIDEPOST -> R.drawable.tourism_information_guidepost
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktypeForm.kt
@@ -1,23 +1,10 @@
 package de.westnordost.streetcomplete.quests.tracktype
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.tracktype.Tracktype.GRADE1
-import de.westnordost.streetcomplete.quests.tracktype.Tracktype.GRADE2
-import de.westnordost.streetcomplete.quests.tracktype.Tracktype.GRADE3
-import de.westnordost.streetcomplete.quests.tracktype.Tracktype.GRADE4
-import de.westnordost.streetcomplete.quests.tracktype.Tracktype.GRADE5
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddTracktypeForm : AImageListQuestForm<Tracktype, Tracktype>() {
 
-    override val items = listOf(
-        Item(GRADE1, R.drawable.tracktype_grade1, R.string.quest_tracktype_grade1),
-        Item(GRADE2, R.drawable.tracktype_grade2, R.string.quest_tracktype_grade2a),
-        Item(GRADE3, R.drawable.tracktype_grade3, R.string.quest_tracktype_grade3a),
-        Item(GRADE4, R.drawable.tracktype_grade4, R.string.quest_tracktype_grade4),
-        Item(GRADE5, R.drawable.tracktype_grade5, R.string.quest_tracktype_grade5)
-    )
+    override val items = Tracktype.values().map { it.asItem() }
 
     override val itemsPerRow = 3
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/TracktypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/TracktypeItem.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.tracktype
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.tracktype.Tracktype.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun Tracktype.asItem() = Item(this, iconResId, titleResId)
+
+private val Tracktype.titleResId: Int get() = when (this) {
+    GRADE1 -> R.string.quest_tracktype_grade1
+    GRADE2 -> R.string.quest_tracktype_grade2a
+    GRADE3 -> R.string.quest_tracktype_grade3a
+    GRADE4 -> R.string.quest_tracktype_grade4
+    GRADE5 -> R.string.quest_tracktype_grade5
+}
+
+private val Tracktype.iconResId: Int get() = when (this) {
+    GRADE1 -> R.drawable.tracktype_grade1
+    GRADE2 -> R.drawable.tracktype_grade2
+    GRADE3 -> R.drawable.tracktype_grade3
+    GRADE4 -> R.drawable.tracktype_grade4
+    GRADE5 -> R.drawable.tracktype_grade5
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/AddTrafficCalmingTypeForm.kt
@@ -1,29 +1,10 @@
 package de.westnordost.streetcomplete.quests.traffic_calming_type
 
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AImageListQuestForm
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.BUMP
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.CHICANE
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.CHOKER
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.CUSHION
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.HUMP
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.ISLAND
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.RUMBLE_STRIP
-import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.TABLE
-import de.westnordost.streetcomplete.view.image_select.Item
 
 class AddTrafficCalmingTypeForm : AImageListQuestForm<TrafficCalmingType, TrafficCalmingType>() {
 
-    override val items = listOf(
-        Item(BUMP, R.drawable.traffic_calming_bump, R.string.quest_traffic_calming_type_bump),
-        Item(HUMP, R.drawable.traffic_calming_hump, R.string.quest_traffic_calming_type_hump),
-        Item(TABLE, R.drawable.traffic_calming_table, R.string.quest_traffic_calming_type_table),
-        Item(CUSHION, R.drawable.traffic_calming_cushion, R.string.quest_traffic_calming_type_cushion),
-        Item(ISLAND, R.drawable.traffic_calming_island, R.string.quest_traffic_calming_type_island),
-        Item(CHOKER, R.drawable.traffic_calming_choker, R.string.quest_traffic_calming_type_choker),
-        Item(CHICANE, R.drawable.traffic_calming_chicane, R.string.quest_traffic_calming_type_chicane),
-        Item(RUMBLE_STRIP, R.drawable.traffic_calming_rumble_strip, R.string.quest_traffic_calming_type_rumble_strip),
-    )
+    override val items = TrafficCalmingType.values().map { it.asItem() }
 
     override val itemsPerRow = 3
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/TrafficCalmingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/traffic_calming_type/TrafficCalmingTypeItem.kt
@@ -1,0 +1,29 @@
+package de.westnordost.streetcomplete.quests.traffic_calming_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.traffic_calming_type.TrafficCalmingType.*
+import de.westnordost.streetcomplete.view.image_select.Item
+
+fun TrafficCalmingType.asItem() = Item(this, iconResId, titleResId)
+
+private val TrafficCalmingType.titleResId: Int get() = when (this) {
+    BUMP ->         R.string.quest_traffic_calming_type_bump
+    HUMP ->         R.string.quest_traffic_calming_type_hump
+    TABLE ->        R.string.quest_traffic_calming_type_table
+    CUSHION ->      R.string.quest_traffic_calming_type_cushion
+    ISLAND ->       R.string.quest_traffic_calming_type_island
+    CHOKER ->       R.string.quest_traffic_calming_type_choker
+    CHICANE ->      R.string.quest_traffic_calming_type_chicane
+    RUMBLE_STRIP -> R.string.quest_traffic_calming_type_rumble_strip
+}
+
+private val TrafficCalmingType.iconResId: Int get() = when (this) {
+    BUMP ->         R.drawable.traffic_calming_bump
+    HUMP ->         R.drawable.traffic_calming_hump
+    TABLE ->        R.drawable.traffic_calming_table
+    CUSHION ->      R.drawable.traffic_calming_cushion
+    ISLAND ->       R.drawable.traffic_calming_island
+    CHOKER ->       R.drawable.traffic_calming_choker
+    CHICANE ->      R.drawable.traffic_calming_chicane
+    RUMBLE_STRIP -> R.drawable.traffic_calming_rumble_strip
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/Item.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/Item.kt
@@ -10,7 +10,7 @@ data class Item<T>(
     val drawableId: Int? = null,
     val titleId: Int? = null,
     val descriptionId: Int? = null,
-    override val items: List<Item<T>>? = null
+    override val items: List<GroupableDisplayItem<T>>? = null
 ) : GroupableDisplayItem<T> {
 
     override val image: Image? get() = drawableId?.let { ResImage(it) }


### PR DESCRIPTION
**Reasons (in order of soundness):**
1. consistency: for some this separation is necessary; let's do it for all then. It's easier for new contributors if they just see one pattern in the code, not several
2. separation of concerns: the definition how the selectable items look does not have anything directly to do with the UI logic of the form
3. leads to slightly shorter files (because there are more files now)