### PR TITLE
Remove waterway=fuel from compressed air quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/air_pump/AddAirCompressor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/air_pump/AddAirCompressor.kt
@@ -22,6 +22,7 @@ class AddAirCompressor : OsmFilterQuestType<Boolean>() {
            or compressed_air older today -6 years
        )
        and access !~ private|no
+       and waterway != fuel
     """
 
     override val changesetComment = "Survey availability of air compressors"


### PR DESCRIPTION
Fix #4460 