### PR TITLE
Display name in undo dialog

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.edithistory.Edit
 import de.westnordost.streetcomplete.data.edithistory.EditHistoryController
@@ -36,6 +37,7 @@ import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestHidden
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.databinding.DialogUndoBinding
 import de.westnordost.streetcomplete.quests.getHtmlQuestTitle
+import de.westnordost.streetcomplete.util.getNameAndLocationLabel
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import de.westnordost.streetcomplete.view.CharSequenceText
 import de.westnordost.streetcomplete.view.ResText
@@ -49,7 +51,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.koin.core.qualifier.named
 import java.util.MissingFormatArgumentException
+import java.util.concurrent.FutureTask
 
 class UndoDialog(
     context: Context,
@@ -58,6 +62,9 @@ class UndoDialog(
 
     private val mapDataSource: MapDataWithEditsSource by inject()
     private val editHistoryController: EditHistoryController by inject()
+    private val featureDictionaryFuture: FutureTask<FeatureDictionary> by inject(named("FeatureDictionaryFuture"))
+
+    private val featureDictionary: FeatureDictionary get() = featureDictionaryFuture.get()
 
     private val binding = DialogUndoBinding.inflate(LayoutInflater.from(context))
 
@@ -83,6 +90,8 @@ class UndoDialog(
         super.onCreate(savedInstanceState)
         scope.launch {
             binding.titleText.text = edit.getTitle()
+            if (edit is ElementEdit)
+                binding.titleHintText.text = getNameAndLocationLabel(edit.originalElement, context.resources, featureDictionary)
         }
     }
 

--- a/app/src/main/res/layout/dialog_undo.xml
+++ b/app/src/main/res/layout/dialog_undo.xml
@@ -44,12 +44,26 @@
         android:layout_marginStart="@dimen/dialog_horizontal_margin"
         android:layout_toEndOf="@id/icon"
         android:textAppearance="@android:style/TextAppearance.Theme.Dialog"
-        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintBottom_toTopOf="@id/titleHintText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintTop_toTopOf="@id/icon"
         tools:ignore="RtlSymmetry"
         tools:text="@string/quest_address_title" />
+
+    <TextView
+        android:id="@+id/titleHintText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dialog_horizontal_margin"
+        android:layout_toEndOf="@id/icon"
+        android:textAppearance="@style/TextAppearance.Title.Hint"
+        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toBottomOf="@id/titleText"
+        tools:ignore="RtlSymmetry"
+        tools:text="Building" />
 
     <View
         android:id="@+id/divider"


### PR DESCRIPTION
fix #4767 

This shows name and location label below the question in undo dialog, just like in the quest form.
I'm not sure how useful the location part is here, but there were no negative reactions on https://github.com/streetcomplete/StreetComplete/issues/4767#issuecomment-1407126969