### PR TITLE
Fix pivot point in StreetParkingDrawable

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingDrawable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingDrawable.kt
@@ -44,10 +44,13 @@ class StreetParkingDrawable(
     override fun draw(canvas: Canvas) {
         if (!isVisible) return
 
+        if (isUpsideDown) {
+            val pivotY = bounds.height() / ceil(height / width / 2f)
+            canvas.scale(1f, -1f, bounds.width() / 2f, pivotY)
+        }
+
         val height = bounds.height().toFloat() / (height / width) * 2f
         val width = bounds.width()
-
-        if (isUpsideDown) canvas.scale(1f, -1f, width / 2f, height)
 
         val omittedCarIndices = getOmittedCarIndices(parkingOrientation, parkingPosition)
         val carWidth = 0.23f * width


### PR DESCRIPTION
Closes #4590 (sorry).

Before my changes in 99be3a9, the car illustrations were shown correctly, but some cars were clipped when editing in a country with left-handed traffic:

<img src="https://user-images.githubusercontent.com/6892794/199593642-0f4aaac9-51d7-4542-bd3d-b84b906161c4.png" width="300">

After my changes in 99be3a9, the pivot point for the `Canvas` rotation / scaling was incorrect and the illustrations were not shown correctly:

<img src="https://user-images.githubusercontent.com/6892794/199593641-287aee14-1a4f-41d0-a695-799ad433adf3.png" width="300">

With this PR both issues are fixed:

<img src="https://user-images.githubusercontent.com/6892794/199593637-aeffb438-d360-4d81-a89f-9b5a50f4a935.png" width="300">

I tested my changes both with left-handed and right-handed traffic and did not notice any new issues.