### PR TITLE
Fix symbols cut off in cycleway overlay

### DIFF
--- a/app/src/main/res/layout/fragment_overlay_image_select.xml
+++ b/app/src/main/res/layout/fragment_overlay_image_select.xml
@@ -19,7 +19,8 @@
             android:id="@+id/selectedCellView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toStartOf="@id/dropDownArrowImageView"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/selectTextView"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
@@ -31,7 +32,7 @@
             android:text="@string/quest_select_hint"
             android:textAppearance="@style/TextAppearance.AppCompat.Widget.Button"
             android:padding="16dp"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@id/selectedCellView"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/dropDownArrowImageView" />
@@ -42,6 +43,8 @@
             android:layout_height="wrap_content"
             android:src="@drawable/ic_arrow_expand_down_24dp"
             android:padding="4dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/selectTextView"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
This PR fixes the cycleway symbols being cut off in the cycleway overlay form by setting the `ConstraintLayout`'s constraints so that the `wrap_content` width of the first and last view inside it are respected.

![Screenshot_20221207_131449](https://user-images.githubusercontent.com/6892794/206178048-605ae70f-9bc5-4aef-b4cb-a660733949e0.png)

I checked that the lit overlay form also still works correctly with these changes.

Fixes #4672.