### PR TITLE
implement ATM cash-in quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.quests.air_conditioning.AddAirConditioning
 import de.westnordost.streetcomplete.quests.air_pump.AddAirCompressor
 import de.westnordost.streetcomplete.quests.air_pump.AddBicyclePump
 import de.westnordost.streetcomplete.quests.atm_operator.AddAtmOperator
-import de.westnordost.streetcomplete.quests.atm_cashin.AddAtmCashin
+import de.westnordost.streetcomplete.quests.atm_cashin.AddAtmCashIn
 import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.AddBicycleBarrierType
 import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnPath
@@ -352,7 +352,7 @@ fun questTypeRegistry(
     AddBicyclePump(), // visible from the outside, but only during opening hours
 
     AddAtmOperator(),
-    AddAtmCashin(),
+    AddAtmCashIn(),
 
     AddClothingBinOperator(),
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.quests.air_conditioning.AddAirConditioning
 import de.westnordost.streetcomplete.quests.air_pump.AddAirCompressor
 import de.westnordost.streetcomplete.quests.air_pump.AddBicyclePump
 import de.westnordost.streetcomplete.quests.atm_operator.AddAtmOperator
+import de.westnordost.streetcomplete.quests.atm_cashin.AddAtmCashin
 import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
 import de.westnordost.streetcomplete.quests.barrier_bicycle_barrier_type.AddBicycleBarrierType
 import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnPath
@@ -351,6 +352,7 @@ fun questTypeRegistry(
     AddBicyclePump(), // visible from the outside, but only during opening hours
 
     AddAtmOperator(),
+    AddAtmCashin(),
 
     AddClothingBinOperator(),
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
@@ -1,0 +1,36 @@
+package de.westnordost.streetcomplete.quests.atm_cashin
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.YesNoQuestForm
+import de.westnordost.streetcomplete.util.ktx.toYesNo
+
+class AddAtmCashin : OsmFilterQuestType<Boolean>() {
+
+    override val elementFilter = """
+        nodes with
+         amenity = atm
+         and !cash_in
+    """
+    override val changesetComment = "Determine whether ATM allows depositing cash"
+    override val wikiLink = "Key:cash_in"
+    override val icon = R.drawable.ic_quest_money
+    override val isDeleteElementEnabled = true
+    override val achievements = listOf(CITIZEN)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_atm_cashin_title
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("nodes with amenity = atm")
+
+    override fun createForm() = YesNoQuestForm()
+
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, timestampEdited: Long) {
+        tags["cash_in"] = answer.toYesNo()
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
@@ -12,11 +12,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddAtmCashin : OsmFilterQuestType<Boolean>() {
 
-    override val elementFilter = """
-        nodes with
-         amenity = atm
-         and !cash_in
-    """
+    override val elementFilter = "nodes with amenity = atm and !cash_in"
     override val changesetComment = "Determine whether ATM allows depositing cash"
     override val wikiLink = "Key:cash_in"
     override val icon = R.drawable.ic_quest_money

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashin.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddAtmCashin : OsmFilterQuestType<Boolean>() {
+class AddAtmCashIn : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = "nodes with amenity = atm and !cash_in"
     override val changesetComment = "Determine whether ATM allows depositing cash"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,7 +605,7 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
 
     <string name="quest_airConditioning_title">"Is this place air-conditioned?"</string>
 
-    <string name="quest_atm_cashin_title">"Does this ATM allows depositing cash?"</string>
+    <string name="quest_atm_cashin_title">"Can you deposit cash at this ATM?"</string>
     <string name="quest_atm_operator_title">"Which bank operates this ATM?"</string>
 
     <string name="quest_baby_changing_table_title2">"Does this place have a baby changing table?"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,7 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
 
     <string name="quest_airConditioning_title">"Is this place air-conditioned?"</string>
 
+    <string name="quest_atm_cashin_title">"Does this ATM allows depositing cash?"</string>
     <string name="quest_atm_operator_title">"Which bank operates this ATM?"</string>
 
     <string name="quest_baby_changing_table_title2">"Does this place have a baby changing table?"</string>


### PR DESCRIPTION
Closes: https://github.com/streetcomplete/StreetComplete/issues/4292
([tested](https://github.com/mnalis/StreetComplete/actions/runs/2976059075) and seems to work ok)

Note: I re-used _"ATM Operator"_ quest `ic_quest_money` icon ("wad of notes" image)
Maybe it is fine as-is (for similar quests to have same icon), or a modified icon should be created.