### PR TITLE
Add move node action

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
@@ -19,6 +19,8 @@ import de.westnordost.streetcomplete.data.osm.edits.create.CreateNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.create.RevertCreateNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.delete.DeletePoiNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.delete.RevertDeletePoiNodeAction
+import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
+import de.westnordost.streetcomplete.data.osm.edits.move.RevertMoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.RevertUpdateElementTagsAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
@@ -48,6 +50,8 @@ class ElementEditsDao(
                 subclass(RevertDeletePoiNodeAction::class)
                 subclass(CreateNodeAction::class)
                 subclass(RevertCreateNodeAction::class)
+                subclass(MoveNodeAction::class)
+                subclass(RevertMoveNodeAction::class)
             }
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.edits
 
+import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryEntry
@@ -427,7 +428,21 @@ class MapDataWithEditsSource internal constructor(
             updatedElements[key] = element
             updatedGeometries[key] = createGeometry(element)
         }
-        return MapDataUpdates(updated = updates, deleted = deletedKeys)
+
+        // get affected ways and relations and update geometries if a node was moved
+        val elementsWithChangedGeometry = mutableListOf<Element>()
+        if (edit.action is MoveNodeAction) {
+            val waysContainingNode = getWaysForNode(edit.elementId)
+            val affectedRelations = getRelationsForNode(edit.elementId) + waysContainingNode.flatMap { getRelationsForWay(it.id) }
+            for (element in waysContainingNode + affectedRelations) {
+                val key = ElementKey(element.type, element.id)
+                deletedElements.remove(key)
+                updatedElements[key] = element
+                updatedGeometries[key] = createGeometry(element)
+                elementsWithChangedGeometry.add(element) // questController needs to know that element was affected (though it was not updated in OSM sense)
+            }
+        }
+        return MapDataUpdates(updated = updates + elementsWithChangedGeometry, deleted = deletedKeys)
     }
 
     private fun createGeometry(element: Element): ElementGeometry? {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/MoveNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/MoveNodeAction.kt
@@ -1,0 +1,37 @@
+package de.westnordost.streetcomplete.data.osm.edits.move
+
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
+import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
+import de.westnordost.streetcomplete.data.osm.edits.IsActionRevertable
+import de.westnordost.streetcomplete.data.osm.edits.NewElementsCount
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.isGeometrySubstantiallyDifferent
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.upload.ConflictException
+import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
+import kotlinx.serialization.Serializable
+
+/** Action that moves a node. */
+@Serializable
+data class MoveNodeAction(val position: LatLon) : ElementEditAction, IsActionRevertable {
+
+    override val newElementsCount get() = NewElementsCount(0, 0, 0)
+
+    override fun createUpdates(
+        originalElement: Element,
+        element: Element?,
+        mapDataRepository: MapDataRepository,
+        idProvider: ElementIdProvider
+    ): MapDataChanges {
+        val node = element as? Node ?: throw ConflictException("Element deleted")
+        if (isGeometrySubstantiallyDifferent(originalElement, element)) {
+            throw ConflictException("Element geometry changed substantially")
+        }
+        return MapDataChanges(modifications = listOf(node.copy(position = position)))
+    }
+
+    override fun createReverted(): ElementEditAction = RevertMoveNodeAction
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeAction.kt
@@ -25,6 +25,6 @@ object RevertMoveNodeAction : ElementEditAction, IsRevertAction {
         if (isGeometrySubstantiallyDifferent(originalElement, element)) {
             throw ConflictException("Element geometry changed substantially")
         }
-        return MapDataChanges(deletions = listOf(node.copy(position = (originalElement as Node).position)))
+        return MapDataChanges(modifications = listOf(node.copy(position = (originalElement as Node).position)))
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeAction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeAction.kt
@@ -1,0 +1,30 @@
+package de.westnordost.streetcomplete.data.osm.edits.move
+
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
+import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
+import de.westnordost.streetcomplete.data.osm.edits.IsRevertAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.isGeometrySubstantiallyDifferent
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.upload.ConflictException
+import kotlinx.serialization.Serializable
+
+/** Action reverts moving a node. */
+@Serializable
+object RevertMoveNodeAction : ElementEditAction, IsRevertAction {
+
+    override fun createUpdates(
+        originalElement: Element,
+        element: Element?,
+        mapDataRepository: MapDataRepository,
+        idProvider: ElementIdProvider
+    ): MapDataChanges {
+        val node = element as? Node ?: throw ConflictException("Element deleted")
+        if (isGeometrySubstantiallyDifferent(originalElement, element)) {
+            throw ConflictException("Element geometry changed substantially")
+        }
+        return MapDataChanges(deletions = listOf(node.copy(position = (originalElement as Node).position)))
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -50,6 +50,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuest
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestHidden
@@ -77,6 +78,7 @@ import de.westnordost.streetcomplete.screens.HandlesOnBackPressed
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.CreateNoteFragment
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsCloseableBottomSheet
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapOrientationAware
+import de.westnordost.streetcomplete.screens.main.bottom_sheet.MoveNodeFragment
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.SplitWayFragment
 import de.westnordost.streetcomplete.screens.main.controls.LocationStateButton
 import de.westnordost.streetcomplete.screens.main.controls.MainMenuButtonFragment
@@ -152,6 +154,7 @@ class MainFragment :
     NoteDiscussionForm.Listener,
     LeaveNoteInsteadFragment.Listener,
     CreateNoteFragment.Listener,
+    MoveNodeFragment.Listener,
     EditHistoryFragment.Listener,
     MainMenuButtonFragment.Listener,
     UndoButtonFragment.Listener,
@@ -469,6 +472,24 @@ class MainFragment :
 
     override fun onSplittedWay(editType: ElementEditType, way: Way, geometry: ElementPolylinesGeometry) {
         showQuestSolvedAnimation(editType.icon, geometry.center)
+        closeBottomSheet()
+    }
+
+    /* ------------------------------- MoveNodeFragment.Listener -------------------------------- */
+
+    override fun onMoveNode(editType: ElementEditType, node: Node) {
+        val mapFragment = mapFragment ?: return
+        showInBottomSheet(MoveNodeFragment.create(editType, node))
+        mapFragment.hideNonHighlightedPins()
+        mapFragment.hideOverlay()
+
+        mapFragment.show3DBuildings = false
+        val offsetPos = mapFragment.getPositionThatCentersPosition(node.position, mapOffsetWithOpenBottomSheet)
+        mapFragment.updateCameraPosition { position = offsetPos }
+    }
+
+    override fun onMovedNode(editType: ElementEditType, position: LatLon) {
+        showQuestSolvedAnimation(editType.icon, position)
         closeBottomSheet()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/MoveNodeFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/MoveNodeFragment.kt
@@ -1,0 +1,146 @@
+package de.westnordost.streetcomplete.screens.main.bottom_sheet
+
+import android.content.res.Configuration
+import android.graphics.Point
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.UiThread
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditType
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditsController
+import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
+import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
+import de.westnordost.streetcomplete.databinding.FragmentCreateNoteBinding
+import de.westnordost.streetcomplete.overlays.IsShowingElement
+import de.westnordost.streetcomplete.util.ktx.getLocationInWindow
+import de.westnordost.streetcomplete.util.ktx.popIn
+import de.westnordost.streetcomplete.util.ktx.viewLifecycleScope
+import de.westnordost.streetcomplete.util.math.distanceTo
+import de.westnordost.streetcomplete.util.viewBinding
+import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.koin.android.ext.android.inject
+
+/** Fragment that lets the user move an OSM node */
+class MoveNodeFragment :
+    Fragment(R.layout.fragment_create_note), IsCloseableBottomSheet, IsShowingElement {
+
+    private val binding by viewBinding(FragmentCreateNoteBinding::bind)
+    private val bottomSheetBinding get() = binding.questAnswerLayout
+    private val okButton get() = bottomSheetBinding.okButton
+    private val okButtonContainer get() = bottomSheetBinding.okButtonContainer
+
+    private val elementEditsController: ElementEditsController by inject()
+    private val questTypeRegistry: QuestTypeRegistry by inject()
+    private val overlayRegistry: OverlayRegistry by inject()
+
+    override val elementKey: ElementKey by lazy { ElementKey(node.type, node.id) }
+
+    private lateinit var node: Node
+    private lateinit var editType: ElementEditType
+
+    private val hasChanges get() = getPosition() != node.position
+    private val isFormComplete get() = hasChanges //&& getPosition()?.distanceTo(node.position)?.let { it > 2.0 } ?: false // this is ugly
+
+    interface Listener {
+        fun getMapPositionAt(screenPos: Point): LatLon?
+
+        fun onMovedNode(editType: ElementEditType, position: LatLon)
+    }
+    private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
+
+    private fun getPosition(): LatLon? {
+        val createNoteMarker = binding.markerCreateLayout.createNoteMarker
+        val screenPos = createNoteMarker.getLocationInWindow()
+        screenPos.offset(createNoteMarker.width / 2, createNoteMarker.height / 2)
+        return listener?.getMapPositionAt(screenPos)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val args = requireArguments()
+        node = Json.decodeFromString(args.getString(ARG_NODE)!!)
+        editType = questTypeRegistry.getByName(args.getString(ARG_QUESTTYPE)!!) as? OsmElementQuestType<*>
+            ?: overlayRegistry.getByName(args.getString(ARG_QUESTTYPE)!!)!!
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        okButton.setOnClickListener { onClickOk() }
+        okButtonContainer.popIn()
+        okButton.popIn()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        binding.markerCreateLayout.centeredMarkerLayout.setPadding(
+            resources.getDimensionPixelSize(R.dimen.quest_form_leftOffset),
+            resources.getDimensionPixelSize(R.dimen.quest_form_topOffset),
+            resources.getDimensionPixelSize(R.dimen.quest_form_rightOffset),
+            resources.getDimensionPixelSize(R.dimen.quest_form_bottomOffset)
+        )
+    }
+
+    private fun onClickOk() {
+        val pos = getPosition() ?: return
+        viewLifecycleScope.launch {
+            val action = MoveNodeAction(pos)
+            elementEditsController.add(editType, node, ElementPointGeometry(node.position), "survey", action)
+            listener?.onMovedNode(editType, pos)
+        }
+    }
+
+    override fun onClickMapAt(position: LatLon, clickAreaSizeInMeters: Double): Boolean {
+        // todo: maybe move map to this position? what would a "normal" person expect?
+        return false
+    }
+
+    // todo:
+    //  nicer view with that crosshair and distance?
+    //   don't use the note layout!
+    //  hide ok button if not moved, or moved very far -> see MainFragment.onMapIsChanging
+    //  confirm large move
+    //  confirm very small move?
+    //  switch to satellite view??
+
+    @UiThread override fun onClickClose(onConfirmed: () -> Unit) {
+        if (!hasChanges) {
+            onConfirmed()
+        } else {
+            activity?.let {
+                AlertDialog.Builder(it)
+                    .setMessage(R.string.confirmation_discard_title)
+                    .setPositiveButton(R.string.confirmation_discard_positive) { _, _ ->
+                        onConfirmed()
+                    }
+                    .setNegativeButton(R.string.short_no_answer_on_button, null)
+                    .show()
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_NODE = "node"
+        private const val ARG_QUESTTYPE = "quest_type"
+
+        fun create(elementEditType: ElementEditType, node: Node): MoveNodeFragment {
+            val f = MoveNodeFragment()
+            f.arguments = bundleOf(
+                ARG_NODE to Json.encodeToString(node),
+                ARG_QUESTTYPE to elementEditType.name
+            )
+            return f
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
@@ -20,6 +20,7 @@ import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.edits.create.CreateNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.delete.DeletePoiNodeAction
+import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
@@ -118,6 +119,7 @@ class UndoDialog(
                 is DeletePoiNodeAction ->     createTextView(ResText(R.string.deleted_poi_action_description))
                 is SplitWayAction ->          createTextView(ResText(R.string.split_way_action_description))
                 is CreateNodeAction ->        createCreateNodeDescriptionView(action.position, action.tags)
+                is MoveNodeAction ->          createTextView(ResText(R.string.move_node_action_description))
                 else -> throw IllegalArgumentException()
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
@@ -23,6 +23,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.HideOsmQuestController
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -195,6 +196,11 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
 
     override fun onSplitWay(editType: ElementEditType, way: Way, geometry: ElementPolylinesGeometry) {
         message("Splitting way")
+        popQuestForm()
+    }
+
+    override fun onMoveNode(editType: ElementEditType, node: Node) {
+        message("Moving node")
         popQuestForm()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="quest_split_way_too_imprecise">"Please zoom in further"</string>
     <string name="quest_split_way_many_splits_confirmation_description">These are quite a few splits. You can always further split up the way later.</string>
     <string name="split_way">Split way</string>
+    <string name="move_node">Move node</string>
+    <string name="quest_move_node_description">If it is at a wrong position, you can move the node. Pleas be aware that your displayed location and the map may not be exact.\nMove it now?</string>
 
     <string name="quest_source_dialog_title">Are you sure you checked this on-site?</string>
     <string name="quest_source_dialog_note">Only information that was found on a survey should be entered.</string>
@@ -185,6 +187,7 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="split_way_action_description">You split the way</string>
     <string name="deleted_poi_action_description">You deleted it</string>
     <string name="create_node_action_description">You created a node with …</string>
+    <string name="move_node_action_description">You moved the node</string>
     <string name="added_tag_action_title">Added %s</string>
     <string name="removed_tag_action_title">Removed %s</string>
     <string name="changed_tag_action_title">Updated to %s</string>


### PR DESCRIPTION
a start for fixing #3502

Moving a node works, and geometries of elements containing the node are updated and quest geometries are displayed correctly.
I added a "move node" other answer, which is enabled only for nodes not part of a way/relation (to avoid dealing with https://github.com/streetcomplete/StreetComplete/issues/3502#issuecomment-967127770).

There is still some work to be done:
* decide where to enable the move node answer (really all quests with free floating nodes?)
* add some text explaining the users why they can't move all element, as being able to move only some might be confusing
* proper UI instead of abusing the create note layout (see comments in `MoveNodeFragment.kt`)
* unit tests
* try uploading a move node action, and reverting it

If anyone wants to help (especially with the UI), feel free to do so