### PR TITLE
Add support for edits working on several elements

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDaoTest.kt
@@ -15,13 +15,13 @@ class CreatedElementsDaoTest : ApplicationDbTestCase() {
         dao = CreatedElementsDao(database)
     }
 
-    @Test fun addGetDelete() {
+    @Test fun putGetDelete() {
         assertTrue(dao.getAll().isEmpty())
 
         val elements = listOf(
-            ElementKey(ElementType.NODE, 1),
-            ElementKey(ElementType.WAY, 1),
-            ElementKey(ElementType.NODE, 3),
+            CreatedElementKey(ElementType.NODE, 1, null),
+            CreatedElementKey(ElementType.WAY, 1, 123),
+            CreatedElementKey(ElementType.NODE, 3, 456),
         )
 
         dao.putAll(elements)
@@ -30,14 +30,27 @@ class CreatedElementsDaoTest : ApplicationDbTestCase() {
 
         dao.deleteAll(listOf(
             ElementKey(ElementType.WAY, 1),
-            ElementKey(ElementType.NODE, 3),
+            ElementKey(ElementType.NODE, 456),
         ))
 
-        assertEquals(listOf(ElementKey(ElementType.NODE, 1)), dao.getAll())
+        assertEquals(listOf(CreatedElementKey(ElementType.NODE, 1, null)), dao.getAll())
+    }
+
+    @Test fun putReplaces() {
+        dao.putAll(listOf(
+            CreatedElementKey(ElementType.NODE, 1, null)
+        ))
+        dao.putAll(listOf(
+            CreatedElementKey(ElementType.NODE, 1, 123)
+        ))
+        assertEquals(
+            listOf(CreatedElementKey(ElementType.NODE, 1, 123)),
+            dao.getAll()
+        )
     }
 
     @Test fun clear() {
-        dao.putAll(listOf(ElementKey(ElementType.NODE, 1)))
+        dao.putAll(listOf(CreatedElementKey(ElementType.NODE, 1, 123)))
         dao.clear()
         assertTrue(dao.getAll().isEmpty())
     }

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
@@ -261,9 +261,6 @@ private fun updateTags(
 ) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    element.type,
-    element.id,
-    element,
     geometry,
     "survey",
     timestamp,
@@ -280,9 +277,6 @@ private fun updateTags(
 private fun revertUpdateTags(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    node.type,
-    node.id,
-    node,
     geom,
     "survey",
     timestamp,
@@ -299,9 +293,6 @@ private fun revertUpdateTags(timestamp: Long = 123L, isSynced: Boolean = false) 
 private fun deletePoi(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    node.type,
-    node.id,
-    node,
     geom,
     "survey",
     timestamp,
@@ -312,9 +303,6 @@ private fun deletePoi(timestamp: Long = 123L, isSynced: Boolean = false) = Eleme
 private fun revertDeletePoi(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    node.type,
-    node.id,
-    node,
     geom,
     "survey",
     timestamp,
@@ -325,9 +313,6 @@ private fun revertDeletePoi(timestamp: Long = 123L, isSynced: Boolean = false) =
 private fun splitWay(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    ElementType.WAY,
-    1,
-    Way(1, listOf(0, 1)),
     ElementPolylinesGeometry(listOf(listOf(LatLon(0.0, 0.0), LatLon(1.0, 1.0))), LatLon(0.5, 0.5)),
     "survey",
     timestamp,
@@ -347,9 +332,6 @@ private fun splitWay(timestamp: Long = 123L, isSynced: Boolean = false) = Elemen
 private fun createNode(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    node.type,
-    node.id,
-    node,
     geom,
     "survey",
     timestamp,
@@ -360,9 +342,6 @@ private fun createNode(timestamp: Long = 123L, isSynced: Boolean = false) = Elem
 private fun revertCreateNode(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
     0,
     TEST_QUEST_TYPE,
-    node.type,
-    node.id,
-    node,
     geom,
     "survey",
     timestamp,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
@@ -178,11 +178,12 @@ class StreetCompleteSQLiteOpenHelper(context: Context, dbName: String) :
             db.execSQL("DROP INDEX osm_element_edits_index")
             db.execSQL("ALTER TABLE ${CreatedElementsTable.NAME} ADD COLUMN ${CreatedElementsTable.Columns.NEW_ELEMENT_ID} int")
             db.execSQL(CreatedElementsTable.NEW_ID_INDEX_CREATE)
+
+            // TODO upgrade database: ElementEditsTable different now (no element type, id, element) but this is in the actions now
         }
     }
 }
 
 private const val DB_VERSION = 7
 
-// TODO upgrade database:
-// ElementEditsTable different now (no element type, id, element) but this is in the actions now
+

--- a/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
@@ -59,11 +59,11 @@ class StreetCompleteSQLiteOpenHelper(context: Context, dbName: String) :
 
         // changes made on OSM map data
         db.execSQL(ElementEditsTable.CREATE)
-        db.execSQL(ElementEditsTable.ELEMENT_INDEX_CREATE)
         db.execSQL(ElementIdProviderTable.CREATE)
         db.execSQL(ElementIdProviderTable.INDEX_CREATE)
 
         db.execSQL(CreatedElementsTable.CREATE)
+        db.execSQL(CreatedElementsTable.NEW_ID_INDEX_CREATE)
 
         // quests
         db.execSQL(VisibleQuestTypeTable.CREATE)
@@ -174,7 +174,15 @@ class StreetCompleteSQLiteOpenHelper(context: Context, dbName: String) :
         if (oldVersion <= 5 && newVersion > 5) {
             db.execSQL("ALTER TABLE ${NoteEditsTable.NAME} ADD COLUMN ${NoteEditsTable.Columns.TRACK} text DEFAULT '[]' NOT NULL")
         }
+        if (oldVersion <= 6 && newVersion > 6) {
+            db.execSQL("DROP INDEX osm_element_edits_index")
+            db.execSQL("ALTER TABLE ${CreatedElementsTable.NAME} ADD COLUMN ${CreatedElementsTable.Columns.NEW_ELEMENT_ID} int")
+            db.execSQL(CreatedElementsTable.NEW_ID_INDEX_CREATE)
+        }
     }
 }
 
-private const val DB_VERSION = 6
+private const val DB_VERSION = 7
+
+// TODO upgrade database:
+// ElementEditsTable different now (no element type, id, element) but this is in the actions now

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementKey.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementKey.kt
@@ -1,0 +1,9 @@
+package de.westnordost.streetcomplete.data.osm.created_elements
+
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+
+data class CreatedElementKey(
+    val elementType: ElementType,
+    val elementId: Long,
+    val newElementId: Long?
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsController.kt
@@ -3,28 +3,38 @@ package de.westnordost.streetcomplete.data.osm.created_elements
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 
+/** Manages which elements have been created, translating if necessary from the local/temporary
+ *  element ids to the proper assigned one from the OSM API (and updating that) */
 class CreatedElementsController(
     private val db: CreatedElementsDao
 ) : CreatedElementsSource {
 
-    private val cache: MutableSet<ElementKey> by lazy {
-        synchronized(this) { db.getAll().toMutableSet() }
+    private val cache: MutableMap<ElementKey, ElementKey> by lazy {
+        synchronized(this) {
+            val entries = db.getAll()
+            val result = HashMap<ElementKey, ElementKey>(entries.size * 2)
+            putAllTo(result, entries)
+            result
+        }
     }
 
     override fun contains(elementType: ElementType, elementId: Long): Boolean =
-        synchronized(this) { cache.contains(ElementKey(elementType, elementId)) }
+        synchronized(this) { cache.containsKey(ElementKey(elementType, elementId)) }
 
-    fun putAll(entries: Collection<ElementKey>) {
+    override fun getId(elementType: ElementType, elementId: Long): Long? =
+        synchronized(this) { cache[ElementKey(elementType, elementId)]?.id }
+
+    fun putAll(entries: Collection<CreatedElementKey>) {
         synchronized(this) {
             db.putAll(entries)
-            cache.addAll(entries)
+            putAllTo(cache, entries)
         }
     }
 
     fun deleteAll(entries: Collection<ElementKey>) {
         synchronized(this) {
             val result = db.deleteAll(entries)
-            cache.removeAll(entries.toSet())
+            cache.keys.removeAll(entries.toSet())
             return result
         }
     }
@@ -33,6 +43,17 @@ class CreatedElementsController(
         synchronized(this) {
             db.clear()
             cache.clear()
+        }
+    }
+
+    private fun putAllTo(map: MutableMap<ElementKey, ElementKey>, entries: Collection<CreatedElementKey>) {
+        for (entry in entries) {
+            val key = ElementKey(entry.elementType, entry.newElementId ?: entry.elementId)
+            map[key] = key
+            if (entry.newElementId != null) {
+                val oldKey = ElementKey(entry.elementType, entry.elementId)
+                map[oldKey] = key
+            }
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
@@ -4,24 +4,27 @@ import de.westnordost.streetcomplete.data.CursorPosition
 import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsTable.Columns.ELEMENT_ID
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsTable.Columns.ELEMENT_TYPE
+import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsTable.Columns.NEW_ELEMENT_ID
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsTable.NAME
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 
+/** Persists which elements have been created, each including their initial (local/temporary) id
+ *  before upload and the assigned (if any, yet) id by the OSM API */
 class CreatedElementsDao(private val db: Database) {
 
-    fun putAll(entries: Collection<ElementKey>) {
+    fun putAll(entries: Collection<CreatedElementKey>) {
         if (entries.isEmpty()) return
 
         db.replaceMany(
             NAME,
-            arrayOf(ELEMENT_TYPE, ELEMENT_ID),
-            entries.map { arrayOf(it.type.name, it.id) }
+            arrayOf(ELEMENT_TYPE, ELEMENT_ID, NEW_ELEMENT_ID),
+            entries.map { arrayOf(it.elementType, it.elementId, it.newElementId) }
         )
     }
 
-    fun getAll(): List<ElementKey> =
-        db.query(NAME) { it.toElementKey() }
+    fun getAll(): List<CreatedElementKey> =
+        db.query(NAME) { it.toCreatedElementKey() }
 
     fun deleteAll(entries: Collection<ElementKey>) {
         if (entries.isEmpty()) return
@@ -29,7 +32,7 @@ class CreatedElementsDao(private val db: Database) {
             for (entry in entries) {
                 db.delete(
                     NAME,
-                    where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ?",
+                    where = "$ELEMENT_TYPE = ? AND ($ELEMENT_ID = ? OR $NEW_ELEMENT_ID = ?)",
                     args = arrayOf(entry.type.name, entry.id)
                 )
             }
@@ -41,7 +44,8 @@ class CreatedElementsDao(private val db: Database) {
     }
 }
 
-private fun CursorPosition.toElementKey() = ElementKey(
+private fun CursorPosition.toCreatedElementKey() = CreatedElementKey(
     ElementType.valueOf(getString(ELEMENT_TYPE)),
-    getLong(ELEMENT_ID)
+    getLong(ELEMENT_ID),
+    getLongOrNull(NEW_ELEMENT_ID),
 )

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
@@ -33,7 +33,7 @@ class CreatedElementsDao(private val db: Database) {
                 db.delete(
                     NAME,
                     where = "$ELEMENT_TYPE = ? AND ($ELEMENT_ID = ? OR $NEW_ELEMENT_ID = ?)",
-                    args = arrayOf(entry.type.name, entry.id)
+                    args = arrayOf(entry.type.name, entry.id, entry.id)
                 )
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDao.kt
@@ -19,7 +19,7 @@ class CreatedElementsDao(private val db: Database) {
         db.replaceMany(
             NAME,
             arrayOf(ELEMENT_TYPE, ELEMENT_ID, NEW_ELEMENT_ID),
-            entries.map { arrayOf(it.elementType, it.elementId, it.newElementId) }
+            entries.map { arrayOf(it.elementType.name, it.elementId, it.newElementId) }
         )
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsSource.kt
@@ -3,5 +3,12 @@ package de.westnordost.streetcomplete.data.osm.created_elements
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 
 interface CreatedElementsSource {
+    /** Returns whether the given element has been created by this app */
     fun contains(elementType: ElementType, elementId: Long): Boolean
+    /** Returns the current id of the given created element. Created elements get their proper ids
+     *  assigned only after upload, so an element may have an old local id they can be referred
+     *  to and a proper real id. This function returns the latter even if for [elementId], the old
+     *  id is specified.
+     *  Returns null if the given element is not a created element. */
+    fun getId(elementType: ElementType, elementId: Long): Long?
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsTable.kt
@@ -5,6 +5,7 @@ object CreatedElementsTable {
 
     object Columns {
         const val ELEMENT_ID = "element_id"
+        const val NEW_ELEMENT_ID = "new_element_id"
         const val ELEMENT_TYPE = "element_type"
     }
 
@@ -12,10 +13,18 @@ object CreatedElementsTable {
         CREATE TABLE $NAME (
             ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
             ${Columns.ELEMENT_ID} int NOT NULL,
+            ${Columns.NEW_ELEMENT_ID} int,
             CONSTRAINT primary_key PRIMARY KEY (
                 ${Columns.ELEMENT_TYPE},
                 ${Columns.ELEMENT_ID}
             )
+        );
+    """
+
+    const val NEW_ID_INDEX_CREATE = """
+        CREATE INDEX created_elements_new_ids_idx ON $NAME (
+            ${Columns.ELEMENT_TYPE},
+            ${Columns.NEW_ELEMENT_ID}
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/MapDataRepositoryWithUpdatedIds.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/MapDataRepositoryWithUpdatedIds.kt
@@ -1,0 +1,24 @@
+package de.westnordost.streetcomplete.data.osm.created_elements
+
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+
+class MapDataRepositoryWithUpdatedIds(
+    private val createdElementsSource: CreatedElementsSource,
+    private val mapDataRepository: MapDataRepository
+) : MapDataRepository {
+
+    private fun nodeId(id: Long): Long = createdElementsSource.getId(ElementType.NODE, id) ?: id
+    private fun wayId(id: Long): Long = createdElementsSource.getId(ElementType.WAY, id) ?: id
+    private fun relId(id: Long): Long = createdElementsSource.getId(ElementType.RELATION, id) ?: id
+
+    override fun getNode(id: Long) = mapDataRepository.getNode(nodeId(id))
+    override fun getWay(id: Long) = mapDataRepository.getWay(wayId(id))
+    override fun getRelation(id: Long) = mapDataRepository.getRelation(relId(id))
+    override fun getWayComplete(id: Long) = mapDataRepository.getWayComplete(wayId(id))
+    override fun getRelationComplete(id: Long) = mapDataRepository.getRelationComplete(relId(id))
+    override fun getWaysForNode(id: Long) = mapDataRepository.getWaysForNode(nodeId(id))
+    override fun getRelationsForNode(id: Long) = mapDataRepository.getRelationsForNode(nodeId(id))
+    override fun getRelationsForWay(id: Long) = mapDataRepository.getRelationsForWay(wayId(id))
+    override fun getRelationsForRelation(id: Long) = mapDataRepository.getRelationsForRelation(wayId(id))
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/MapDataRepositoryWithUpdatedIds.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/created_elements/MapDataRepositoryWithUpdatedIds.kt
@@ -3,6 +3,8 @@ package de.westnordost.streetcomplete.data.osm.created_elements
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 
+/** A wrapper around a MapDataRepository that makes sure that if an element is queried over a
+ *  temporary/old id, it is redirected to the current id */
 class MapDataRepositoryWithUpdatedIds(
     private val createdElementsSource: CreatedElementsSource,
     private val mapDataRepository: MapDataRepository

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/AddElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/AddElementEditsController.kt
@@ -6,7 +6,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 interface AddElementEditsController {
     fun add(
         type: ElementEditType,
-        element: Element,
         geometry: ElementGeometry,
         source: String,
         action: ElementEditAction

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
@@ -3,8 +3,6 @@ package de.westnordost.streetcomplete.data.osm.edits
 import de.westnordost.streetcomplete.data.edithistory.Edit
 import de.westnordost.streetcomplete.data.edithistory.ElementEditKey
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
-import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 
 data class ElementEdit(
@@ -15,13 +13,6 @@ data class ElementEdit(
      *  associated with the quest type. A changeset gets its comment from the quest type */
     val type: ElementEditType,
 
-    /** element type this edit refers to */
-    val elementType: ElementType,
-    /** element id this edit refers to. Unlike element.id, this field may change when the OSM API
-     *  returns element ID updates. Use 0 for newly created elements */
-    val elementId: Long,
-    /** original element this edit was made on */
-    val originalElement: Element,
     /** original geometry of element this edit refers to */
     val originalGeometry: ElementGeometry,
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditAction.kt
@@ -1,6 +1,5 @@
 package de.westnordost.streetcomplete.data.osm.edits
 
-import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 
@@ -15,8 +14,6 @@ interface ElementEditAction {
      * when applied to the given element or throw a ElementConflictException
      * */
     fun createUpdates(
-        originalElement: Element,
-        element: Element?,
         mapDataRepository: MapDataRepository,
         idProvider: ElementIdProvider
     ): MapDataChanges

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditAction.kt
@@ -22,6 +22,6 @@ interface ElementEditAction {
 data class NewElementsCount(val nodes: Int, val ways: Int, val relations: Int)
 
 interface IsActionRevertable {
-    fun createReverted(): ElementEditAction
+    fun createReverted(idProvider: ElementIdProvider): ElementEditAction
 }
 interface IsRevertAction

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -23,12 +23,11 @@ class ElementEditsController(
     /** Add new unsynced edit to the to-be-uploaded queue */
     override fun add(
         type: ElementEditType,
-        element: Element,
         geometry: ElementGeometry,
         source: String,
         action: ElementEditAction
     ) {
-        add(ElementEdit(0, type, element.type, element.id, element, geometry, source, currentTimeMillis(), false, action))
+        add(ElementEdit(0, type, geometry, source, currentTimeMillis(), false, action))
     }
 
     fun get(id: Long): ElementEdit? =
@@ -99,7 +98,7 @@ class ElementEditsController(
             // need to delete the original edit from history because this should not be undoable anymore
             delete(edit)
             // ... and add a new revert to the queue
-            add(ElementEdit(0, edit.type, edit.elementType, edit.elementId, edit.originalElement, edit.originalGeometry, edit.source, currentTimeMillis(), false, action.createReverted()))
+            add(ElementEdit(0, edit.type, edit.originalGeometry, edit.source, currentTimeMillis(), false, action.createReverted()))
         }
         // not uploaded yet
         else {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 class ElementEditsController(
     private val editsDB: ElementEditsDao,
     private val elementIdProviderDB: ElementIdProviderDao,
-    private val lastEditTimeStore: LastEditTimeStore
+    private val lastEditTimeStore: LastEditTimeStore,
 ) : ElementEditsSource, AddElementEditsController {
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */
@@ -89,7 +89,8 @@ class ElementEditsController(
             // need to delete the original edit from history because this should not be undoable anymore
             delete(edit)
             // ... and add a new revert to the queue
-            add(ElementEdit(0, edit.type, edit.originalGeometry, edit.source, currentTimeMillis(), false, action.createReverted()))
+            val reverted = action.createReverted(getIdProvider(edit.id))
+            add(ElementEdit(0, edit.type, edit.originalGeometry, edit.source, currentTimeMillis(), false, reverted))
         }
         // not uploaded yet
         else {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -2,7 +2,6 @@ package de.westnordost.streetcomplete.data.osm.edits
 
 import de.westnordost.streetcomplete.data.osm.edits.upload.LastEditTimeStore
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
-import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
 import java.lang.System.currentTimeMillis

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 class ElementEditsController(
     private val editsDB: ElementEditsDao,
     private val elementIdProviderDB: ElementIdProviderDao,
-    private val lastEditTimeStore: LastEditTimeStore,
+    private val lastEditTimeStore: LastEditTimeStore
 ) : ElementEditsSource, AddElementEditsController {
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -116,13 +116,9 @@ class ElementEditsController(
     }
 
     private fun delete(edit: ElementEdit) {
-        val edits = mutableListOf<ElementEdit>()
-        val ids: List<Long>
+        val edits = listOf(edit)
+        val ids = listOf(edit.id)
         synchronized(this) {
-            edits.addAll(getEditsBasedOnElementsCreatedByEdit(edit))
-
-            ids = edits.map { it.id }
-
             editsDB.deleteAll(ids)
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
@@ -19,7 +19,6 @@ import de.westnordost.streetcomplete.data.osm.edits.delete.RevertDeletePoiNodeAc
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.RevertUpdateElementTagsAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
@@ -57,13 +56,6 @@ class ElementEditsDao(
     fun get(id: Long): ElementEdit? =
         db.queryOne(NAME, where = "$ID = $id") { it.toElementEdit() }
 
-    fun getByElement(elementType: ElementType, elementId: Long): List<ElementEdit> =
-        db.query(NAME,
-            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ?",
-            args = arrayOf(elementType.name, elementId),
-            orderBy = "$IS_SYNCED, $CREATED_TIMESTAMP"
-        ) { it.toElementEdit() }
-
     fun getOldestUnsynced(): ElementEdit? =
         db.queryOne(NAME,
             where = "$IS_SYNCED = 0",
@@ -95,22 +87,6 @@ class ElementEditsDao(
 
     fun getSyncedOlderThan(timestamp: Long): List<ElementEdit> =
         db.query(NAME, where = "$IS_SYNCED = 1 AND $CREATED_TIMESTAMP < $timestamp") { it.toElementEdit() }
-
-    fun updateElementId(id: Long, newElementId: Long): Int =
-        db.update(
-            NAME,
-            values = listOf(ELEMENT_ID to newElementId),
-            where = "$ID = ?",
-            args = arrayOf(id)
-        )
-
-    fun updateElementId(elementType: ElementType, oldElementId: Long, newElementId: Long): Int =
-        db.update(
-            NAME,
-            values = listOf(ELEMENT_ID to newElementId),
-            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ?",
-            args = arrayOf(elementType.name, oldElementId)
-        )
 
     private fun ElementEdit.toPairs(): List<Pair<String, Any?>> = listOf(
         QUEST_TYPE to type.name,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
@@ -4,9 +4,6 @@ import de.westnordost.streetcomplete.data.CursorPosition
 import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.ACTION
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.CREATED_TIMESTAMP
-import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.ELEMENT
-import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.ELEMENT_ID
-import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.ELEMENT_TYPE
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.GEOMETRY
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.ID
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.IS_SYNCED
@@ -117,9 +114,6 @@ class ElementEditsDao(
 
     private fun ElementEdit.toPairs(): List<Pair<String, Any?>> = listOf(
         QUEST_TYPE to type.name,
-        ELEMENT_TYPE to elementType.name,
-        ELEMENT_ID to elementId,
-        ELEMENT to json.encodeToString(originalElement),
         GEOMETRY to json.encodeToString(originalGeometry),
         SOURCE to source,
         LATITUDE to position.latitude,
@@ -133,9 +127,6 @@ class ElementEditsDao(
         getLong(ID),
         questTypeRegistry.getByName(getString(QUEST_TYPE)) as? OsmElementQuestType<*>
             ?: overlayRegistry.getByName(getString(QUEST_TYPE))!!,
-        ElementType.valueOf(getString(ELEMENT_TYPE)),
-        getLong(ELEMENT_ID),
-        json.decodeFromString(getString(ELEMENT)),
         json.decodeFromString(getString(GEOMETRY)),
         getString(SOURCE),
         getLong(CREATED_TIMESTAMP),

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
@@ -12,7 +12,7 @@ import org.koin.dsl.module
 
 val elementEditsModule = module {
     factory { ChangesetAutoCloser(get()) }
-    factory { ElementEditUploader(get(), get(), get()) }
+    factory { ElementEditUploader(get(), get(), get(), get()) }
 
     factory { ElementEditsDao(get(), get(), get()) }
     factory { ElementIdProviderDao(get()) }
@@ -25,7 +25,7 @@ val elementEditsModule = module {
 
     single<ElementEditsSource> { get<ElementEditsController>() }
     single { ElementEditsController(get(), get(), get()) }
-    single { MapDataWithEditsSource(get(), get(), get()) }
+    single { MapDataWithEditsSource(get(), get(), get(), get()) }
 
     worker { ChangesetAutoCloserWorker(get(), get(), get()) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsTable.kt
@@ -6,9 +6,6 @@ object ElementEditsTable {
     object Columns {
         const val ID = "id"
         const val QUEST_TYPE = "quest_type"
-        const val ELEMENT_ID = "element_id"
-        const val ELEMENT_TYPE = "element_type"
-        const val ELEMENT = "element"
         const val GEOMETRY = "geometry"
         const val SOURCE = "source"
         const val LATITUDE = "latitude"
@@ -22,9 +19,6 @@ object ElementEditsTable {
         CREATE TABLE $NAME (
             ${Columns.ID} INTEGER PRIMARY KEY AUTOINCREMENT,
             ${Columns.QUEST_TYPE} varchar(255) NOT NULL,
-            ${Columns.ELEMENT_ID} int NOT NULL,
-            ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
-            ${Columns.ELEMENT} text NOT NULL,
             ${Columns.GEOMETRY} text NOT NULL,
             ${Columns.SOURCE} varchar(255) NOT NULL,
             ${Columns.LATITUDE} double NOT NULL,
@@ -32,13 +26,6 @@ object ElementEditsTable {
             ${Columns.CREATED_TIMESTAMP} int NOT NULL,
             ${Columns.IS_SYNCED} int NOT NULL,
             ${Columns.ACTION} text
-        );
-    """
-
-    const val ELEMENT_INDEX_CREATE = """
-        CREATE INDEX osm_element_edits_index ON $NAME (
-            ${Columns.ELEMENT_TYPE},
-            ${Columns.ELEMENT_ID}
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -322,17 +322,22 @@ class MapDataWithEditsSource internal constructor(
 
             rebuildLocalChanges()
 
-            elementsDeletedNow = deletedElements - previousDeletedElements
-            val elementsNotDeletedAnymore = previousDeletedElements - deletedElements
+            val elementKeysNotDeletedAnymore = previousDeletedElements - deletedElements
 
-            val changedElements = (
-                elementsNotDeletedAnymore +
-                    (updatedElements.keys + previousUpdatedElements.keys).filterNot {
-                        previousUpdatedElements[it] equalsIgnoringVersioning updatedElements[it]
-                    }
-                ).toSet()
+            val changedElementKeys = (
+                elementKeysNotDeletedAnymore +
+                (updatedElements.keys + previousUpdatedElements.keys).filterNot {
+                    previousUpdatedElements[it] equalsIgnoringVersioning updatedElements[it]
+                }
+            ).toSet()
 
-            mapData.putAll(getAll(changedElements), getGeometries(changedElements))
+            val changedElements = getAll(changedElementKeys)
+
+            val missingElementKeys = changedElementKeys - changedElements.map { ElementKey(it.type, it.id) }
+
+            elementsDeletedNow = deletedElements - previousDeletedElements + missingElementKeys
+
+            mapData.putAll(changedElements, getGeometries(changedElementKeys))
         }
 
         callOnUpdated(updated = mapData, deleted = elementsDeletedNow)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -374,11 +374,10 @@ class MapDataWithEditsSource internal constructor(
 
     private fun applyEdit(edit: ElementEdit): MapDataUpdates? = synchronized(this) {
         val idProvider = elementEditsController.getIdProvider(edit.id)
-        val editElement = get(edit.elementType, edit.elementId)
 
         val mapDataChanges: MapDataChanges
         try {
-            mapDataChanges = edit.action.createUpdates(edit.originalElement, editElement, this, idProvider)
+            mapDataChanges = edit.action.createUpdates(this, idProvider)
         } catch (e: ConflictException) {
             return null
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -180,6 +180,11 @@ class MapDataWithEditsSource internal constructor(
         return updatedElements[key] ?: mapDataController.get(type, id)
     }
 
+    fun getAll(keys: Collection<ElementKey>): List<Element> = synchronized(this) {
+        val originalKeys = keys.filter { !deletedElements.contains(it) && !updatedElements.containsKey(it) }
+        return keys.mapNotNull { updatedElements[it] } + mapDataController.getAll(originalKeys)
+    }
+
     fun getGeometry(type: ElementType, id: Long): ElementGeometry? = synchronized(this) {
         val key = ElementKey(type, id)
         if (deletedElements.contains(key)) return null

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
@@ -4,7 +4,6 @@ import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
 import de.westnordost.streetcomplete.data.osm.edits.IsActionRevertable
 import de.westnordost.streetcomplete.data.osm.edits.NewElementsCount
-import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
@@ -27,8 +26,6 @@ data class CreateNodeAction(
     override val newElementsCount get() = NewElementsCount(1, 0, 0)
 
     override fun createUpdates(
-        originalElement: Element,
-        element: Element?,
         mapDataRepository: MapDataRepository,
         idProvider: ElementIdProvider
     ): MapDataChanges {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
@@ -62,8 +62,11 @@ data class CreateNodeAction(
         return MapDataChanges(creations = listOf(newNode), modifications = editedWays)
     }
 
-    override fun createReverted(): ElementEditAction =
-        RevertCreateNodeAction(insertIntoWays.map { it.wayId })
+    override fun createReverted(idProvider: ElementIdProvider): ElementEditAction =
+        RevertCreateNodeAction(
+            Node(idProvider.nextNodeId(), position, tags, 1, Instant.now().toEpochMilli()),
+            insertIntoWays.map { it.wayId }
+        )
 }
 
 /** Inserting the node into the given [wayId] in between the nodes at the given positions

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeAction.kt
@@ -9,14 +9,19 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.data.upload.ConflictException
+import de.westnordost.streetcomplete.util.ktx.equalsInOsm
 import kotlinx.serialization.Serializable
+import java.lang.System.currentTimeMillis
 import java.time.Instant
 
-/** Action that creates a (free-floating) node. */
+/** Action that creates a node and optionally inserts it as a vertex into the given way(s) */
 @Serializable
 data class CreateNodeAction(
     val position: LatLon,
-    val tags: Map<String, String>
+    val tags: Map<String, String>,
+    val insertIntoWays: List<InsertIntoWayAt> = emptyList()
 ) : ElementEditAction, IsActionRevertable {
 
     override val newElementsCount get() = NewElementsCount(1, 0, 0)
@@ -27,9 +32,46 @@ data class CreateNodeAction(
         mapDataRepository: MapDataRepository,
         idProvider: ElementIdProvider
     ): MapDataChanges {
-        val node = Node(idProvider.nextNodeId(), position, tags, 1, Instant.now().toEpochMilli())
-        return MapDataChanges(creations = listOf(node))
+        val newNode = Node(idProvider.nextNodeId(), position, tags, 1, Instant.now().toEpochMilli())
+
+        // inserting node into way(s)
+        val editedWays = ArrayList<Way>(insertIntoWays.size)
+        for (insertIntoWay in insertIntoWays) {
+            val wayId = insertIntoWay.wayId
+            val completeWay = mapDataRepository.getWayComplete(wayId)
+
+            val way = completeWay?.getWay(wayId)
+                ?: throw ConflictException("Way #$wayId has been deleted")
+
+            val positions = way.nodeIds.map { nodeId -> completeWay.getNode(nodeId)!!.position }
+
+            val node1Index = positions.indexOfFirst { it.equalsInOsm(insertIntoWay.pos1) }
+            if (node1Index == -1) throw ConflictException("Node in way at insert position has been moved or deleted")
+
+            // ensures that node 2 is after node 1 (e.g. when node 2 is the first and last node in a closed way)
+            val node2Index = positions
+                .subList(node1Index + 1, positions.size)
+                .indexOfFirst { it.equalsInOsm(insertIntoWay.pos2) }
+            if (node2Index == -1) throw ConflictException("Node in way at insert position has been moved or deleted")
+            // index 0 because of subList starting at node1Index + 1
+            if (node2Index != 0) throw ConflictException("Other nodes have been inserted into the way")
+
+            val nodeIds = way.nodeIds.toMutableList()
+            nodeIds.add(node1Index + 1, newNode.id)
+
+            editedWays.add(way.copy(nodeIds = nodeIds, timestampEdited = currentTimeMillis()))
+        }
+
+        return MapDataChanges(creations = listOf(newNode), modifications = editedWays)
     }
 
-    override fun createReverted(): ElementEditAction = RevertCreateNodeAction
+    override fun createReverted(): ElementEditAction =
+        RevertCreateNodeAction(insertIntoWays.map { it.wayId })
 }
+
+/** Inserting the node into the given [wayId] in between the nodes at the given positions
+ *  [pos1] and [pos2].
+ *  Not the node ids but the positions are given for better conflict checking - if any of the two
+ *  nodes have been moved, that's a conflict. */
+@Serializable
+data class InsertIntoWayAt(val wayId: Long, val pos1: LatLon, val pos2: LatLon)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeAction.kt
@@ -54,19 +54,3 @@ data class RevertCreateNodeAction(
         return MapDataChanges(modifications = editedWays, deletions = listOf(currentNode))
     }
 }
-
-// TODO id updates?!: way ids in CreateNodeAction.insertIntoWays and RevertCreateNodeAction.insertedIntoWayIds
-/* need to be updated... when a way with e.g. id=-1 has been uploaded
- ..but they are somewhere in the action (persisted as json), not in the edit...
-
- in current architecture, what would need to be done is to fetch every element edit and ask its
- action to update the ids...
-
- possible solutions:
-
- - maintain a "dictionary" of negative ids to real ids; use that dictionary at a critical point to
-   translate the old ids to the new ids - i.e. do not even change the ids in the database
-
- - make element edits dao into two tables, so that it is possible that several different element id+types
-   refer to the same edit(?)
-*/

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeAction.kt
@@ -55,5 +55,6 @@ data class DeletePoiNodeAction(
         }
     }
 
-    override fun createReverted(): ElementEditAction = RevertDeletePoiNodeAction(originalNode)
+    override fun createReverted(idProvider: ElementIdProvider): ElementEditAction =
+        RevertDeletePoiNodeAction(originalNode)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeAction.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.upload.ConflictException
 import kotlinx.serialization.Serializable
+import java.lang.System.currentTimeMillis
 
 /** Action that deletes a POI node.
  *
@@ -45,10 +46,11 @@ object DeletePoiNodeAction : ElementEditAction, IsActionRevertable {
         }
         // if it is a vertex in a way or has a role in a relation: just clear the tags then
         else {
-            MapDataChanges(modifications = listOf(node.copy(
+            val emptyNode = node.copy(
                 tags = emptyMap(),
-                timestampEdited = System.currentTimeMillis()
-            )))
+                timestampEdited = currentTimeMillis()
+            )
+            MapDataChanges(modifications = listOf(emptyNode))
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsAction.kt
@@ -40,7 +40,7 @@ data class UpdateElementTagsAction(
         return MapDataChanges(modifications = listOf(currentElement.changesApplied(changes)))
     }
 
-    override fun createReverted(): ElementEditAction =
+    override fun createReverted(idProvider: ElementIdProvider): ElementEditAction =
         RevertUpdateElementTagsAction(originalElement, changes.reversed())
 
     fun isReverseOf(other: UpdateElementTagsAction): Boolean =

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsAction.kt
@@ -19,26 +19,29 @@ import kotlinx.serialization.Serializable
  *  the tag update made may not be correct anymore, so that is considered a conflict.
  *  */
 @Serializable
-data class UpdateElementTagsAction(val changes: StringMapChanges) : ElementEditAction, IsActionRevertable {
+data class UpdateElementTagsAction(
+    val originalElement: Element,
+    val changes: StringMapChanges
+) : ElementEditAction, IsActionRevertable {
 
     override val newElementsCount get() = NewElementsCount(0, 0, 0)
 
     override fun createUpdates(
-        originalElement: Element,
-        element: Element?,
         mapDataRepository: MapDataRepository,
         idProvider: ElementIdProvider
     ): MapDataChanges {
-        if (element == null) throw ConflictException("Element deleted")
-        if (isGeometrySubstantiallyDifferent(originalElement, element)) {
+        val currentElement = mapDataRepository.get(originalElement.type, originalElement.id)
+            ?: throw ConflictException("Element deleted")
+
+        if (isGeometrySubstantiallyDifferent(originalElement, currentElement)) {
             throw ConflictException("Element geometry changed substantially")
         }
 
-        return MapDataChanges(modifications = listOf(element.changesApplied(changes)))
+        return MapDataChanges(modifications = listOf(currentElement.changesApplied(changes)))
     }
 
     override fun createReverted(): ElementEditAction =
-        RevertUpdateElementTagsAction(changes.reversed())
+        RevertUpdateElementTagsAction(originalElement, changes.reversed())
 
     fun isReverseOf(other: UpdateElementTagsAction): Boolean =
         changes.reversed() == other.changes

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
@@ -4,11 +4,9 @@ import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
 import de.westnordost.streetcomplete.data.osm.edits.upload.changesets.OpenChangesetsManager
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApi
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
-import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
 import de.westnordost.streetcomplete.data.upload.ConflictException
 
@@ -23,14 +21,8 @@ class ElementEditUploader(
      *  @throws ConflictException if element has been changed server-side in an incompatible way
      *  */
     fun upload(edit: ElementEdit, getIdProvider: () -> ElementIdProvider): MapDataUpdates {
-        val remoteChanges by lazy {
-            val element = mapDataApi.fetch(edit.elementType, edit.elementId)
-            edit.action.createUpdates(edit.originalElement, element, mapDataApi, getIdProvider())
-        }
-        val localChanges by lazy {
-            val element = mapDataController.fetch(edit.elementType, edit.elementId)
-            edit.action.createUpdates(edit.originalElement, element, mapDataController, getIdProvider())
-        }
+        val remoteChanges by lazy { edit.action.createUpdates(mapDataApi, getIdProvider()) }
+        val localChanges by lazy { edit.action.createUpdates(mapDataController, getIdProvider()) }
 
         val mustUseRemoteData = edit.action::class in ApplicationConstants.EDIT_ACTIONS_NOT_ALLOWED_TO_USE_LOCAL_CHANGES
 
@@ -61,11 +53,5 @@ class ElementEditUploader(
             if (newChangeset) changesetManager.createChangeset(edit.type, edit.source)
             else              changesetManager.getOrCreateChangeset(edit.type, edit.source)
         return mapDataApi.uploadChanges(changesetId, mapDataChanges, ApplicationConstants.IGNORED_RELATION_TYPES)
-    }
-
-    private fun MapDataRepository.fetch(elementType: ElementType, elementId: Long) = when (elementType) {
-        ElementType.NODE     -> getNode(elementId)
-        ElementType.WAY      -> getWay(elementId)
-        ElementType.RELATION -> getRelation(elementId)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -57,7 +57,7 @@ class ElementEditsUploader(
             Log.d(TAG, "Uploaded a $editActionClassName")
             uploadedChangeListener?.onUploaded(edit.type.name, edit.position)
 
-            elementEditsController.markSynced(edit, updates)
+            elementEditsController.markSynced(edit)
             mapDataController.updateAll(updates)
             noteEditsController.updateElementIds(updates.idUpdates)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -5,12 +5,10 @@ import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsController
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
 import de.westnordost.streetcomplete.data.osm.edits.IsRevertAction
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapData
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApi
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
-import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
 import de.westnordost.streetcomplete.data.osm.mapdata.MutableMapData
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsController
 import de.westnordost.streetcomplete.data.upload.ConflictException
@@ -73,15 +71,6 @@ class ElementEditsUploader(
             elementEditsController.markSyncFailed(edit)
         }
     }
-
-    private suspend fun fetchElementComplete(elementType: ElementType, elementId: Long): MapData? =
-        withContext(Dispatchers.IO) {
-            when (elementType) {
-                ElementType.NODE -> mapDataApi.getNode(elementId)?.let { MutableMapData(listOf(it)) }
-                ElementType.WAY -> mapDataApi.getWayComplete(elementId)
-                ElementType.RELATION -> mapDataApi.getRelationComplete(elementId)
-            }
-        }
 
     companion object {
         private const val TAG = "ElementEditsUploader"

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -71,14 +71,6 @@ class ElementEditsUploader(
             uploadedChangeListener?.onDiscarded(edit.type.name, edit.position)
 
             elementEditsController.markSyncFailed(edit)
-
-            val mapData = fetchElementComplete(edit.elementType, edit.elementId)
-            if (mapData != null) {
-                mapDataController.updateAll(MapDataUpdates(updated = mapData.toList()))
-            } else {
-                val elementKey = ElementKey(edit.elementType, edit.elementId)
-                mapDataController.updateAll(MapDataUpdates(deleted = listOf(elementKey)))
-            }
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -160,8 +160,6 @@ class MapDataController internal constructor(
         mapData.addAll(ways)
     }
 
-    fun get(type: ElementType, id: Long): Element? = cache.getElement(type, id, elementDB::get)
-
     fun getGeometry(type: ElementType, id: Long): ElementGeometry? = cache.getGeometry(type, id, geometryDB::get)
 
     fun getGeometries(keys: Collection<ElementKey>): List<ElementGeometryEntry> = cache.getGeometries(keys, geometryDB::getAllEntries)
@@ -185,9 +183,9 @@ class MapDataController internal constructor(
         )
     }
 
-    override fun getNode(id: Long): Node? = get(ElementType.NODE, id) as? Node
-    override fun getWay(id: Long): Way? = get(ElementType.WAY, id) as? Way
-    override fun getRelation(id: Long): Relation? = get(ElementType.RELATION, id) as? Relation
+    override fun getNode(id: Long): Node? = cache.getElement(ElementType.NODE, id, elementDB::get) as? Node
+    override fun getWay(id: Long): Way? = cache.getElement(ElementType.WAY, id, elementDB::get) as? Way
+    override fun getRelation(id: Long): Relation? = cache.getElement(ElementType.RELATION, id, elementDB::get) as? Relation
 
     fun getAll(elementKeys: Collection<ElementKey>): List<Element> =
         cache.getElements(elementKeys, elementDB::getAll)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.data.osm.mapdata
 
 import android.util.Log
+import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementKey
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsController
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
@@ -104,7 +105,8 @@ class MapDataController internal constructor(
 
             geometryEntries = createGeometries(elements, mapData)
 
-            val newElementKeys = mapDataUpdates.idUpdates.map { ElementKey(it.elementType, it.newElementId) }
+            val createdElementsKeys = mapDataUpdates.idUpdates
+                .map { CreatedElementKey(it.elementType, it.oldElementId, it.newElementId) }
             val oldElementKeys = mapDataUpdates.idUpdates.map { ElementKey(it.elementType, it.oldElementId) }
             deletedKeys = mapDataUpdates.deleted + oldElementKeys
 
@@ -114,7 +116,7 @@ class MapDataController internal constructor(
             geometryDB.deleteAll(deletedKeys)
             geometryDB.putAll(geometryEntries)
             elementDB.putAll(elements)
-            createdElementsController.putAll(newElementKeys)
+            createdElementsController.putAll(createdElementsKeys)
         }
 
         val mapDataWithGeom = MutableMapDataWithGeometry(elements, geometryEntries)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataRepository.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataRepository.kt
@@ -12,4 +12,10 @@ interface MapDataRepository {
     fun getRelationsForNode(id: Long): Collection<Relation>
     fun getRelationsForWay(id: Long): Collection<Relation>
     fun getRelationsForRelation(id: Long): Collection<Relation>
+
+    fun get(elementType: ElementType, elementId: Long) = when (elementType) {
+        ElementType.NODE     -> getNode(elementId)
+        ElementType.WAY      -> getWay(elementId)
+        ElementType.RELATION -> getRelation(elementId)
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataRepository.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataRepository.kt
@@ -13,9 +13,9 @@ interface MapDataRepository {
     fun getRelationsForWay(id: Long): Collection<Relation>
     fun getRelationsForRelation(id: Long): Collection<Relation>
 
-    fun get(elementType: ElementType, elementId: Long) = when (elementType) {
-        ElementType.NODE     -> getNode(elementId)
-        ElementType.WAY      -> getWay(elementId)
-        ElementType.RELATION -> getRelation(elementId)
+    fun get(type: ElementType, id: Long) = when (type) {
+        ElementType.NODE     -> getNode(id)
+        ElementType.WAY      -> getWay(id)
+        ElementType.RELATION -> getRelation(id)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -366,7 +366,7 @@ abstract class AbstractOverlayForm :
         val element = element ?: Node(0, geometry.center)
 
         withContext(Dispatchers.IO) {
-            addElementEditsController.add(overlay, element, geometry, "survey", action)
+            addElementEditsController.add(overlay, geometry, "survey", action)
         }
         listener?.onEdited(overlay, element, geometry)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlayForm.kt
@@ -166,7 +166,7 @@ class AddressOverlayForm : AbstractOverlayForm() {
         streetOrPlaceName?.applyTo(tagChanges)
 
         if (element != null) {
-            applyEdit(UpdateElementTagsAction(tagChanges.create()))
+            applyEdit(UpdateElementTagsAction(element!!, tagChanges.create()))
         } else {
             applyEdit(CreateNodeAction(geometry.center, tagChanges))
         }
@@ -201,7 +201,7 @@ class AddressOverlayForm : AbstractOverlayForm() {
     private fun removeAddress() {
         val element = element!!
         if (element is Node && element.tags.all { isAddressTag(it.key, it.value) }) {
-            applyEdit(DeletePoiNodeAction)
+            applyEdit(DeletePoiNodeAction(element))
         } else {
             val tagChanges = StringMapChangesBuilder(element.tags)
             for (tag in tagChanges) {
@@ -209,7 +209,7 @@ class AddressOverlayForm : AbstractOverlayForm() {
                     tagChanges.remove(tag.key)
                 }
             }
-            applyEdit(UpdateElementTagsAction(tagChanges.create()))
+            applyEdit(UpdateElementTagsAction(element, tagChanges.create()))
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/shops/ShopsOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/shops/ShopsOverlayForm.kt
@@ -146,7 +146,7 @@ class ShopsOverlayForm : AbstractOverlayForm() {
         }
 
         if (element != null) {
-            applyEdit(UpdateElementTagsAction(tagChanges.create()))
+            applyEdit(UpdateElementTagsAction(element!!, tagChanges.create()))
         } else {
             applyEdit(CreateNodeAction(geometry.center, tagChanges))
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlayForm.kt
@@ -48,7 +48,7 @@ class SidewalkOverlayForm : AStreetSideSelectOverlayForm<Sidewalk>() {
         val sidewalks = LeftAndRightSidewalk(streetSideSelect.left?.value, streetSideSelect.right?.value)
         val tagChanges = StringMapChangesBuilder(element!!.tags)
         sidewalks.applyTo(tagChanges)
-        applyEdit(UpdateElementTagsAction(tagChanges.create()))
+        applyEdit(UpdateElementTagsAction(element!!, tagChanges.create()))
     }
 
     override fun hasChanges(): Boolean =

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlayForm.kt
@@ -175,7 +175,7 @@ class StreetParkingOverlayForm : AStreetSideSelectOverlayForm<StreetParking>() {
         val parking = LeftAndRightStreetParking(streetSideSelect.left?.value, streetSideSelect.right?.value)
         val tagChanges = StringMapChangesBuilder(element!!.tags)
         parking.applyTo(tagChanges)
-        applyEdit(UpdateElementTagsAction(tagChanges.create()))
+        applyEdit(UpdateElementTagsAction(element!!, tagChanges.create()))
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/way_lit/WayLitOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/way_lit/WayLitOverlayForm.kt
@@ -37,6 +37,6 @@ class WayLitOverlayForm : AImageSelectOverlayForm<LitStatus>() {
     override fun onClickOk() {
         val tagChanges = StringMapChangesBuilder(element!!.tags)
         selectedItem!!.value!!.applyTo(tagChanges)
-        applyEdit(UpdateElementTagsAction(tagChanges.create()))
+        applyEdit(UpdateElementTagsAction(element!!, tagChanges.create()))
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -25,6 +25,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.HideOsmQuestController
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -197,7 +198,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
 
     protected fun applyAnswer(answer: T) {
         viewLifecycleScope.launch {
-            solve(UpdateElementTagsAction(createQuestChanges(answer)))
+            solve(UpdateElementTagsAction(element, createQuestChanges(answer)))
         }
     }
 
@@ -243,7 +244,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
         viewLifecycleScope.launch {
             val builder = StringMapChangesBuilder(element.tags)
             builder.replaceShop(tags)
-            solve(UpdateElementTagsAction(builder.create()))
+            solve(UpdateElementTagsAction(element, builder.create()))
         }
     }
 
@@ -257,7 +258,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
 
     private fun onDeletePoiNodeConfirmed() {
         viewLifecycleScope.launch {
-            solve(DeletePoiNodeAction)
+            solve(DeletePoiNodeAction(element as Node))
         }
     }
 
@@ -273,7 +274,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
                 val text = createNoteTextForTooLongTags(questTitle, element.type, element.id, action.changes.changes)
                 noteEditsController.add(0, NoteEditAction.CREATE, geometry.center, text)
             } else {
-                addElementEditsController.add(osmElementQuestType, element, geometry, "survey", action)
+                addElementEditsController.add(osmElementQuestType, geometry, "survey", action)
             }
         }
         listener?.onEdited(osmElementQuestType, element, geometry)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/SplitWayFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/SplitWayFragment.kt
@@ -152,9 +152,9 @@ class SplitWayFragment :
         if (splits.size <= 2 || confirmManySplits()) {
             val location = listOfNotNull(listener?.displayedMapLocation)
             if (checkIsSurvey(requireContext(), geometry, location)) {
-                val action = SplitWayAction(ArrayList(splits.map { it.first }))
+                val action = SplitWayAction(way, ArrayList(splits.map { it.first }))
                 withContext(Dispatchers.IO) {
-                    elementEditsController.add(editType, way, geometry, "survey", action)
+                    elementEditsController.add(editType, geometry, "survey", action)
                 }
                 listener?.onSplittedWay(editType, way, geometry)
                 return

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
@@ -91,7 +91,7 @@ class UndoDialog(
 
     private suspend fun Edit.getTitle(): CharSequence = when (this) {
         is ElementEdit -> {
-            if (type is QuestType) getQuestTitle(type, originalElement.tags)
+            if (type is QuestType) getQuestTitle(type, emptyMap())
             else context.resources.getText(type.title)
         }
         is NoteEdit -> {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
@@ -147,7 +147,6 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
         f.addElementEditsController = object : AddElementEditsController {
             override fun add(
                 type: ElementEditType,
-                element: Element,
                 geometry: ElementGeometry,
                 source: String,
                 action: ElementEditAction,

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsControllerTest.kt
@@ -1,0 +1,42 @@
+package de.westnordost.streetcomplete.data.osm.created_elements
+
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.testutils.mock
+import de.westnordost.streetcomplete.testutils.on
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class CreatedElementsControllerTest {
+
+    private lateinit var ctrl: CreatedElementsController
+    private lateinit var db: CreatedElementsDao
+
+    @Before fun setUp() {
+        db = mock()
+        ctrl = CreatedElementsController(db)
+    }
+
+    @Test fun `contains works with old and new ids`() {
+        on(db.getAll()).thenReturn(listOf(
+            CreatedElementKey(ElementType.NODE, 1, 123)
+        ))
+        assertTrue(ctrl.contains(ElementType.NODE, 1))
+        assertTrue(ctrl.contains(ElementType.NODE, 123))
+        assertFalse(ctrl.contains(ElementType.NODE, 124))
+        assertFalse(ctrl.contains(ElementType.WAY, 1))
+    }
+
+    @Test fun `getId works with old and new ids`() {
+        on(db.getAll()).thenReturn(listOf(
+            CreatedElementKey(ElementType.NODE, 1, 123)
+        ))
+        assertEquals(123, ctrl.getId(ElementType.NODE, 1))
+        assertEquals(123, ctrl.getId(ElementType.NODE, 123))
+        assertNull(ctrl.getId(ElementType.NODE, 124))
+        assertNull(ctrl.getId(ElementType.WAY, 1))
+    }
+}

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsControllerTest.kt
@@ -34,8 +34,8 @@ internal class CreatedElementsControllerTest {
         on(db.getAll()).thenReturn(listOf(
             CreatedElementKey(ElementType.NODE, 1, 123)
         ))
-        assertEquals(123, ctrl.getId(ElementType.NODE, 1))
-        assertEquals(123, ctrl.getId(ElementType.NODE, 123))
+        assertEquals(123L, ctrl.getId(ElementType.NODE, 1))
+        assertEquals(123L, ctrl.getId(ElementType.NODE, 123))
         assertNull(ctrl.getId(ElementType.NODE, 124))
         assertNull(ctrl.getId(ElementType.WAY, 1))
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
@@ -13,7 +13,6 @@ import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.edit
 import de.westnordost.streetcomplete.testutils.eq
 import de.westnordost.streetcomplete.testutils.mock
-import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import org.junit.Before
@@ -45,7 +44,7 @@ class ElementEditsControllerTest {
         val action = mock<ElementEditAction>()
         on(action.newElementsCount).thenReturn(NewElementsCount(1, 2, 3))
 
-        ctrl.add(QUEST_TYPE, node(1), pGeom(), "test", action)
+        ctrl.add(QUEST_TYPE, pGeom(), "test", action)
 
         verify(db).add(any())
         verify(idProvider).assign(0L, 1, 2, 3)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.edit
 import de.westnordost.streetcomplete.testutils.eq
 import de.westnordost.streetcomplete.testutils.mock
+import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import org.junit.Before
@@ -67,24 +68,17 @@ class ElementEditsControllerTest {
     @Test fun synced() {
         val edit = edit(action = mock())
 
-        val idUpdates = listOf(
-            ElementIdUpdate(NODE, -1, 2),
-            ElementIdUpdate(NODE, -8, 20),
-        )
-        val updates = MapDataUpdates(idUpdates = idUpdates)
+        ctrl.markSynced(edit)
 
-        ctrl.markSynced(edit, updates)
-
-        verify(db).updateElementId(NODE, -1, 2)
-        verify(db).updateElementId(NODE, -8, 20)
         verify(db).markSynced(edit.id)
         verify(idProvider).delete(edit.id)
         verify(listener).onSyncedEdit(edit)
     }
 
     @Test fun `undo unsynced`() {
+        val node = node()
         val edit = edit(
-            action = UpdateElementTagsAction(StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+            action = UpdateElementTagsAction(node, StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
             isSynced = false
         )
 
@@ -98,46 +92,10 @@ class ElementEditsControllerTest {
         verify(listener).onDeletedEdits(listOf(edit))
     }
 
-    @Test fun `delete edits based on the the one being undone`() {
-        val edit1 = edit(action = mock(), id = 1L)
-        val edit2 = edit(action = mock(), id = 2L)
-        val edit3 = edit(action = mock(), id = 3L)
-        val edit4 = edit(action = mock(), id = 4L)
-        val edit5 = edit(action = mock(), id = 5L)
-
-        on(idProvider.get(1L)).thenReturn(ElementIdProvider(listOf(
-            ElementKey(NODE, -1),
-            ElementKey(NODE, -2),
-        )))
-        on(idProvider.get(2L)).thenReturn(ElementIdProvider(listOf(
-            ElementKey(NODE, -3),
-        )))
-        on(idProvider.get(3L)).thenReturn(ElementIdProvider(listOf()))
-        on(idProvider.get(4L)).thenReturn(ElementIdProvider(listOf()))
-        on(idProvider.get(5L)).thenReturn(ElementIdProvider(listOf()))
-
-        on(db.getByElement(NODE, -1)).thenReturn(listOf(edit2, edit3))
-        on(db.getByElement(NODE, -2)).thenReturn(listOf(edit4))
-        on(db.getByElement(NODE, -3)).thenReturn(listOf(edit5))
-
-        on(db.get(1L)).thenReturn(edit1)
-        on(db.get(2L)).thenReturn(edit2)
-        on(db.get(3L)).thenReturn(edit3)
-        on(db.get(4L)).thenReturn(edit4)
-        on(db.get(5L)).thenReturn(edit5)
-
-        ctrl.undo(edit1)
-
-        val deletedEditIds = listOf(5L, 2L, 3L, 4L, 1L)
-
-        verify(db).deleteAll(eq(deletedEditIds))
-        verify(idProvider).deleteAll(eq(deletedEditIds))
-        verify(listener).onDeletedEdits(listOf(edit5, edit2, edit3, edit4, edit1))
-    }
-
     @Test fun `undo synced`() {
+        val node = node()
         val edit = edit(
-            action = UpdateElementTagsAction(StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+            action = UpdateElementTagsAction(node, StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
             isSynced = true
         )
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -214,8 +214,8 @@ class MapDataWithEditsSourceTest {
         val action3 = mock<ElementEditAction>()
         on(action3.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(
-            edit(element = nd, action = action2),
-            edit(element = nd, action = action3),
+            edit(action = action2),
+            edit(action = action3),
         ))
 
         val s = create()
@@ -244,7 +244,7 @@ class MapDataWithEditsSourceTest {
 
         val action = mock<ElementEditAction>()
         on(action.createUpdates(any(), any())).thenThrow(ConflictException())
-        on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(element = nd, action = action)))
+        on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(action = action)))
 
         val s = create()
         assertEquals(nd, s.get(NODE, 1))
@@ -330,8 +330,8 @@ class MapDataWithEditsSourceTest {
         val action3 = mock<ElementEditAction>()
         on(action3.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(
-            edit(element = nd, action = action2),
-            edit(element = nd, action = action3)
+            edit(action = action2),
+            edit(action = action3)
         ))
 
         val s = create()
@@ -1105,10 +1105,7 @@ class MapDataWithEditsSourceTest {
     ) {
         val action = mock<ElementEditAction>()
         on(action.createUpdates(any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
-        on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(
-            element = node(-1),
-            action = action
-        )))
+        on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(action = action)))
     }
 
     private fun thereAreNoMapDataChanges() {
@@ -1122,10 +1119,7 @@ class MapDataWithEditsSourceTest {
     ) {
         val action = mock<ElementEditAction>()
         on(action.createUpdates(any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
-        editsListener.onAddedEdit(edit(
-            element = node(-1),
-            action = action
-        ))
+        editsListener.onAddedEdit(edit(action = action))
     }
 
     private fun editsControllerNotifiesDeletedEdit(element: Element, createdElementKeys: List<ElementKey>) {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -207,9 +207,9 @@ class MapDataWithEditsSourceTest {
         originalElementsAre(nd)
 
         val action2 = mock<ElementEditAction>()
-        on(action2.createUpdates(any(), eq(nd), any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd2)))
+        on(action2.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd2)))
         val action3 = mock<ElementEditAction>()
-        on(action3.createUpdates(any(), eq(nd2), any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
+        on(action3.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(
             edit(element = nd, action = action2),
             edit(element = nd, action = action3),
@@ -238,7 +238,7 @@ class MapDataWithEditsSourceTest {
         originalElementsAre(nd)
 
         val action = mock<ElementEditAction>()
-        on(action.createUpdates(eq(nd), eq(nd), any(), any())).thenThrow(ConflictException())
+        on(action.createUpdates(any(), any())).thenThrow(ConflictException())
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(element = nd, action = action)))
 
         val s = create()
@@ -308,9 +308,9 @@ class MapDataWithEditsSourceTest {
         originalGeometriesAre(ElementGeometryEntry(NODE, 1, p))
 
         val action2 = mock<ElementEditAction>()
-        on(action2.createUpdates(any(), eq(nd), any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd2)))
+        on(action2.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd2)))
         val action3 = mock<ElementEditAction>()
-        on(action3.createUpdates(any(), eq(nd2), any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
+        on(action3.createUpdates(any(), any())).thenReturn(MapDataChanges(modifications = listOf(nd3)))
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(
             edit(element = nd, action = action2),
             edit(element = nd, action = action3)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.edits
 
+import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsSource
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryEntry
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
@@ -39,6 +40,7 @@ import org.mockito.Mockito.verifyNoInteractions
 class MapDataWithEditsSourceTest {
 
     private lateinit var editsCtrl: ElementEditsController
+    private lateinit var createdElementsSource: CreatedElementsSource
     private lateinit var mapDataCtrl: MapDataController
     private val geometryCreator = ElementGeometryCreator()
 
@@ -51,6 +53,7 @@ class MapDataWithEditsSourceTest {
     fun setUp() {
         editsCtrl = mock()
         mapDataCtrl = mock()
+        createdElementsSource = mock()
         mapData = MutableMapDataWithGeometry()
         // a trick to get the edit action to apply to anything
         mapData.putElement(node(-1, pos = p(60.0, 60.0)))
@@ -1053,7 +1056,7 @@ class MapDataWithEditsSourceTest {
 
     //endregion
 
-    private fun create() = MapDataWithEditsSource(mapDataCtrl, editsCtrl, geometryCreator)
+    private fun create() = MapDataWithEditsSource(mapDataCtrl, editsCtrl, geometryCreator, createdElementsSource)
 
     /** Feed mock MapDataController the data */
     private fun originalGeometriesAre(vararg elementGeometryEntries: ElementGeometryEntry) {
@@ -1083,7 +1086,7 @@ class MapDataWithEditsSourceTest {
         deletions: Collection<Element> = emptyList()
     ) {
         val action = mock<ElementEditAction>()
-        on(action.createUpdates(any(), any(), any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
+        on(action.createUpdates(any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
         on(editsCtrl.getAllUnsynced()).thenReturn(listOf(edit(
             element = node(-1),
             action = action
@@ -1100,7 +1103,7 @@ class MapDataWithEditsSourceTest {
         deletions: Collection<Element> = emptyList()
     ) {
         val action = mock<ElementEditAction>()
-        on(action.createUpdates(any(), any(), any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
+        on(action.createUpdates(any(), any())).thenReturn(MapDataChanges(creations, modifications, deletions))
         editsListener.onAddedEdit(edit(
             element = node(-1),
             action = action

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -164,7 +164,7 @@ class MapDataWithEditsSourceTest {
         }
     }
 
-    //region get
+    //region get and getAll
 
     @Test
     fun `get returns nothing`() {
@@ -173,6 +173,7 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertNull(s.get(NODE, 1))
+        assertEquals(emptyList<Element>(), s.getAll(listOf(ElementKey(NODE, 1))))
     }
 
     @Test
@@ -184,6 +185,7 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertEquals(nd, s.get(NODE, 1))
+        assertEquals(listOf(nd), s.getAll(listOf(ElementKey(NODE, 1))))
     }
 
     @Test
@@ -196,6 +198,7 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertEquals(nd2, s.get(NODE, 1))
+        assertEquals(listOf(nd2), s.getAll(listOf(ElementKey(NODE, 1))))
     }
 
     @Test
@@ -217,6 +220,7 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertEquals(nd3, s.get(NODE, 1))
+        assertEquals(listOf(nd3), s.getAll(listOf(ElementKey(NODE, 1))))
     }
 
     @Test
@@ -229,6 +233,7 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertNull(s.get(NODE, 1))
+        assertEquals(listOf<Element>(), s.getAll(listOf(ElementKey(NODE, 1))))
     }
 
     @Test
@@ -243,11 +248,24 @@ class MapDataWithEditsSourceTest {
 
         val s = create()
         assertEquals(nd, s.get(NODE, 1))
+        assertEquals(listOf(nd), s.getAll(listOf(ElementKey(NODE, 1))))
+    }
+
+    @Test
+    fun `getAll returns mix of original and updated elements`() {
+        val nd = node(1)
+        val nd2 = node(2)
+
+        originalElementsAre(nd)
+        mapDataChangesAre(modifications = listOf(nd2))
+
+        val s = create()
+        assertEquals(listOf(nd, nd2), s.getAll(listOf(ElementKey(NODE, 1), ElementKey(NODE, 2))))
     }
 
     //endregion
 
-    //region getGeometry
+    //region getGeometry and getGeometries
 
     @Test
     fun `getGeometry returns nothing`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
@@ -31,10 +31,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("amenity" to "atm")
         val position = LatLon(12.0, 34.0)
-        val dummyNode = node(0, position, tags, 1)
         val action = CreateNodeAction(position, tags)
 
-        val data = action.createUpdates(dummyNode, null, repos, provider)
+        val data = action.createUpdates(repos, provider)
 
         assertTrue(data.deletions.isEmpty())
         assertTrue(data.modifications.isEmpty())
@@ -59,10 +58,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 1.5)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos2)))
 
-        val data = action.createUpdates(dummyNode, null, repos, provider)
+        val data = action.createUpdates(repos, provider)
 
         val createdNode = data.creations.single() as Node
         assertEquals(-123, createdNode.id)
@@ -85,10 +83,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 1.5)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos2)))
 
-        action.createUpdates(dummyNode, null, repos, provider)
+        action.createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
@@ -106,10 +103,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 1.5)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos3)))
 
-        action.createUpdates(dummyNode, null, repos, provider)
+        action.createUpdates(repos, provider)
     }
 
     @Test fun `no conflict if node 2 is first node within closed way`() {
@@ -129,7 +125,7 @@ internal class CreateNodeActionTest {
         val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos3, pos1)))
 
-        action.createUpdates(dummyNode, null, repos, provider)
+        action.createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
@@ -146,10 +142,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 1.5)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, oldPos1, pos2)))
 
-        action.createUpdates(dummyNode, null, repos, provider)
+        action.createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
@@ -166,10 +161,9 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 1.5)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, oldPos2)))
 
-        action.createUpdates(dummyNode, null, repos, provider)
+        action.createUpdates(repos, provider)
     }
 
     @Test fun `create node and add to ways`() {
@@ -190,13 +184,12 @@ internal class CreateNodeActionTest {
 
         val tags = mapOf("entrance" to "yes")
         val position = LatLon(0.0, 0.0)
-        val dummyNode = node(0, position, tags)
         val action = CreateNodeAction(position, tags, listOf(
             InsertIntoWayAt(way1.id, pos1, pos2),
             InsertIntoWayAt(way2.id, pos3, pos4),
         ))
 
-        val data = action.createUpdates(dummyNode, null, repos, provider)
+        val data = action.createUpdates(repos, provider)
 
         val createdNode = data.creations.single() as Node
         assertEquals(-123, createdNode.id)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
@@ -3,10 +3,14 @@ package de.westnordost.streetcomplete.data.osm.edits.create
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+import de.westnordost.streetcomplete.data.osm.mapdata.MutableMapData
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.data.upload.ConflictException
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
+import de.westnordost.streetcomplete.testutils.way
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -22,7 +26,7 @@ internal class CreateNodeActionTest {
         provider = mock()
     }
 
-    @Test fun `add node`() {
+    @Test fun `create node`() {
         on(provider.nextNodeId()).thenReturn(-123)
 
         val tags = mapOf("amenity" to "atm")
@@ -41,5 +45,162 @@ internal class CreateNodeActionTest {
         assertEquals(tags, createdNode.tags)
         assertEquals(position, createdNode.position)
         assertNotEquals(0, createdNode.timestampEdited)
+    }
+
+    @Test fun `create node and add to way`() {
+        val way = way(id = 1, nodes = listOf(1,2))
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way, node1, node2)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos2)))
+
+        val data = action.createUpdates(dummyNode, null, repos, provider)
+
+        val createdNode = data.creations.single() as Node
+        assertEquals(-123, createdNode.id)
+
+        val updatedWay = data.modifications.single() as Way
+        assertEquals(way.id, updatedWay.id)
+        assertEquals(updatedWay.tags, updatedWay.tags)
+        assertNotEquals(0, updatedWay.timestampEdited)
+        assertEquals(listOf<Long>(1, -123, 2), updatedWay.nodeIds)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict if way the node should be inserted into does not exist`() {
+        val way = way(id = 1, nodes = listOf(1,2))
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(null)
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos2)))
+
+        action.createUpdates(dummyNode, null, repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict if node 2 is not successive to node 1`() {
+        val way = way(id = 1, nodes = listOf(1,2,3))
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+        val pos3 = LatLon(0.0, 3.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+        val node3 = node(id = 3, pos = pos3)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way, node1, node2, node3)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos3)))
+
+        action.createUpdates(dummyNode, null, repos, provider)
+    }
+
+    @Test fun `no conflict if node 2 is first node within closed way`() {
+        val way = way(id = 1, nodes = listOf(1,2,3,1))
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+        val pos3 = LatLon(0.0, 3.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+        val node3 = node(id = 3, pos = pos3)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way, node1, node2, node3)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos3, pos1)))
+
+        action.createUpdates(dummyNode, null, repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict if node 1 has been moved`() {
+        val way = way(id = 1, nodes = listOf(1,2))
+        val oldPos1 = LatLon(0.0, 0.0)
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way, node1, node2)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, oldPos1, pos2)))
+
+        action.createUpdates(dummyNode, null, repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict if node 2 has been moved`() {
+        val way = way(id = 1, nodes = listOf(1,2))
+        val oldPos2 = LatLon(0.0, 0.0)
+        val pos1 = LatLon(0.0, 1.0)
+        val pos2 = LatLon(0.0, 2.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way, node1, node2)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 1.5)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, oldPos2)))
+
+        action.createUpdates(dummyNode, null, repos, provider)
+    }
+
+    @Test fun `create node and add to ways`() {
+        val way1 = way(id = 1, nodes = listOf(1,2))
+        val way2 = way(id = 2, nodes = listOf(3,4))
+        val pos1 = LatLon(0.0, -1.0)
+        val pos2 = LatLon(0.0, +1.0)
+        val pos3 = LatLon(-1.0, 0.0)
+        val pos4 = LatLon(+1.0, 0.0)
+        val node1 = node(id = 1, pos = pos1)
+        val node2 = node(id = 2, pos = pos2)
+        val node3 = node(id = 3, pos = pos3)
+        val node4 = node(id = 4, pos = pos4)
+
+        on(provider.nextNodeId()).thenReturn(-123)
+        on(repos.getWayComplete(1)).thenReturn(MutableMapData(listOf(way1, way2, node1, node2)))
+        on(repos.getWayComplete(2)).thenReturn(MutableMapData(listOf(way2, node3, node4)))
+
+        val tags = mapOf("entrance" to "yes")
+        val position = LatLon(0.0, 0.0)
+        val dummyNode = node(0, position, tags)
+        val action = CreateNodeAction(position, tags, listOf(
+            InsertIntoWayAt(way1.id, pos1, pos2),
+            InsertIntoWayAt(way2.id, pos3, pos4),
+        ))
+
+        val data = action.createUpdates(dummyNode, null, repos, provider)
+
+        val createdNode = data.creations.single() as Node
+        assertEquals(-123, createdNode.id)
+
+        assertEquals(listOf<Long>(1,2), data.modifications.map { it.id })
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
@@ -6,11 +6,13 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.upload.ConflictException
+import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
+import de.westnordost.streetcomplete.util.math.translate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -30,7 +32,8 @@ class RevertCreateNodeActionTest {
     @Test
     fun `revert add node`() {
         val node = node(123, LatLon(12.0, 34.0), mapOf("amenity" to "atm"), 1)
-        val data = RevertCreateNodeAction(listOf()).createUpdates(node, node, repos, provider)
+        on(repos.getNode(node.id)).thenReturn(node)
+        val data = RevertCreateNodeAction(node, listOf()).createUpdates(repos, provider)
 
         assertTrue(data.creations.isEmpty())
         assertTrue(data.modifications.isEmpty())
@@ -41,37 +44,64 @@ class RevertCreateNodeActionTest {
 
     @Test(expected = ConflictException::class)
     fun `conflict when node already deleted`() {
-        RevertCreateNodeAction(listOf()).createUpdates(node(), null, repos, provider)
+        on(repos.getNode(any())).thenReturn(null)
+        RevertCreateNodeAction(node(), listOf()).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict when node is now member of a relation`() {
         val node = node(1)
 
+        on(repos.getNode(node.id)).thenReturn(node)
         on(repos.getWaysForNode(1)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1)).thenReturn(listOf(rel()))
 
-        RevertCreateNodeAction(listOf()).createUpdates(node, node, repos, provider)
+        RevertCreateNodeAction(node, listOf()).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict when node is part of more ways than initially`() {
         val node = node(1)
 
+        on(repos.getNode(node.id)).thenReturn(node)
         on(repos.getWaysForNode(1)).thenReturn(listOf(way(1), way(2), way(3)))
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        RevertCreateNodeAction(listOf(1,2)).createUpdates(node, node, repos, provider)
+        RevertCreateNodeAction(node, listOf(1,2)).createUpdates(repos, provider)
+    }
+
+
+    @Test(expected = ConflictException::class)
+    fun `conflict when node was moved at all`() {
+        val node = node(1)
+
+        on(repos.getNode(1)).thenReturn(node.copy(position = node.position.translate(10.0, 0.0)))
+        on(repos.getWaysForNode(1)).thenReturn(emptyList())
+        on(repos.getRelationsForNode(1)).thenReturn(emptyList())
+
+        RevertCreateNodeAction(node).createUpdates(repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict when tags changed on node at all`() {
+        val node = node(1)
+
+        on(repos.getNode(1)).thenReturn(node.copy(tags = mapOf("different" to "tags")))
+        on(repos.getWaysForNode(1)).thenReturn(emptyList())
+        on(repos.getRelationsForNode(1)).thenReturn(emptyList())
+
+        RevertCreateNodeAction(node).createUpdates(repos, provider)
     }
 
     @Test
     fun `no conflict when node is part of less ways than initially`() {
         val node = node(1)
 
+        on(repos.getNode(node.id)).thenReturn(node)
         on(repos.getWaysForNode(1)).thenReturn(listOf(way(1)))
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        RevertCreateNodeAction(listOf(1,2)).createUpdates(node, node, repos, provider)
+        RevertCreateNodeAction(node, listOf(1,2)).createUpdates(repos, provider)
     }
 
     @Test
@@ -81,10 +111,11 @@ class RevertCreateNodeActionTest {
         val way1 = way(1, nodes = listOf(1,2,3), timestamp = 0)
         val way2 = way(2, nodes = listOf(4,1,6), timestamp = 0)
 
+        on(repos.getNode(node.id)).thenReturn(node)
         on(repos.getWaysForNode(1)).thenReturn(listOf(way1, way2))
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        val data = RevertCreateNodeAction(listOf(1,2,3)).createUpdates(node, node, repos, provider)
+        val data = RevertCreateNodeAction(node, listOf(1,2,3)).createUpdates(repos, provider)
 
         assertEquals(2, data.modifications.size)
         val updatedWays = data.modifications.toList()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
@@ -6,7 +6,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.upload.ConflictException
-import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
@@ -44,8 +43,8 @@ class RevertCreateNodeActionTest {
 
     @Test(expected = ConflictException::class)
     fun `conflict when node already deleted`() {
-        on(repos.getNode(any())).thenReturn(null)
-        RevertCreateNodeAction(node(), listOf()).createUpdates(repos, provider)
+        on(repos.getNode(1)).thenReturn(null)
+        RevertCreateNodeAction(node(1), listOf()).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
@@ -74,8 +73,9 @@ class RevertCreateNodeActionTest {
     @Test(expected = ConflictException::class)
     fun `conflict when node was moved at all`() {
         val node = node(1)
+        val movedNode = node.copy(position = node.position.translate(10.0, 0.0))
 
-        on(repos.getNode(1)).thenReturn(node.copy(position = node.position.translate(10.0, 0.0)))
+        on(repos.getNode(1)).thenReturn(movedNode)
         on(repos.getWaysForNode(1)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
@@ -4,10 +4,15 @@ import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.upload.ConflictException
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.on
+import de.westnordost.streetcomplete.testutils.rel
+import de.westnordost.streetcomplete.testutils.way
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -25,7 +30,7 @@ class RevertCreateNodeActionTest {
     @Test
     fun `revert add node`() {
         val node = node(123, LatLon(12.0, 34.0), mapOf("amenity" to "atm"), 1)
-        val data = RevertCreateNodeAction.createUpdates(node, node, repos, provider)
+        val data = RevertCreateNodeAction(listOf()).createUpdates(node, node, repos, provider)
 
         assertTrue(data.creations.isEmpty())
         assertTrue(data.modifications.isEmpty())
@@ -35,7 +40,66 @@ class RevertCreateNodeActionTest {
     }
 
     @Test(expected = ConflictException::class)
-    fun `conflict revert add node when already deleted`() {
-        RevertCreateNodeAction.createUpdates(node(), null, repos, provider)
+    fun `conflict when node already deleted`() {
+        RevertCreateNodeAction(listOf()).createUpdates(node(), null, repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict when node is now member of a relation`() {
+        val node = node(1)
+
+        on(repos.getWaysForNode(1)).thenReturn(emptyList())
+        on(repos.getRelationsForNode(1)).thenReturn(listOf(rel()))
+
+        RevertCreateNodeAction(listOf()).createUpdates(node, node, repos, provider)
+    }
+
+    @Test(expected = ConflictException::class)
+    fun `conflict when node is part of more ways than initially`() {
+        val node = node(1)
+
+        on(repos.getWaysForNode(1)).thenReturn(listOf(way(1), way(2), way(3)))
+        on(repos.getRelationsForNode(1)).thenReturn(emptyList())
+
+        RevertCreateNodeAction(listOf(1,2)).createUpdates(node, node, repos, provider)
+    }
+
+    @Test
+    fun `no conflict when node is part of less ways than initially`() {
+        val node = node(1)
+
+        on(repos.getWaysForNode(1)).thenReturn(listOf(way(1)))
+        on(repos.getRelationsForNode(1)).thenReturn(emptyList())
+
+        RevertCreateNodeAction(listOf(1,2)).createUpdates(node, node, repos, provider)
+    }
+
+    @Test
+    fun `removes to be deleted node from ways`() {
+        val node = node(1)
+
+        val way1 = way(1, nodes = listOf(1,2,3), timestamp = 0)
+        val way2 = way(2, nodes = listOf(4,1,6), timestamp = 0)
+
+        on(repos.getWaysForNode(1)).thenReturn(listOf(way1, way2))
+        on(repos.getRelationsForNode(1)).thenReturn(emptyList())
+
+        val data = RevertCreateNodeAction(listOf(1,2,3)).createUpdates(node, node, repos, provider)
+
+        assertEquals(2, data.modifications.size)
+        val updatedWays = data.modifications.toList()
+
+        val updatedWay1 = updatedWays[0] as Way
+        assertEquals(way1.id, updatedWay1.id)
+        assertNotEquals(0, updatedWay1.timestampEdited)
+        assertEquals(listOf<Long>(2,3), updatedWay1.nodeIds)
+
+        val updatedWay2 = updatedWays[1] as Way
+        assertEquals(way2.id, updatedWay2.id)
+        assertNotEquals(0, updatedWay2.timestampEdited)
+        assertEquals(listOf<Long>(4,6), updatedWay2.nodeIds)
+
+        val deletedNode = data.deletions.single() as Node
+        assertEquals(node, deletedNode)
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
@@ -27,7 +27,8 @@ class DeletePoiNodeActionTest {
     @Test fun `delete free-floating node`() {
         on(repos.getWaysForNode(1L)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1L)).thenReturn(emptyList())
-        val data = DeletePoiNodeAction.createUpdates(e, e, repos, provider)
+        on(repos.getNode(e.id)).thenReturn(e)
+        val data = DeletePoiNodeAction(e).createUpdates(repos, provider)
         assertTrue(data.modifications.isEmpty())
         assertTrue(data.creations.isEmpty())
         assertEquals(e, data.deletions.single())
@@ -36,7 +37,8 @@ class DeletePoiNodeActionTest {
     @Test fun `'delete' vertex`() {
         on(repos.getWaysForNode(1L)).thenReturn(listOf(mock()))
         on(repos.getRelationsForNode(1L)).thenReturn(emptyList())
-        val data = DeletePoiNodeAction.createUpdates(e, e, repos, provider)
+        on(repos.getNode(e.id)).thenReturn(e)
+        val data = DeletePoiNodeAction(e).createUpdates(repos, provider)
         assertTrue(data.deletions.isEmpty())
         assertTrue(data.creations.isEmpty())
         assertTrue(data.modifications.single().tags.isEmpty())
@@ -44,9 +46,7 @@ class DeletePoiNodeActionTest {
 
     @Test(expected = ConflictException::class)
     fun `moved element creates conflict`() {
-        DeletePoiNodeAction.createUpdates(
-            e.copy(position = p(1.0, 1.0)),
-            e, repos, provider
-        )
+        on(repos.getNode(e.id)).thenReturn(e.copy(position = p(1.0, 1.0)))
+        DeletePoiNodeAction(e).createUpdates(repos, provider)
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.upload.ConflictException
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.util.ktx.copy
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -29,19 +30,20 @@ class RevertDeletePoiNodeActionTest {
                 version = 3,
                 timestampEdited = 0
             ),
-            RevertDeletePoiNodeAction.createUpdates(e, null, repos, provider).modifications
+            RevertDeletePoiNodeAction(e).createUpdates(repos, provider).modifications
                 .single()
                 .copy(timestampEdited = 0)
         )
     }
 
     @Test fun `restore element with cleared tags`() {
+        on(repos.getNode(1)).thenReturn(e.copy(version = 3))
         assertEquals(
             e.copy(
                 version = 3,
                 timestampEdited = 0
             ),
-            RevertDeletePoiNodeAction.createUpdates(e, e.copy(version = 3), repos, provider).modifications
+            RevertDeletePoiNodeAction(e).createUpdates(repos, provider).modifications
                 .single()
                 .copy(timestampEdited = 0)
         )
@@ -49,7 +51,8 @@ class RevertDeletePoiNodeActionTest {
 
     @Test(expected = ConflictException::class)
     fun `conflict if there is already a newer version`() {
+        on(repos.getNode(1)).thenReturn(e.copy(version = 4))
         // version 3 would be the deletion
-        RevertDeletePoiNodeAction.createUpdates(e, e.copy(version = 4), repos, provider)
+        RevertDeletePoiNodeAction(e).createUpdates(repos, provider)
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
@@ -646,14 +646,15 @@ class SplitWayActionTest {
         vararg splits: SplitPolylineAtPosition = arrayOf(split),
         originalWay: Way = way
     ): MapData {
-        val action = SplitWayAction(ArrayList(splits.toList()))
+        val action = SplitWayAction(originalWay, ArrayList(splits.toList()))
         val counts = action.newElementsCount
         val elementKeys = ArrayList<ElementKey>()
         for (i in 1L..counts.nodes) { elementKeys.add(ElementKey(NODE, -i)) }
         for (i in 1L..counts.ways) { elementKeys.add(ElementKey(WAY, -i)) }
         for (i in 1L..counts.relations) { elementKeys.add(ElementKey(RELATION, -i)) }
         val provider = ElementIdProvider(elementKeys)
-        val data = action.createUpdates(originalWay, way, repos, provider)
+        on(repos.getWay(way.id)).thenReturn(way)
+        val data = action.createUpdates(repos, provider)
         return MutableMapData(data.creations + data.modifications)
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.NODE
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.*
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -33,101 +33,84 @@ class UpdateElementTagsActionTest {
 
     @Test(expected = ConflictException::class)
     fun `conflict if node moved too much`() {
+        on(repos.get(NODE, 1)).thenReturn(node(1, p(1.0, 0.0)))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             node(1, p(0.0, 0.0)),
-            node(1, p(0.1, 0.0)),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if way was extended or shortened at start`() {
+        on(repos.get(WAY, 1)).thenReturn(way(1, listOf(1, 2, 3)))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             way(1, listOf(0, 1, 2, 3)),
-            way(1, listOf(1, 2, 3)),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if way was extended or shortened at end`() {
+        on(repos.get(WAY, 1)).thenReturn(way(1, listOf(0, 1, 2)))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             way(1, listOf(0, 1, 2, 3)),
-            way(1, listOf(0, 1, 2)),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if relation members were removed`() {
+        on(repos.get(RELATION, 1)).thenReturn(rel(1, listOf(member(NODE, 1))))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             rel(1, listOf(member(NODE, 1), member(NODE, 2))),
-            rel(1, listOf(member(NODE, 1))),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if relation members were added`() {
+        on(repos.get(RELATION, 1)).thenReturn(rel(1, listOf(member(NODE, 1), member(NODE, 2))))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             rel(1, listOf(member(NODE, 1))),
-            rel(1, listOf(member(NODE, 1), member(NODE, 2))),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if order of relation members changed`() {
+        on(repos.get(RELATION, 1)).thenReturn(rel(1, listOf(member(NODE, 1), member(NODE, 2))))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             rel(1, listOf(member(NODE, 2), member(NODE, 1))),
-            rel(1, listOf(member(NODE, 1), member(NODE, 2))),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if role of any relation member changed`() {
+        on(repos.get(RELATION, 1)).thenReturn(rel(1, listOf(member(NODE, 1, "a"))))
         UpdateElementTagsAction(
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(
             rel(1, listOf(member(NODE, 1, "b"))),
-            rel(1, listOf(member(NODE, 1, "a"))),
-            repos,
-            provider
-        )
+            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        ).createUpdates(repos, provider)
     }
 
     @Test(expected = ConflictException::class)
     fun `conflict if changes are not applicable`() {
         val w = way(1, listOf(1, 2, 3), mutableMapOf("highway" to "residential"))
+        on(repos.get(WAY, 1)).thenReturn(w)
         UpdateElementTagsAction(
+            w,
             StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
-        ).createUpdates(w, w, repos, provider)
+        ).createUpdates(repos, provider)
     }
 
     @Test fun `apply changes`() {
         val w = way(1, listOf(1, 2, 3))
+        on(repos.get(WAY, 1)).thenReturn(w)
         val data = UpdateElementTagsAction(
+            w,
             StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
-        ).createUpdates(w, w, repos, provider)
+        ).createUpdates(repos, provider)
         val updatedWay = data.modifications.single() as Way
         assertEquals(mapOf("highway" to "living_street"), updatedWay.tags)
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
@@ -11,13 +11,10 @@ import de.westnordost.streetcomplete.testutils.edit
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
-import de.westnordost.streetcomplete.testutils.rel
-import de.westnordost.streetcomplete.testutils.way
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.doThrow
-import org.mockito.Mockito.verify
 
 class ElementEditUploaderTest {
 
@@ -37,44 +34,12 @@ class ElementEditUploaderTest {
     }
 
     @Test(expected = ConflictException::class)
-    fun `throws deleted exception if node is no more`() {
-        on(mapDataApi.getNode(12)).thenReturn(null)
-        on(mapDataController.getNode(12)).thenReturn(node(12))
+    fun `passes on conflict exception`() {
+        val node = node(1)
+        on(mapDataApi.getNode(anyLong())).thenReturn(node)
+        on(mapDataController.getNode(anyLong())).thenReturn(node)
         on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException())
-        uploader.upload(edit(element = node(12)), { mock() })
-    }
-
-    @Test(expected = ConflictException::class)
-    fun `throws deleted exception if way is no more`() {
-        on(mapDataApi.getWay(12)).thenReturn(null)
-        on(mapDataController.getWay(12)).thenReturn(way(12))
-        on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException())
-        uploader.upload(edit(element = way(12)), { mock() })
-    }
-
-    @Test(expected = ConflictException::class)
-    fun `throws deleted exception if relation is no more`() {
-        on(mapDataApi.getRelation(12)).thenReturn(null)
-        on(mapDataApi.getRelation(12)).thenReturn(rel(12))
-        on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException())
-        uploader.upload(edit(element = rel(12)), { mock() })
-    }
-
-    @Test
-    fun `doesn't download element if no exception`() {
-        on(mapDataApi.getNode(12)).thenThrow(NullPointerException()) // ConflictException is handled!
-        on(mapDataController.getNode(12)).thenReturn(node(12))
-        uploader.upload(edit(element = node(12)), { mock() })
-    }
-
-    @Test
-    fun `downloads element on exception`() {
-        on(mapDataApi.getNode(12)).thenReturn(node(12))
-        on(mapDataController.getNode(12)).thenReturn(node(12))
-        on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException()).thenReturn(null)
-        uploader.upload(edit(element = node(12)), { mock() })
-        verify(mapDataController).getNode(12)
-        verify(mapDataApi).getNode(12)
+        uploader.upload(edit(element = node(1)), { mock() })
     }
 
     @Test(expected = ConflictException::class)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.edits.upload
 
+import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsSource
 import de.westnordost.streetcomplete.data.osm.edits.upload.changesets.OpenChangesetsManager
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApi
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
@@ -23,14 +24,16 @@ class ElementEditUploaderTest {
     private lateinit var changesetManager: OpenChangesetsManager
     private lateinit var mapDataApi: MapDataApi
     private lateinit var mapDataController: MapDataController
+    private lateinit var createdElementsSource: CreatedElementsSource
     private lateinit var uploader: ElementEditUploader
 
     @Before fun setUp() {
         changesetManager = mock()
         mapDataApi = mock()
         mapDataController = mock()
+        createdElementsSource = mock()
 
-        uploader = ElementEditUploader(changesetManager, mapDataApi, mapDataController)
+        uploader = ElementEditUploader(changesetManager, mapDataApi, mapDataController, createdElementsSource)
     }
 
     @Test(expected = ConflictException::class)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
@@ -1,8 +1,11 @@
 package de.westnordost.streetcomplete.data.osm.edits.upload
 
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsSource
+import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
 import de.westnordost.streetcomplete.data.osm.edits.upload.changesets.OpenChangesetsManager
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApi
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
 import de.westnordost.streetcomplete.data.upload.ConflictException
@@ -35,36 +38,41 @@ class ElementEditUploaderTest {
 
     @Test(expected = ConflictException::class)
     fun `passes on conflict exception`() {
-        val node = node(1)
-        on(mapDataApi.getNode(anyLong())).thenReturn(node)
-        on(mapDataController.getNode(anyLong())).thenReturn(node)
+        val edit: ElementEdit = mock()
+        val action: ElementEditAction = mock()
+        on(edit.action).thenReturn(action)
+        on(action.createUpdates(any(), any())).thenReturn(MapDataChanges())
         on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException())
-        uploader.upload(edit(element = node(1)), { mock() })
+        uploader.upload(edit, { mock() })
     }
 
     @Test(expected = ConflictException::class)
     fun `passes on element conflict exception`() {
-        val node = node(1)
-        on(mapDataApi.getNode(anyLong())).thenReturn(node)
-        on(mapDataController.getNode(anyLong())).thenReturn(node)
+        val edit: ElementEdit = mock()
+        val action: ElementEditAction = mock()
+        on(edit.action).thenReturn(action)
+        on(action.createUpdates(any(), any())).thenReturn(MapDataChanges())
+
         on(changesetManager.getOrCreateChangeset(any(), any())).thenReturn(1)
         on(changesetManager.createChangeset(any(), any())).thenReturn(1)
         on(mapDataApi.uploadChanges(anyLong(), any(), any()))
             .thenThrow(ConflictException())
             .thenThrow(ConflictException())
 
-        uploader.upload(edit(element = node(1)), { mock() })
+        uploader.upload(edit, { mock() })
     }
 
     @Test fun `handles changeset conflict exception`() {
-        val node = node(1)
-        on(mapDataApi.getNode(anyLong())).thenReturn(node)
-        on(mapDataController.getNode(anyLong())).thenReturn(node)
+        val edit: ElementEdit = mock()
+        val action: ElementEditAction = mock()
+        on(edit.action).thenReturn(action)
+        on(action.createUpdates(any(), any())).thenReturn(MapDataChanges())
+
         on(changesetManager.getOrCreateChangeset(any(), any())).thenReturn(1)
         on(changesetManager.createChangeset(any(), any())).thenReturn(1)
         doThrow(ConflictException()).doAnswer { MapDataUpdates() }
             .on(mapDataApi).uploadChanges(anyLong(), any(), any())
 
-        uploader.upload(edit(element = node(1)), { mock() })
+        uploader.upload(edit, { mock() })
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
@@ -108,7 +108,7 @@ class ElementEditsUploaderTest {
     }
 
     @Test fun `upload catches deleted element exception`() = runBlocking {
-        val edit = edit(element = node(1))
+        val edit = edit()
         val idProvider = mock<ElementIdProvider>()
         val node = node(1)
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
@@ -75,7 +75,7 @@ class ElementEditsUploaderTest {
 
         verify(singleUploader).upload(eq(edit), any())
         verify(listener).onUploaded(any(), any())
-        verify(elementEditsController).markSynced(edit, updates)
+        verify(elementEditsController).markSynced(edit)
         verify(noteEditsController).updateElementIds(any())
         verify(mapDataController).updateAll(updates)
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataControllerTest.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.data.osm.mapdata
 
 import de.westnordost.streetcomplete.data.download.tiles.asBoundingBoxOfEnclosingTiles
+import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementKey
 import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsController
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryDao
@@ -120,7 +121,8 @@ class MapDataControllerTest {
         verify(elementDB).deleteAll(expectedDeleteKeys)
         verify(elementDB).putAll(elements)
         verify(geometryDB).putAll(eq(geomEntries))
-        verify(createdElementsController).putAll(eq(idUpdates.map { ElementKey(it.elementType, it.newElementId) }))
+        val createdElements = idUpdates.map { CreatedElementKey(it.elementType, it.oldElementId, it.newElementId) }
+        verify(createdElementsController).putAll(eq(createdElements))
 
         sleep(100)
         verify(listener).onUpdated(any(), eq(expectedDeleteKeys))

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
@@ -3,6 +3,9 @@ package de.westnordost.streetcomplete.testutils
 import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
 import de.westnordost.streetcomplete.data.osm.edits.delete.DeletePoiNodeAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
@@ -110,7 +113,7 @@ fun edit(
     element: Element = node(),
     geometry: ElementGeometry = pGeom(),
     timestamp: Long = 123L,
-    action: ElementEditAction = DeletePoiNodeAction(element as Node),
+    action: ElementEditAction = UpdateElementTagsAction(element, StringMapChanges(setOf(StringMapEntryAdd("hey", "ho")))),
     isSynced: Boolean = false
 ) = ElementEdit(
     id,

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
@@ -110,14 +110,11 @@ fun edit(
     element: Element = node(),
     geometry: ElementGeometry = pGeom(),
     timestamp: Long = 123L,
-    action: ElementEditAction = DeletePoiNodeAction,
+    action: ElementEditAction = DeletePoiNodeAction(element as Node),
     isSynced: Boolean = false
 ) = ElementEdit(
     id,
     QUEST_TYPE,
-    element.type,
-    element.id,
-    element,
     geometry,
     "survey",
     timestamp,

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
@@ -110,10 +110,9 @@ fun noteEdit(
 
 fun edit(
     id: Long = 1L,
-    element: Element = node(),
     geometry: ElementGeometry = pGeom(),
     timestamp: Long = 123L,
-    action: ElementEditAction = UpdateElementTagsAction(element, StringMapChanges(setOf(StringMapEntryAdd("hey", "ho")))),
+    action: ElementEditAction = UpdateElementTagsAction(node(), StringMapChanges(setOf(StringMapEntryAdd("hey", "ho")))),
     isSynced: Boolean = false
 ) = ElementEdit(
     id,


### PR DESCRIPTION
Currently, `ElementEdit`s refer to exactly one element.  Each `ElementEdit` hence contains the original element the edit was made on and its element type and id.

This is necessary:

1. **most importantly:** to update the id of the element the edit refers to after upload of created elements (new elements get temporary negative ids assigned and get their proper id assigned after upload by the OSM API).
2. downloading the current version of an element for which the upload of an edit resulted in a conflict
3. clearing all edits made on an object one just created with another edit when that first edit is deleted via undo-function
4. show the correct quest title looking at the tags of the element edited by an edit in the undo dialog

This reaches a limitation when an edit touches several elements or when an edit creates an element (i.e. has no original element to refer to). Creating (free-floating) nodes already only worked through a hack (using a "dummy" element). Creating a vertex of a way (=create node and modify way) would not work for ways that were created in this app because with the above, it wouldn't be possible to update the id of the way that edit refers to.

### The goal

We want an action that can (without hacks) do exactly that:

Create a new node with tags at a given position and make it a node of the given way(s). (ways in plural because it is practically no extra complexity to support adding it to several ways even if this is not used (yet)).

### This solution

1. The `ElementEdit` does not refer to one element anymore. Instead: The `ElementEditAction` (each `ElementEdit` has one action) contains all the information it needs to perform (e.g. the original element the edit was made on)
2. The element edits are no longer indexed by element in the database. In fact, the elements of an element edit action are never updated. Instead: `CreatedElementsController` keeps track of the information which temporary/local ids refer to which ids assigned by the OSM API and is able to return that assigned id given a temporary/local id. When an `ElementEditAction` gets passed a `MapDataRepository`, it is wrapped in a `MapDataRepositoryWithUpdatedIds` which automatically resolves old ids to new ids using `CreatedElementsSource`.

Point 2,3,4 are not solved with this (so far).

### TODO

- upgrade database
- 2 remaining failing tests (should only continue after rebasing on top of #4472)
- solve 2,3,4