### PR TITLE
Set default theme to system on Android 11+

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -46,6 +46,7 @@ import de.westnordost.streetcomplete.screens.measure.arModule
 import de.westnordost.streetcomplete.screens.settings.ResurveyIntervalsUpdater
 import de.westnordost.streetcomplete.screens.settings.settingsModule
 import de.westnordost.streetcomplete.util.CrashReportExceptionHandler
+import de.westnordost.streetcomplete.util.getDefaultTheme
 import de.westnordost.streetcomplete.util.getSelectedLocale
 import de.westnordost.streetcomplete.util.getSystemLocales
 import de.westnordost.streetcomplete.util.ktx.addedToFront
@@ -183,7 +184,7 @@ class StreetCompleteApplication : Application() {
     }
 
     private fun setDefaultTheme() {
-        val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
+        val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, getDefaultTheme())!!)
         AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
@@ -31,6 +31,7 @@ import de.westnordost.streetcomplete.databinding.DialogDeleteCacheBinding
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.screens.settings.debug.ShowLinksActivity
 import de.westnordost.streetcomplete.screens.settings.debug.ShowQuestFormsActivity
+import de.westnordost.streetcomplete.util.getDefaultTheme
 import de.westnordost.streetcomplete.util.getSelectedLocales
 import de.westnordost.streetcomplete.util.ktx.format
 import de.westnordost.streetcomplete.util.ktx.getYamlObject
@@ -171,7 +172,7 @@ class SettingsFragment :
                 }
             }
             Prefs.THEME_SELECT -> {
-                val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
+                val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, getDefaultTheme())!!)
                 AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
                 activity?.let { ActivityCompat.recreate(it) }
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Theme.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Theme.kt
@@ -1,0 +1,9 @@
+package de.westnordost.streetcomplete.util
+
+import android.os.Build
+
+fun getDefaultTheme(): String =
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R)
+        "AUTO"
+    else
+        "SYSTEM"

--- a/app/src/main/res/values-v30/untranslatableStrings.xml
+++ b/app/src/main/res/values-v30/untranslatableStrings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_theme">SYSTEM</string>
+</resources>

--- a/app/src/main/res/values/untranslatableStrings.xml
+++ b/app/src/main/res/values/untranslatableStrings.xml
@@ -36,4 +36,6 @@
     <string name="quest_policeType_type_it_polizia_ferroviaria" translatable="false">Polizia Ferroviaria</string>
 
     <string name="quest_maxspeed_answer_nsl">"National Speed Limit"</string>
+
+    <string name="default_theme">AUTO</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -62,7 +62,7 @@
             android:key="theme.select"
             android:title="@string/pref_title_theme_select"
             app:useSimpleSummaryProvider="true"
-            android:defaultValue="AUTO"
+            android:defaultValue="@string/default_theme"
             android:entries="@array/pref_entries_theme_select"
             android:entryValues="@array/pref_entryvalues_theme_select"
             android:persistent="true" />


### PR DESCRIPTION
fixes #4710 

This sets the default theme to "system" on Android 11+, and keeps it on "auto" for older versions.
Tested on Android 9 using the version in this PR, and a test version that set theme to "system" on Android 9+ instead of 11+.