### PR TITLE
Upgrade kaml to v0.48.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,13 +103,6 @@ configurations {
     all {
         // it's already included in Android
         exclude(group = "net.sf.kxml", module = "kxml2")
-
-        // TODO remove substitution when `kaml` dependency uses newer version of `org.snakeyaml:snakeyaml-engine`
-        resolutionStrategy.dependencySubstitution {
-            substitute(module("org.snakeyaml:snakeyaml-engine:2.3"))
-                .using(module("org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484"))
-                .because("https://github.com/streetcomplete/StreetComplete/issues/3889")
-        }
     }
 }
 
@@ -183,7 +176,7 @@ dependencies {
 
     // serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
-    implementation("com.charleskorn.kaml:kaml:0.47.0")
+    implementation("com.charleskorn.kaml:kaml:0.48.0")
 
     // map and location
     implementation("com.mapzen.tangram:tangram:0.17.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        // TODO remove when dependency to org.bitbucket.snakeyaml:snakeyaml-engine:8209bb9484 is no longer needed
-        maven { url = java.net.URI("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
[`kaml` v0.48.0](https://github.com/charleskorn/kaml/releases/tag/0.48.0) was just released, which updates `snakeyaml-engine` to v2.4.
[`snakeyaml-engine` v2.4](https://bitbucket.org/snakeyaml/snakeyaml-engine/wiki/Changes) includes the fix to support Android 5 (see #3889).

Thus, we can drop our workaround/patch introduced in #3914.

@westnordost Can you verify that these changes work correctly on Android 5? I tested on an Android 11 emulator and it works fine.