### PR TITLE
Parse housenumbers starting with letter

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/address/HouseNumbers.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/address/HouseNumbers.kt
@@ -89,6 +89,14 @@ data class HouseNumberWithLetter(
 ) : StructuredHouseNumber() {
     override fun toString() = "$number$separator$letter"
 }
+/** e.g. C-12 */
+data class HouseNumberWithLetterAtStart(
+    override val number: Int,
+    val separator: String,
+    val letter: String
+) : StructuredHouseNumber() {
+    override fun toString() = "$letter$separator$number"
+}
 /** e.g. 12/3 */
 data class HouseNumberWithNumber(
     override val number: Int,

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtil.kt
@@ -8,16 +8,20 @@ fun addToHouseNumber(houseNumber: String, add: Int): String? {
             is SingleHouseNumbersPart -> listOf(it.single.number)
         }
     }
+    val p = parsed.list.singleOrNull()
+    val firstPart = if (p is SingleHouseNumbersPart && p.single is HouseNumberWithLetterAtStart)
+        p.single.letter + p.single.separator
+        else ""
     when {
         add == 0 -> return houseNumber
         add > 0 -> {
             val max = numbers.maxOrNull() ?: return null
-            return (max + add).toString()
+            return firstPart + (max + add)
         }
         add < 0 -> {
             val min = numbers.minOrNull() ?: return null
             val result = min + add
-            return if (result < 1) null else result.toString()
+            return if (result < 1) null else firstPart + result
         }
         else -> return null
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersParserKtTest.kt
@@ -30,6 +30,9 @@ class HouseNumbersParserKtTest {
         assertParses("1,3,5-8,12,21-24B")
 
         assertParses("10-4")
+        assertParses("B-145")
+        assertParses("BA-145")
+        assertParses("B145")
 
         assertParsingFails("10-b")
         assertParsingFails("-1")

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtilKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtilKtTest.kt
@@ -8,6 +8,7 @@ class HouseNumbersUtilKtTest {
     @Test fun addZero() {
         assertEquals("1", addToHouseNumber("1", 0))
         assertEquals("1c", addToHouseNumber("1c", 0))
+        assertEquals("M-2", addToHouseNumber("M-2", 0))
     }
 
     @Test fun addOne() {
@@ -18,6 +19,8 @@ class HouseNumbersUtilKtTest {
         assertEquals("7", addToHouseNumber("2,6,3", 1))
         assertEquals("7", addToHouseNumber("2,6/3,3", 1))
         assertEquals("9", addToHouseNumber("2,6-8,3", 1))
+        assertEquals("C-14", addToHouseNumber("C-13", 1))
+        assertEquals("CA14", addToHouseNumber("CA13", 1))
     }
 
     @Test fun subtractOne() {
@@ -37,5 +40,7 @@ class HouseNumbersUtilKtTest {
         assertEquals(null, addToHouseNumber("6,1/4-8,3", -1))
         assertEquals("1", addToHouseNumber("6,2-8,3", -1))
         assertEquals("1", addToHouseNumber("6,2f-8,3", -1))
+        assertEquals(null, addToHouseNumber("C-1", -1))
+        assertEquals("C/12", addToHouseNumber("C/13", -1))
     }
 }


### PR DESCRIPTION
Improves #4718

This allows housenumber parsing for numbers like C-245, and some similar housenumbers I found when randomly checking housenumbers in India: up to two letters, and `-`, `/` or nothing as separator.

Though maybe the added parsing doesn't integrate nicely with the other code, maybe this should be improved?