### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx1024m
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 


### PR DESCRIPTION
This PR disables the Jetifier tool tool, which was used to migrate support-library-dependent libraries to rely on the equivalent AndroidX packages. As can be seen from the screenshot of Android Studio's build analyzer below, there are no longer any dependencies that require the use of the Jetifier tool. Turning it off didn't make a noticeable difference in build times for me, though.

![Jetifier](https://user-images.githubusercontent.com/6892794/196005367-912cbd5e-3224-4856-8a5c-e46a09b2223a.png)
