### PR TITLE
Don't change timestamp when splitting a way

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayAction.kt
@@ -131,9 +131,10 @@ private fun getSplitWayAtIndices(
 
     return nodesChunks.mapIndexed { index, nodes ->
         if (index == indexOfChunkToKeep) {
-            Way(originalWay.id, nodes, tags, originalWay.version, currentTimeMillis())
+            // keep the original timestampEdited, so resurvey quests are still shown after splitting
+            Way(originalWay.id, nodes, tags, originalWay.version, originalWay.timestampEdited)
         } else {
-            Way(idProvider.nextWayId(), nodes, tags, 0, currentTimeMillis())
+            Way(idProvider.nextWayId(), nodes, tags, 0, originalWay.timestampEdited)
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayAction.kt
@@ -130,8 +130,8 @@ private fun getSplitWayAtIndices(
     removeTagsThatArePotentiallyWrongAfterSplit(tags)
 
     return nodesChunks.mapIndexed { index, nodes ->
+        // keep the original timestampEdited, so resurvey quests are still shown after splitting (only when auto-sync is off)
         if (index == indexOfChunkToKeep) {
-            // keep the original timestampEdited, so resurvey quests are still shown after splitting
             Way(originalWay.id, nodes, tags, originalWay.version, originalWay.timestampEdited)
         } else {
             Way(idProvider.nextWayId(), nodes, tags, 0, originalWay.timestampEdited)


### PR DESCRIPTION
Fixes resurvey quests disappearing when splitting a way (only with auto-sync off), as discussed in #3567.
Tested and works.