### PR TITLE
Add "The sidewalk situation is different" OtherAnswer to sidewalk surface quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -38,7 +38,7 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     override fun createForm() = AddSidewalkSurfaceForm()
 
     override fun applyAnswerTo(answer: SidewalkSurfaceAnswer, tags: Tags, timestampEdited: Long) {
-        if (answer is SidewalkIsDifferent) {
+        /*if (answer is SidewalkIsDifferent) {
             deleteSmoothnessKeys(Side.LEFT, tags)
             deleteSmoothnessKeys(Side.RIGHT, tags)
             deleteSmoothnessKeys(Side.BOTH, tags)
@@ -51,7 +51,7 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
             tags.remove("sidewalk:both")
             tags.remove("sidewalk")
             return
-        }
+        }*/
 
         val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
         val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -38,27 +38,44 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     override fun createForm() = AddSidewalkSurfaceForm()
 
     override fun applyAnswerTo(answer: SidewalkSurfaceAnswer, tags: Tags, timestampEdited: Long) {
-        val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
-        val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
+       when (answer) {
+            is SidewalkIsDifferent -> {
+                deleteSmoothnessKeys(Side.LEFT, tags)
+                deleteSmoothnessKeys(Side.RIGHT, tags)
+                deleteSmoothnessKeys(Side.BOTH, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+                tags.remove("sidewalk:left")
+                tags.remove("sidewalk:right")
+                tags.remove("sidewalk:both")
+                tags.remove("sidewalk")
+            }
+            else -> {
+                val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
+                val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
 
-        if (leftChanged == true) {
-            deleteSmoothnessKeys(Side.LEFT, tags)
-            deleteSmoothnessKeys(Side.BOTH, tags)
-        }
-        if (rightChanged == true) {
-            deleteSmoothnessKeys(Side.RIGHT, tags)
-            deleteSmoothnessKeys(Side.BOTH, tags)
+                if (leftChanged == true) {
+                    deleteSmoothnessKeys(Side.LEFT, tags)
+                    deleteSmoothnessKeys(Side.BOTH, tags)
+                }
+                if (rightChanged == true) {
+                    deleteSmoothnessKeys(Side.RIGHT, tags)
+                    deleteSmoothnessKeys(Side.BOTH, tags)
+                }
+
+                if (answer.left == answer.right) {
+                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
+                    deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+                    deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+                } else {
+                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
+                    answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
+                    deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+                }
+            }
         }
 
-        if (answer.left == answer.right) {
-            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
-            deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
-            deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
-        } else {
-            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
-            answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
-            deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-        }
         deleteSidewalkSurfaceAnswerIfExists(null, tags)
 
         // only set the check date if nothing was changed or if check date was already set
@@ -66,6 +83,10 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
             tags.updateCheckDateForKey("sidewalk:surface")
         }
     }
+
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_sidewalk_answer_different) { applyAnswer(SidewalkIsDifferent) }
+    )
 
     private enum class Side(val value: String) {
         LEFT("left"), RIGHT("right"), BOTH("both")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -40,39 +40,39 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     override fun applyAnswerTo(answer: SidewalkSurfaceAnswer, tags: Tags, timestampEdited: Long) {
        when (answer) {
             is SidewalkIsDifferent -> {
-            deleteSmoothnessKeys(Side.LEFT, tags)
-            deleteSmoothnessKeys(Side.RIGHT, tags)
-            deleteSmoothnessKeys(Side.BOTH, tags)
-            deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
-            deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
-            deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-            tags.remove("sidewalk:left")
-            tags.remove("sidewalk:right")
-            tags.remove("sidewalk:both")
-            tags.remove("sidewalk")
+                deleteSmoothnessKeys(Side.LEFT, tags)
+                deleteSmoothnessKeys(Side.RIGHT, tags)
+                deleteSmoothnessKeys(Side.BOTH, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+                deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+                tags.remove("sidewalk:left")
+                tags.remove("sidewalk:right")
+                tags.remove("sidewalk:both")
+                tags.remove("sidewalk")
             }
             else -> {
-        val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
-        val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
+                val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
+                val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
 
-        if (leftChanged == true) {
-            deleteSmoothnessKeys(Side.LEFT, tags)
-            deleteSmoothnessKeys(Side.BOTH, tags)
-        }
-        if (rightChanged == true) {
-            deleteSmoothnessKeys(Side.RIGHT, tags)
-            deleteSmoothnessKeys(Side.BOTH, tags)
-        }
+                if (leftChanged == true) {
+                    deleteSmoothnessKeys(Side.LEFT, tags)
+                    deleteSmoothnessKeys(Side.BOTH, tags)
+                }
+                if (rightChanged == true) {
+                    deleteSmoothnessKeys(Side.RIGHT, tags)
+                    deleteSmoothnessKeys(Side.BOTH, tags)
+                }
 
-        if (answer.left == answer.right) {
-            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
-            deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
-            deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
-        } else {
-            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
-            answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
-            deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-        }
+                if (answer.left == answer.right) {
+                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
+                    deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+                    deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+                } else {
+                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
+                    answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
+                    deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+                }
             }
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -45,32 +45,34 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
             deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
             deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
             deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+            deleteSidewalkSurfaceAnswerIfExists(null, tags)
             tags.remove("sidewalk:left")
             tags.remove("sidewalk:right")
             tags.remove("sidewalk:both")
             tags.remove("sidewalk")
+            return
+        }
+
+        val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
+        val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
+
+        if (leftChanged == true) {
+            deleteSmoothnessKeys(Side.LEFT, tags)
+            deleteSmoothnessKeys(Side.BOTH, tags)
+        }
+        if (rightChanged == true) {
+            deleteSmoothnessKeys(Side.RIGHT, tags)
+            deleteSmoothnessKeys(Side.BOTH, tags)
+        }
+
+        if (answer.left == answer.right) {
+            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
+            deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+            deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
         } else {
-            val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
-            val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
-
-            if (leftChanged == true) {
-                deleteSmoothnessKeys(Side.LEFT, tags)
-                deleteSmoothnessKeys(Side.BOTH, tags)
-            }
-            if (rightChanged == true) {
-                deleteSmoothnessKeys(Side.RIGHT, tags)
-                deleteSmoothnessKeys(Side.BOTH, tags)
-            }
-
-            if (answer.left == answer.right) {
-                answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
-                deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
-                deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
-            } else {
-                answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
-                answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
-                deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-            }
+            answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
+            answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
+            deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
         }
 
         deleteSidewalkSurfaceAnswerIfExists(null, tags)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -51,7 +51,7 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
                 tags.remove("sidewalk:both")
                 tags.remove("sidewalk")
             }
-            else -> {
+            is SidewalkSurface -> {
                 val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
                 val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -83,10 +83,6 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
         }
     }
 
-    override val otherAnswers = listOf(
-        AnswerItem(R.string.quest_sidewalk_answer_different) { applyAnswer(SidewalkIsDifferent) }
-    )
-
     private enum class Side(val value: String) {
         LEFT("left"), RIGHT("right"), BOTH("both")
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -38,21 +38,20 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     override fun createForm() = AddSidewalkSurfaceForm()
 
     override fun applyAnswerTo(answer: SidewalkSurfaceAnswer, tags: Tags, timestampEdited: Long) {
-        /*if (answer is SidewalkIsDifferent) {
+       when (answer) {
+            is SidewalkIsDifferent -> {
             deleteSmoothnessKeys(Side.LEFT, tags)
             deleteSmoothnessKeys(Side.RIGHT, tags)
             deleteSmoothnessKeys(Side.BOTH, tags)
             deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
             deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
             deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-            deleteSidewalkSurfaceAnswerIfExists(null, tags)
             tags.remove("sidewalk:left")
             tags.remove("sidewalk:right")
             tags.remove("sidewalk:both")
             tags.remove("sidewalk")
-            return
-        }*/
-
+            }
+            else -> {
         val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
         val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
 
@@ -73,6 +72,8 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
             answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
             answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
             deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+        }
+            }
         }
 
         deleteSidewalkSurfaceAnswerIfExists(null, tags)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -38,41 +38,38 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     override fun createForm() = AddSidewalkSurfaceForm()
 
     override fun applyAnswerTo(answer: SidewalkSurfaceAnswer, tags: Tags, timestampEdited: Long) {
-       when (answer) {
-            is SidewalkIsDifferent -> {
+        if (answer is SidewalkIsDifferent) {
+            deleteSmoothnessKeys(Side.LEFT, tags)
+            deleteSmoothnessKeys(Side.RIGHT, tags)
+            deleteSmoothnessKeys(Side.BOTH, tags)
+            deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
+            deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+            deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
+            tags.remove("sidewalk:left")
+            tags.remove("sidewalk:right")
+            tags.remove("sidewalk:both")
+            tags.remove("sidewalk")
+        } else {
+            val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
+            val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
+
+            if (leftChanged == true) {
                 deleteSmoothnessKeys(Side.LEFT, tags)
+                deleteSmoothnessKeys(Side.BOTH, tags)
+            }
+            if (rightChanged == true) {
                 deleteSmoothnessKeys(Side.RIGHT, tags)
                 deleteSmoothnessKeys(Side.BOTH, tags)
+            }
+
+            if (answer.left == answer.right) {
+                answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
                 deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
                 deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
+            } else {
+                answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
+                answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
                 deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-                tags.remove("sidewalk:left")
-                tags.remove("sidewalk:right")
-                tags.remove("sidewalk:both")
-                tags.remove("sidewalk")
-            }
-            else -> {
-                val leftChanged = answer.left?.let { sideSurfaceChanged(it, Side.LEFT, tags) }
-                val rightChanged = answer.right?.let { sideSurfaceChanged(it, Side.RIGHT, tags) }
-
-                if (leftChanged == true) {
-                    deleteSmoothnessKeys(Side.LEFT, tags)
-                    deleteSmoothnessKeys(Side.BOTH, tags)
-                }
-                if (rightChanged == true) {
-                    deleteSmoothnessKeys(Side.RIGHT, tags)
-                    deleteSmoothnessKeys(Side.BOTH, tags)
-                }
-
-                if (answer.left == answer.right) {
-                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.BOTH, tags) }
-                    deleteSidewalkSurfaceAnswerIfExists(Side.LEFT, tags)
-                    deleteSidewalkSurfaceAnswerIfExists(Side.RIGHT, tags)
-                } else {
-                    answer.left?.let { applySidewalkSurfaceAnswerTo(it, Side.LEFT, tags) }
-                    answer.right?.let { applySidewalkSurfaceAnswerTo(it, Side.RIGHT, tags) }
-                    deleteSidewalkSurfaceAnswerIfExists(Side.BOTH, tags)
-                }
             }
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceForm.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk
 import de.westnordost.streetcomplete.osm.sidewalk.createSidewalkSides
+import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.AStreetSideSelectForm
 import de.westnordost.streetcomplete.view.controller.StreetSideDisplayItem
 import de.westnordost.streetcomplete.view.controller.StreetSideSelectWithLastAnswerButtonViewController.Sides.BOTH
@@ -17,6 +18,10 @@ class AddSidewalkSurfaceForm : AStreetSideSelectForm<Surface, SidewalkSurfaceAns
 
     private var leftNote: String? = null
     private var rightNote: String? = null
+
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_sidewalk_answer_different) { applyAnswer(SidewalkIsDifferent) }
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceForm.kt
@@ -86,7 +86,7 @@ class AddSidewalkSurfaceForm : AStreetSideSelectForm<Surface, SidewalkSurfaceAns
         if (left?.shouldBeDescribed != true && right?.shouldBeDescribed != true) {
             streetSideSelect.saveLastSelection()
         }
-        applyAnswer(SidewalkSurfaceAnswer(
+        applyAnswer(SidewalkSurface(
             left?.let { SurfaceAnswer(it, leftNote) },
             right?.let { SurfaceAnswer(it, rightNote) }
         ))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.quests.surface
 sealed interface SidewalkSurfaceAnswer
 object SidewalkIsDifferent : SidewalkSurfaceAnswer
 
-data class SidewalkSurfaceAnswer(
+data class SidewalkSurface(
     val left: SurfaceAnswer?,
     val right: SurfaceAnswer?,
-)
+) : SidewalkSurfaceAnswer
 
 data class SidewalkSurfaceSide(val surface: Surface)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
@@ -1,5 +1,7 @@
 package de.westnordost.streetcomplete.quests.surface
 
+data class SidewalkSurfaceSide(val surface: Surface)
+
 sealed interface SidewalkSurfaceAnswer
 object SidewalkIsDifferent : SidewalkSurfaceAnswer
 
@@ -8,4 +10,3 @@ data class SidewalkSurface(
     val right: SurfaceAnswer?,
 ) : SidewalkSurfaceAnswer
 
-data class SidewalkSurfaceSide(val surface: Surface)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
@@ -1,5 +1,8 @@
 package de.westnordost.streetcomplete.quests.surface
 
+sealed interface SidewalkSurfaceAnswer
+object SidewalkIsDifferent : SidewalkSurfaceAnswer
+
 data class SidewalkSurfaceAnswer(
     val left: SurfaceAnswer?,
     val right: SurfaceAnswer?,

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/SidewalkSurfaceAnswer.kt
@@ -1,12 +1,13 @@
 package de.westnordost.streetcomplete.quests.surface
 
-data class SidewalkSurfaceSide(val surface: Surface)
-
 sealed interface SidewalkSurfaceAnswer
-object SidewalkIsDifferent : SidewalkSurfaceAnswer
 
 data class SidewalkSurface(
     val left: SurfaceAnswer?,
     val right: SurfaceAnswer?,
 ) : SidewalkSurfaceAnswer
+
+object SidewalkIsDifferent : SidewalkSurfaceAnswer
+
+data class SidewalkSurfaceSide(val surface: Surface)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1311,7 +1311,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_sidewalk_value_yes">sidewalk</string>
     <string name="quest_sidewalk_value_no">no sidewalk</string>
     <string name="quest_sidewalk_value_separate">sidewalk, but displayed separately on map</string>
-    <string name="quest_sidewalk_answer_different">The sidewalk situation is different</string>
+    <string name="quest_sidewalk_answer_different">Sidewalk situation is different</string>
     <string name="quest_sidewalk_answer_none">No sidewalk at all</string>
     <string name="quest_sidewalk_answer_none_title">Selecting that sidewalks are missing</string>
     <string name="quest_side_select_interface_explanation">Tap one side and select the matching answer.\nDo the same for the other side if present.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1311,6 +1311,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_sidewalk_value_yes">sidewalk</string>
     <string name="quest_sidewalk_value_no">no sidewalk</string>
     <string name="quest_sidewalk_value_separate">sidewalk, but displayed separately on map</string>
+    <string name="quest_sidewalk_answer_different">The sidewalk situation is different</string>
     <string name="quest_sidewalk_answer_none">No sidewalk at all</string>
     <string name="quest_sidewalk_answer_none_title">Selecting that sidewalks are missing</string>
     <string name="quest_side_select_interface_explanation">Tap one side and select the matching answer.\nDo the same for the other side if present.</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
@@ -131,7 +131,7 @@ class AddSidewalkSurfaceTest {
                 "sidewalk:left" to "yes",
                 "sidewalk:right" to "yes",
             ),
-            SidewalkSurface(SidewalkIsDifferent),
+            SidewalkIsDifferent,
             StringMapEntryDelete("sidewalk:left:surface", "asphalt"),
             StringMapEntryDelete("sidewalk:right:surface", "concrete"),
             StringMapEntryDelete("sidewalk:left:smoothness", "excellent"),

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
@@ -122,6 +122,25 @@ class AddSidewalkSurfaceTest {
         )
     }
 
+    @Test fun `remove all sidewalk information`() {
+        questType.verifyAnswer(
+            mapOf("sidewalk:left:surface" to "asphalt",
+                "sidewalk:right:surface" to "concrete",
+                "sidewalk:left:smoothness" to "excellent",
+                "sidewalk:right:smoothness" to "good",
+                "sidewalk:left" to "yes",
+                "sidewalk:right" to "yes",
+            ),
+            SidewalkSurfaceAnswer(SidewalkIsDifferent),
+            StringMapEntryDelete("sidewalk:left:surface", "asphalt"),
+            StringMapEntryDelete("sidewalk:right:surface", "concrete"),
+            StringMapEntryDelete("sidewalk:left:smoothness", "excellent"),
+            StringMapEntryDelete("sidewalk:right:smoothness", "good"),
+            StringMapEntryDelete("sidewalk:left", "yes"),
+            StringMapEntryDelete("sidewalk:right", "yes")
+        )
+    }
+
     private fun assertIsApplicable(vararg pairs: Pair<String, String>) {
         assertTrue(questType.isApplicableTo(way(nodes = listOf(1, 2, 3), tags = mapOf(*pairs))))
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
@@ -131,7 +131,7 @@ class AddSidewalkSurfaceTest {
                 "sidewalk:left" to "yes",
                 "sidewalk:right" to "yes",
             ),
-            SidewalkSurfaceAnswer(SidewalkIsDifferent),
+            SidewalkSurface(SidewalkIsDifferent),
             StringMapEntryDelete("sidewalk:left:surface", "asphalt"),
             StringMapEntryDelete("sidewalk:right:surface", "concrete"),
             StringMapEntryDelete("sidewalk:left:smoothness", "excellent"),

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
@@ -46,14 +46,14 @@ class AddSidewalkSurfaceTest {
 
     @Test fun `apply asphalt surface on both sides`() {
         questType.verifyAnswer(
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.ASPHALT)),
+            SidewalkSurface(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.ASPHALT)),
             StringMapEntryAdd("sidewalk:both:surface", "asphalt")
         )
     }
 
     @Test fun `apply different surface on each side`() {
         questType.verifyAnswer(
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.PAVING_STONES)),
+            SidewalkSurface(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.PAVING_STONES)),
             StringMapEntryAdd("sidewalk:left:surface", "asphalt"),
             StringMapEntryAdd("sidewalk:right:surface", "paving_stones")
         )
@@ -61,7 +61,7 @@ class AddSidewalkSurfaceTest {
 
     @Test fun `apply generic surface on both sides`() {
         questType.verifyAnswer(
-            SidewalkSurfaceAnswer(
+            SidewalkSurface(
                 SurfaceAnswer(Surface.PAVED_ROAD, "note"),
                 SurfaceAnswer(Surface.PAVED_ROAD, "note")),
             StringMapEntryAdd("sidewalk:both:surface", "paved"),
@@ -72,7 +72,7 @@ class AddSidewalkSurfaceTest {
     @Test fun `updates check_date`() {
         questType.verifyAnswer(
             mapOf("sidewalk:both:surface" to "asphalt", "check_date:sidewalk:surface" to "2000-10-10"),
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.ASPHALT)),
+            SidewalkSurface(SurfaceAnswer(Surface.ASPHALT), SurfaceAnswer(Surface.ASPHALT)),
             StringMapEntryModify("sidewalk:both:surface", "asphalt", "asphalt"),
             StringMapEntryModify("check_date:sidewalk:surface", "2000-10-10", LocalDate.now().toCheckDateString()),
         )
@@ -81,7 +81,7 @@ class AddSidewalkSurfaceTest {
     @Test fun `sidewalk surface changes to be the same on both sides`() {
         questType.verifyAnswer(
             mapOf("sidewalk:left:surface" to "asphalt", "sidewalk:right:surface" to "paving_stones"),
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.CONCRETE), SurfaceAnswer(Surface.CONCRETE)),
+            SidewalkSurface(SurfaceAnswer(Surface.CONCRETE), SurfaceAnswer(Surface.CONCRETE)),
             StringMapEntryDelete("sidewalk:left:surface", "asphalt"),
             StringMapEntryDelete("sidewalk:right:surface", "paving_stones"),
             StringMapEntryAdd("sidewalk:both:surface", "concrete")
@@ -91,7 +91,7 @@ class AddSidewalkSurfaceTest {
     @Test fun `sidewalk surface changes on each side`() {
         questType.verifyAnswer(
             mapOf("sidewalk:left:surface" to "asphalt", "sidewalk:right:surface" to "paving_stones"),
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.CONCRETE), SurfaceAnswer(Surface.GRAVEL)),
+            SidewalkSurface(SurfaceAnswer(Surface.CONCRETE), SurfaceAnswer(Surface.GRAVEL)),
             StringMapEntryModify("sidewalk:left:surface", "asphalt", "concrete"),
             StringMapEntryModify("sidewalk:right:surface", "paving_stones", "gravel"),
         )
@@ -100,7 +100,7 @@ class AddSidewalkSurfaceTest {
     @Test fun `smoothness tag removed when surface changes, same on both sides`() {
         questType.verifyAnswer(
             mapOf("sidewalk:both:surface" to "asphalt", "sidewalk:both:smoothness" to "excellent"),
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.PAVING_STONES), SurfaceAnswer(Surface.PAVING_STONES)),
+            SidewalkSurface(SurfaceAnswer(Surface.PAVING_STONES), SurfaceAnswer(Surface.PAVING_STONES)),
             StringMapEntryDelete("sidewalk:both:smoothness", "excellent"),
             StringMapEntryModify("sidewalk:both:surface", "asphalt", "paving_stones")
         )
@@ -113,7 +113,7 @@ class AddSidewalkSurfaceTest {
                 "sidewalk:left:smoothness" to "excellent",
                 "sidewalk:right:smoothness" to "good"
             ),
-            SidewalkSurfaceAnswer(SurfaceAnswer(Surface.PAVING_STONES), SurfaceAnswer(Surface.PAVING_STONES)),
+            SidewalkSurface(SurfaceAnswer(Surface.PAVING_STONES), SurfaceAnswer(Surface.PAVING_STONES)),
             StringMapEntryDelete("sidewalk:left:surface", "asphalt"),
             StringMapEntryDelete("sidewalk:right:surface", "concrete"),
             StringMapEntryDelete("sidewalk:left:smoothness", "excellent"),


### PR DESCRIPTION
When  _"The sidewalk situation is different"_, it removes `sidewalk=*` and `sidewalk:*=*` tags, allowing the user to subsequently give correct on-the-ground answer. It also adds new test to check new option works correctly.

(When reviewing, you may want to use ["?w=1"](https://github.com/streetcomplete/StreetComplete/pull/4508/files?w=1) to ignore whitespace changes in GitHub as I needed to restructure some code making the diff seem bigger than it is).

Closes: https://github.com/streetcomplete/StreetComplete/issues/4495
(also closes https://github.com/streetcomplete/StreetComplete/issues/3920)
