### PR TITLE
If more specific access (like hgv=*) is already specified, skip the quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -15,11 +15,19 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     // though.
     //
     // Cf. #2408: Parking access might omit parking=street_side
+    // Cf. #4538: should skip elements with more specific access tag already mapped
     override val elementFilter = """
         nodes, ways, relations with amenity = parking
         and (
             access = unknown
-            or (!access and parking !~ street_side|lane)
+            or (parking !~ street_side|lane and !access and
+              !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar and !motorhome and
+              !tourist_bus and !coach and !goods and !hgv and !hgv_articulated and !bdouble and
+              !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and !ohv and
+              !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and !hov and
+              !carpool and !car_sharing and !emergency and !hazmat and !water and !disabled and
+              !4wd_only and !roadtrain and !lhv and !tank
+            )
         )
     """
     override val changesetComment = "Specify parking access"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -20,14 +20,13 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
         nodes, ways, relations with amenity = parking
         and (
             access = unknown
-            or (parking !~ street_side|lane and !access and
-              !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar and !motorhome and
-              !tourist_bus and !coach and !goods and !hgv and !hgv_articulated and !bdouble and
-              !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and !ohv and
-              !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and !hov and
-              !carpool and !car_sharing and !emergency and !hazmat and !water and !disabled and
-              !4wd_only and !roadtrain and !lhv and !tank
-            )
+            or (!access and parking !~ street_side|lane) and
+            !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar and
+            !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated and
+            !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and
+            !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and
+            !hov and !carpool and !car_sharing and !emergency and !hazmat and !water and
+            !disabled and !4wd_only and !roadtrain and !lhv and !tank
         )
     """
     override val changesetComment = "Specify parking access"


### PR DESCRIPTION
We skip them, in order to not introduce more problems.

PR [compiles sucessfully](https://github.com/mnalis/StreetComplete/actions/runs/3313012182) and seems to work fine. (e.g. no longer asks for parking access on [w79658967](https://www.openstreetmap.org/way/79658967), while normally asking elsewhere).
 
Closes: https://github.com/streetcomplete/StreetComplete/issues/4538
