### PR TITLE
Fix overlays not showing properly

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
@@ -48,8 +48,8 @@ class StyleableOverlayManager(
     private var overlay: Overlay? = null
     set(value) {
         if (field == value) return
-        if (value != null) show() else hide()
         field = value
+        if (value != null) show() else hide()
     }
 
     private val overlayListener = object : SelectedOverlaySource.Listener {


### PR DESCRIPTION
onNewScreenPosition currently checks `if (overlay == null)` before setting overlay field to the new value