### PR TITLE
remove "surface:grade" when updating "smoothness"

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
@@ -39,16 +39,19 @@ class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
         when (answer) {
             is SmoothnessValueAnswer -> {
                 tags.updateWithCheckDate("smoothness", answer.value.osmValue)
+                tags.remove("surface:grade")
                 tags.remove("smoothness:date")
             }
             is WrongSurfaceAnswer -> {
                 tags.remove("surface")
+                tags.remove("surface:grade")
                 tags.remove("smoothness")
                 tags.remove("smoothness:date")
                 tags.removeCheckDatesForKey("smoothness")
             }
             is IsActuallyStepsAnswer -> {
                 tags["highway"] = "steps"
+                tags.remove("surface:grade")
                 tags.remove("smoothness")
                 tags.remove("smoothness:date")
                 tags.removeCheckDatesForKey("smoothness")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -41,9 +41,11 @@ class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
             is SmoothnessValueAnswer -> {
                 tags.updateWithCheckDate("smoothness", answer.value.osmValue)
                 tags.remove("smoothness:date")
+                tags.remove("surface:grade")
             }
             is WrongSurfaceAnswer -> {
                 tags.remove("surface")
+                tags.remove("surface:grade")
                 tags.remove("smoothness")
                 tags.remove("smoothness:date")
                 tags.removeCheckDatesForKey("smoothness")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SurfaceAnswer.kt
@@ -28,6 +28,7 @@ fun SurfaceAnswer.applyTo(tags: Tags, key: String) {
     // remove smoothness tag if surface was changed
     // or surface can be treated as outdated
     if ((previousOsmValue != null && previousOsmValue != osmValue) || replacesTracktype) {
+        tags.remove("surface:grade")
         tags.remove("smoothness")
         tags.remove("smoothness:date")
         tags.removeCheckDatesForKey("smoothness")

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
@@ -30,6 +30,15 @@ class AddRoadSmoothnessTest {
         )
     }
 
+    @Test fun `deletes surface-grade`() {
+        questType.verifyAnswer(
+            mapOf("smoothness" to "excellent", "surface:grade" to "3"),
+            SmoothnessValueAnswer(Smoothness.HORRIBLE),
+            StringMapEntryModify("smoothness", "excellent", "horrible"),
+            StringMapEntryDelete("surface:grade", "3"),
+        )
+    }
+
     @Test fun `on wrong surface, deletes everything smoothness-related`() {
         questType.verifyAnswer(
             mapOf(

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
@@ -45,12 +45,14 @@ class AddRoadSmoothnessTest {
                 "smoothness" to "excellent",
                 "smoothness:date" to "2000-10-10",
                 "surface" to "asphalt",
+                "surface:grade" to "3",
                 "check_date:smoothness" to "2000-10-10",
             ),
             WrongSurfaceAnswer,
             StringMapEntryDelete("smoothness", "excellent"),
             StringMapEntryDelete("smoothness:date", "2000-10-10"),
             StringMapEntryDelete("surface", "asphalt"),
+            StringMapEntryDelete("surface:grade", "3"),
             StringMapEntryDelete("check_date:smoothness", "2000-10-10"),
         )
     }


### PR DESCRIPTION
[surface:grade=*](https://wiki.openstreetmap.org/wiki/Key:surface:grade) is/was an less popular (and poorly defined) alternative to [smoothness=*](https://wiki.openstreetmap.org/wiki/Key:smoothness). It is still somewhat popular, with about `25k` uses.

So, when updating `smoothness` in any way, we should remove `surface:grade` (which is sometimes used in parallel) as otherwise we'd be leaving conflicting information.

I've also added a [test](https://github.com/mnalis/StreetComplete/actions/runs/3230052001) to check for correct removal.

App [compiles and seems to work fine](https://github.com/mnalis/StreetComplete/actions/runs/3229730590),  e.g.:
![small_Screenshot_20221011_222352_de westnordost streetcomplete mn debug](https://user-images.githubusercontent.com/156656/195191675-773656ec-80a6-4318-8f82-09049d13f42d.jpg)
