### PR TITLE
Include AU in bus stop ref quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -17,7 +17,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
         )
         and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
-    override val enabledInCountries = NoCountriesExcept("US", "CA", "JE", "IE")
+    override val enabledInCountries = NoCountriesExcept("US", "CA", "JE", "IE", "AU")
     override val changesetComment = "Determine bus/tram stop refs"
     override val wikiLink = "Tag:public_transport=platform"
     override val icon = R.drawable.ic_quest_bus_stop_name


### PR DESCRIPTION
Bus/tram stops mostly do have a ref https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Transportation#Stop_numbering