### PR TITLE
improve performance when scanning for quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
@@ -65,7 +65,7 @@ class ElementFilterExpression(
     internal val elementExprRoot: BooleanExpression<ElementFilter, Element>?
 ) {
     /* Performance improvement: Allows to skip early on elements that have no tags at all */
-    private val mayEvaluateToTrueWithNoTags = elementExprRoot?.mayEvaluateToTrueWithNoTags ?: true
+    val mayEvaluateToTrueWithNoTags = elementExprRoot?.mayEvaluateToTrueWithNoTags ?: true
 
     /** returns whether the given element is found through (=matches) this expression */
     fun matches(element: Element): Boolean =


### PR DESCRIPTION
`OsmFilterQuestType` quests always uses element tags, so there is no need to check whether an element without tags is applicable.
This change results in ~15-30% faster creation of quests in a bbox.