### PR TITLE
Fix crash when onDestroy is not called in StyleableOverlayManager

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -109,11 +109,11 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
 
         questPinsManager = QuestPinsManager(ctrl, pinsMapComponent!!, questTypeOrderSource, questTypeRegistry, resources, visibleQuestsSource)
         viewLifecycleOwner.lifecycle.addObserver(questPinsManager!!)
-        questPinsManager!!.isActive = pinMode == PinMode.QUESTS
+        questPinsManager!!.isVisible = pinMode == PinMode.QUESTS
 
         editHistoryPinsManager = EditHistoryPinsManager(pinsMapComponent!!, editHistorySource, resources)
         viewLifecycleOwner.lifecycle.addObserver(editHistoryPinsManager!!)
-        editHistoryPinsManager!!.isActive = pinMode == PinMode.EDITS
+        editHistoryPinsManager!!.isVisible = pinMode == PinMode.EDITS
 
         styleableOverlayMapComponent = StyleableOverlayMapComponent(resources, ctrl)
         styleableOverlayManager = StyleableOverlayManager(ctrl, styleableOverlayMapComponent!!, mapDataSource, selectedOverlaySource)
@@ -273,16 +273,16 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
          */
         when (pinMode) {
             PinMode.QUESTS -> {
-                editHistoryPinsManager?.isActive = false
-                questPinsManager?.isActive = true
+                editHistoryPinsManager?.isVisible = false
+                questPinsManager?.isVisible = true
             }
             PinMode.EDITS -> {
-                questPinsManager?.isActive = false
-                editHistoryPinsManager?.isActive = true
+                questPinsManager?.isVisible = false
+                editHistoryPinsManager?.isVisible = true
             }
             else -> {
-                questPinsManager?.isActive = false
-                editHistoryPinsManager?.isActive = false
+                questPinsManager?.isVisible = false
+                editHistoryPinsManager?.isVisible = false
             }
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
@@ -58,7 +58,6 @@ class StyleableOverlayManager(
         }
     }
 
-    private var mapDataListenerActive = false
     private val mapDataListener = object : MapDataWithEditsSource.Listener {
         override fun onUpdated(updated: MapDataWithGeometry, deleted: Collection<ElementKey>) {
             val oldUpdateJob = updateJob
@@ -82,44 +81,28 @@ class StyleableOverlayManager(
         super.onStart(owner)
         overlay = selectedOverlaySource.selectedOverlay
         selectedOverlaySource.addListener(overlayListener)
-        startListeningToMapData()
     }
 
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
+        overlay = null
         selectedOverlaySource.removeListener(overlayListener)
-        stopListeningToMapData()
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
-        hide()
         viewLifecycleScope.cancel()
     }
 
     private fun show() {
         clear()
         onNewScreenPosition()
-        startListeningToMapData()
+        mapDataSource.addListener(mapDataListener)
     }
 
     private fun hide() {
         viewLifecycleScope.coroutineContext.cancelChildren()
         clear()
-        stopListeningToMapData()
-    }
-
-    private fun startListeningToMapData() {
-        if (!mapDataListenerActive && overlay != null) {
-            mapDataSource.addListener(mapDataListener)
-            mapDataListenerActive = true
-        }
-    }
-
-    private fun stopListeningToMapData() {
-        if (mapDataListenerActive) {
-            mapDataSource.removeListener(mapDataListener)
-            mapDataListenerActive = false
-        }
+        mapDataSource.removeListener(mapDataListener)
     }
 
     fun onNewScreenPosition() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
@@ -58,6 +58,7 @@ class StyleableOverlayManager(
         }
     }
 
+    private var mapDataListenerActive = false
     private val mapDataListener = object : MapDataWithEditsSource.Listener {
         override fun onUpdated(updated: MapDataWithGeometry, deleted: Collection<ElementKey>) {
             val oldUpdateJob = updateJob
@@ -81,11 +82,13 @@ class StyleableOverlayManager(
         super.onStart(owner)
         overlay = selectedOverlaySource.selectedOverlay
         selectedOverlaySource.addListener(overlayListener)
+        startListeningToMapData()
     }
 
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         selectedOverlaySource.removeListener(overlayListener)
+        stopListeningToMapData()
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
@@ -96,13 +99,27 @@ class StyleableOverlayManager(
     private fun show() {
         clear()
         onNewScreenPosition()
-        mapDataSource.addListener(mapDataListener)
+        startListeningToMapData()
     }
 
     private fun hide() {
         viewLifecycleScope.coroutineContext.cancelChildren()
         clear()
-        mapDataSource.removeListener(mapDataListener)
+        stopListeningToMapData()
+    }
+
+    private fun startListeningToMapData() {
+        if (!mapDataListenerActive && overlay != null) {
+            mapDataSource.addListener(mapDataListener)
+            mapDataListenerActive = true
+        }
+    }
+
+    private fun stopListeningToMapData() {
+        if (mapDataListenerActive) {
+            mapDataSource.removeListener(mapDataListener)
+            mapDataListenerActive = false
+        }
     }
 
     fun onNewScreenPosition() {


### PR DESCRIPTION
This PR fixes #4540. I was not able to reproduce the crash with these changes.

While I haven't been able to find any problems with the overlays during testing, I don't know if there is some logic in the app that was based on the previous leaky behavior.