### PR TITLE
Ask fire hydrant diameter again after 6 years if unsigned

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -18,7 +18,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
          and fire_hydrant:type and
          (fire_hydrant:type = pillar or fire_hydrant:type = underground)
          and !fire_hydrant:diameter
-         and fire_hydrant:diameter:signed != no
+         and (fire_hydrant:diameter:signed != no or fire_hydrant:diameter:signed older today -6 years)
     """
     override val changesetComment = "Specify fire hydrant diameters"
     override val wikiLink = "Tag:emergency=fire_hydrant"


### PR DESCRIPTION
I noticed in my neighborhood that during construction work that moved a street lantern, a fire hydrant sign was installed for an (underground) fire hydrant that has had no sign for a long time (and was otherwise unchanged by the construction works). Since that hydrant was tagged with `fire_hydrant:diameter:signed = no`, StreetComplete would have not asked about that hydrant anymore.

I suggest to ask the diameter quest again after 6 years for hydrants tagged with `fire_hydrant:diameter:signed = no`. In that time, a sign might have been added. Or if the sign was actually installed the first time but quite far away or hidden, resurveying it (maybe by another mapper) might result in the diameter eventually being added.