### PR TITLE
Remember place selection in address form

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/address/StreetOrPlaceNameViewController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/address/StreetOrPlaceNameViewController.kt
@@ -28,7 +28,8 @@ class StreetOrPlaceNameViewController(
     private val streetNameInput: EditText,
     roadNameSuggestionsSource: RoadNameSuggestionsSource,
     abbreviationsByLocale: AbbreviationsByLocale,
-    countryLocale: Locale
+    countryLocale: Locale,
+    startWithPlace: Boolean,
 ) {
     private val streetNameInputCtrl = AddressStreetNameInputViewController(
         streetNameInput, roadNameSuggestionsSource, abbreviationsByLocale, countryLocale
@@ -69,7 +70,7 @@ class StreetOrPlaceNameViewController(
             R.layout.spinner_item,
             StreetOrPlace.values().map { it.toLocalizedString(select.context.resources) }
         )
-        spinnerSelection = STREET
+        spinnerSelection = if (startWithPlace) PLACE else STREET
 
         select.onItemSelectedListener = OnAdapterItemSelectedListener {
             updateInputVisibilities()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
@@ -24,7 +24,7 @@ class AddAddressStreetForm : AbstractOsmQuestForm<StreetOrPlaceName>() {
 
     private lateinit var streetOrPlaceCtrl: StreetOrPlaceNameViewController
 
-    private var isShowingPlaceName = false
+    private var isShowingPlaceName = lastWasPlaceName
 
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_address_street_no_named_streets) { showPlaceName() }
@@ -33,7 +33,7 @@ class AddAddressStreetForm : AbstractOsmQuestForm<StreetOrPlaceName>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        isShowingPlaceName = savedInstanceState?.getBoolean(IS_PLACE_NAME) ?: false
+        isShowingPlaceName = savedInstanceState?.getBoolean(IS_PLACE_NAME) ?: lastWasPlaceName
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -52,7 +52,8 @@ class AddAddressStreetForm : AbstractOsmQuestForm<StreetOrPlaceName>() {
             streetNameInput = binding.streetNameInput,
             roadNameSuggestionsSource = roadNameSuggestionsSource,
             abbreviationsByLocale = abbreviationsByLocale,
-            countryLocale = countryInfo.locale
+            countryLocale = countryInfo.locale,
+            startWithPlace = isShowingPlaceName
         )
         streetOrPlaceCtrl.onInputChanged = { checkIsFormComplete() }
 
@@ -72,6 +73,7 @@ class AddAddressStreetForm : AbstractOsmQuestForm<StreetOrPlaceName>() {
     }
 
     override fun onClickOk() {
+        lastWasPlaceName = isShowingPlaceName
         applyAnswer(streetOrPlaceCtrl.streetOrPlaceName!!)
     }
 
@@ -85,6 +87,8 @@ class AddAddressStreetForm : AbstractOsmQuestForm<StreetOrPlaceName>() {
     }
 
     companion object {
+        private var lastWasPlaceName = false
+
         private const val IS_PLACE_NAME = "is_place_name"
     }
 }


### PR DESCRIPTION
Improves #4178

Starting in place-mode massively accelerates adding addresses when there are no street names. Plus, it has the side-effect of making the address overlay functionality to remember last used place name work.

While the improvements described in https://github.com/streetcomplete/StreetComplete/issues/4718#issuecomment-1382565191 would be superior, it is definitely more effort to implement (maybe later).