### PR TITLE
GitHub workflow -  longer retention and security hardening

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -3,6 +3,9 @@ name: Build debug apk
 on:
   [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -30,4 +30,4 @@ jobs:
       with: 
         name: debug-apk
         path: app/build/outputs/apk/debug/*.apk
-        retention-days: 1
+        retention-days: 30


### PR DESCRIPTION
- increase `debug-apk.zip` retention to `30` days (instead of just **one** day, where it might be too short for interested parties to go grab it). I've tested (and use it in my fork) up to `90` days, and it works fine
- also harden the build so it cannot write to repository (we don't use it, so apply the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) - more detailed technical rationale can be found for example [here](https://github.com/Leaflet/Leaflet/pull/8419))

I've tested both and they compile and work [fine](https://github.com/mnalis/StreetComplete/actions/runs/3229730590)