### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'
@@ -26,7 +26,7 @@ jobs:
     - name: Rename APK
       run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$(git log -n 1 --format='%h').apk
     - name: Archive APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
         name: debug-apk
         path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/generate-quest-list.yml
+++ b/.github/workflows/generate-quest-list.yml
@@ -10,9 +10,9 @@ jobs:
     name: Generate quest list
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -21,7 +21,7 @@ jobs:
         run: chmod +x gradlew
       - name: Generate quest list
         run: ./gradlew generateQuestList
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: quest-list.csv
           path: ./quest-list.csv

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,5 +16,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       lintResultFilename: ktlint-result.txt
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
       - name: Run Kotlin linter
         id: ktlint-check
         uses: musichin/ktlint-check@v1.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'


### PR DESCRIPTION
This PR fixes GitHub compilation deprecation warnings by using newer version of actions `v3` instead of `v2`, before GitHub removes support completely. 
Tested and it makes warnings go away, while action results work fine (as it did before depreciations).

---

GitHub was complaining  that:

> Node.js 12 actions are deprecated. For more information see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
  Please update the following actions to use Node.js 16

and 
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more
information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
