### PR TITLE
Skip AcceptCards for POIs with access=private/no/customers

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -20,6 +20,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
         and !payment:credit_cards and !payment:debit_cards
         and !brand and !wikipedia:brand and !wikidata:brand
         and (!seasonal or seasonal = no)
+        and access !~ private|no
     """
     override val changesetComment = "Survey whether payment with cards is accepted"
     override val wikiLink = "Key:payment"


### PR DESCRIPTION
This skips the quest for a few hundreds cantines (=`no`/`private`) and embedded restaurants (=`customers` like in waterparks).