### PR TITLE
Change order of footway quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -456,8 +456,8 @@ fun questTypeRegistry(
     AddPathSmoothness(),
 
     // footways
-    AddPathSurface(), // used by OSM Carto, BRouter, OsmAnd, OSRM, graphhopper...
     AddCyclewaySegregation(), // Cyclosm, Valhalla, Bike Citizens Bicycle Navigation...
+    AddPathSurface(), // used by OSM Carto, BRouter, OsmAnd, OSRM, graphhopper...
     AddFootwayPartSurface(),
     AddCyclewayPartSurface(),
     AddSidewalkSurface(),


### PR DESCRIPTION
Since `AddPathSurface` relies on the key `segregated,` the corresponding quest `AddCyclewaySegregation` should be asked before `AddPathSurface` by default.