### PR TITLE
Cache: split up fetch tilesRect if it makes sense

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/TilesRect.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/TilesRect.kt
@@ -3,7 +3,6 @@ package de.westnordost.streetcomplete.data.download.tiles
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.splitAt180thMeridian
-import de.westnordost.streetcomplete.util.ktx.firstAndLast
 import kotlinx.serialization.Serializable
 import kotlin.math.PI
 import kotlin.math.asinh

--- a/app/src/main/java/de/westnordost/streetcomplete/util/SpatialCache.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/SpatialCache.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import de.westnordost.streetcomplete.data.download.tiles.TilePos
 import de.westnordost.streetcomplete.data.download.tiles.enclosingTilePos
 import de.westnordost.streetcomplete.data.download.tiles.enclosingTilesRect
-import de.westnordost.streetcomplete.data.download.tiles.minTileRect
+import de.westnordost.streetcomplete.data.download.tiles.upToTwoMinTileRects
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.math.contains
@@ -113,10 +113,9 @@ class SpatialCache<K, T>(
         val requiredTiles = bbox.asListOfEnclosingTilePos()
 
         val tilesToFetch = requiredTiles.filterNot { byTile.containsKey(it) }
-        val tilesRectToFetch = tilesToFetch.minTileRect()
-        if (tilesRectToFetch != null) {
-            val newItems = fetch(tilesRectToFetch.asBoundingBox(tileZoom))
-            replaceAllInTiles(newItems, tilesToFetch)
+        tilesToFetch.upToTwoMinTileRects()?.forEach { tilesRect ->
+            val newItems = fetch(tilesRect.asBoundingBox(tileZoom))
+            replaceAllInTiles(newItems, tilesRect.asTilePosSequence().toList())
         }
 
         val items = requiredTiles.flatMap { tile ->


### PR DESCRIPTION
This is basically what is mentioned in https://github.com/streetcomplete/StreetComplete/pull/4125#issuecomment-1249154809, dealing with diagonal scrolling as mentioned in https://github.com/streetcomplete/StreetComplete/issues/4079#issuecomment-1152616022.

This was _not_ tested in the current state, only the version I had previously (https://github.com/streetcomplete/StreetComplete/compare/master...Helium314:StreetComplete:cache_divide_fetch_rect).
And it still needs some unit tests...