### PR TITLE
Add 'Uncheck all' button to Weekday Picker

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/WeekdaysPickerDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/WeekdaysPickerDialog.kt
@@ -1,6 +1,9 @@
 package de.westnordost.streetcomplete.quests.opening_hours
 
 import android.content.Context
+import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.osm.opening_hours.model.Weekdays
@@ -19,12 +22,23 @@ object WeekdaysPickerDialog {
             localeWeekdayName + if (weekdayName != localeWeekdayName) " — $weekdayName" else ""
         }.toTypedArray()
 
-        return AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(context)
             .setTitle(R.string.quest_openingHours_chooseWeekdaysTitle)
             .setMultiChoiceItems(names, selection) { _, _, _ -> }
+            .setNeutralButton("Uncheck all") { _, _ ->  }
             .setNegativeButton(android.R.string.cancel, null)
-            .setButton(android.R.string.uncheckAll, null)
             .setPositiveButton(android.R.string.ok) { _, _ -> callback(Weekdays(selection)) }
-            .show()
+
+        val created = builder.create();
+        created.show();
+
+        // TODO: overriding the `Uncheck all` listener to keep it from closing isn't working currently.
+        created.getButton(AlertDialog.BUTTON_NEUTRAL)
+            .setOnClickListener { _ -> run {
+                val view = created.listView;
+                selection.forEachIndexed { i, _ -> view.setItemChecked(i, false) }
+            }}
+
+        return created;
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/WeekdaysPickerDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/WeekdaysPickerDialog.kt
@@ -23,6 +23,7 @@ object WeekdaysPickerDialog {
             .setTitle(R.string.quest_openingHours_chooseWeekdaysTitle)
             .setMultiChoiceItems(names, selection) { _, _, _ -> }
             .setNegativeButton(android.R.string.cancel, null)
+            .setButton(android.R.string.uncheckAll, null)
             .setPositiveButton(android.R.string.ok) { _, _ -> callback(Weekdays(selection)) }
             .show()
     }


### PR DESCRIPTION
I've been using StreetComplete frequently, and often it's faster to clear the selection of all of the weekdays when specifying opening hours than to uncheck all of the ones you don't want. This PR attempts to introduce a neutral button, 'Uncheck all', to the dialog that unchecks all of the checkboxes while leaving the window open.

TODO:
- Fix overriding the button's onClick to allow it to refresh the array on click. It's necessary to override the method to prevent the dialog from closing when pressing the neutral button. I'm not sure why, but the list isn't being refreshed.
- Add internationalization to 'clear all'

Any help would be appreciated!