### PR TITLE
enable camp quests by default

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampDrinkingWater.kt
@@ -24,7 +24,6 @@ class AddCampDrinkingWater : OsmFilterQuestType<Boolean>() {
     override val changesetComment = "Specify whether there is drinking water at camp site"
     override val wikiLink = "Key:drinking_water"
     override val icon = R.drawable.ic_quest_drinking_water
-    override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val achievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camp_drinking_water_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampPower.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampPower.kt
@@ -24,7 +24,6 @@ class AddCampPower : OsmFilterQuestType<Boolean>() {
     override val changesetComment = "Specify whether there is electricity available at camp site"
     override val wikiLink = "Key:power_supply"
     override val icon = R.drawable.ic_quest_camp_power
-    override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val achievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camp_power_supply_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
@@ -24,7 +24,6 @@ class AddCampShower : OsmFilterQuestType<Boolean>() {
     override val changesetComment = "Specify whether there are showers available at camp site"
     override val wikiLink = "Key:shower"
     override val icon = R.drawable.ic_quest_shower
-    override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside
     override val achievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_camp_shower_title


### PR DESCRIPTION
Enable camping quests by default if that is found acceptable.
Suggested in https://github.com/streetcomplete/StreetComplete/issues/4198#issuecomment-1233358308