### PR TITLE
Do not ask AddAddressStreet quest if addr:substreet or addr:parentstreet are present

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -17,8 +17,8 @@ class AddAddressStreet : OsmElementQuestType<StreetOrPlaceName> {
 
     private val filter by lazy { """
         nodes, ways, relations with
-          (addr:housenumber or addr:housename) and !addr:street and !addr:place and !addr:block_number
-          or addr:streetnumber and !addr:street
+          (addr:housenumber or addr:housename) and !addr:street and !addr:place and !addr:block_number and !addr:substreet and !addr:parentstreet
+          or addr:streetnumber and !addr:street and !addr:substreet and !addr:parentstreet
     """.toElementFilterExpression() }
 
     // #2112 - exclude indirect addr:street

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetTest.kt
@@ -31,6 +31,26 @@ class AddAddressStreetTest {
         assertEquals(false, questType.isApplicableTo(addr))
     }
 
+    @Test fun `not applicable to place with substreet name`() {
+        val addr = node(tags = mapOf(
+            "addr:housenumber" to "123",
+            "addr:substreet" to "onetwothree",
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(addr))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+        assertEquals(false, questType.isApplicableTo(addr))
+    }
+
+    @Test fun `not applicable to place with parentstreet name`() {
+        val addr = node(tags = mapOf(
+            "addr:housenumber" to "123",
+            "addr:parentstreet" to "onetwothree",
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(addr))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+        assertEquals(false, questType.isApplicableTo(addr))
+    }
+
     @Test fun `not applicable to place without street name but in a associatedStreet relation`() {
         val addr = node(1, tags = mapOf("addr:housenumber" to "123"))
         val associatedStreetRelation = rel(


### PR DESCRIPTION
This PR (as agreed in https://github.com/streetcomplete/StreetComplete/issues/4483#issuecomment-1276016771) skips the `AddAddressStreet` quest if either `addr:substreet` or `addr:parentstreet` are already defined, as answering this quest there would likely only lead to more confusing data, instead of actually helping OSM.
It also adds tests for checking if those are being ignored.


It [compiles](https://github.com/mnalis/StreetComplete/actions/runs/3237694006), [passes](https://github.com/mnalis/StreetComplete/actions/runs/3237694861) the [tests](https://github.com/mnalis/StreetComplete/blob/ignore-uk-parentstreet-substreet/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetTest.kt#L34-L52) and seems to work fine; e.g.  it skips for example this building: https://www.openstreetmap.org/way/230252831 (v6) which  lacks `addr:street`, but has `addr:substreet` (and on which the `AddAddressStreet` quest was previously being asked):

![small_Screenshot_20221012_213319_de westnordost streetcomplete mn debug](https://user-images.githubusercontent.com/156656/195442578-267c0ea9-acf4-4281-9189-87abe7d433ca.jpg) ![small_Screenshot_20221012_224128_de westnordost streetcomplete mn debug](https://user-images.githubusercontent.com/156656/195443811-f34ed692-06b3-48f0-be64-a93eda3fe99f.jpg)

Closes: https://github.com/streetcomplete/StreetComplete/issues/4483