### PR TITLE
Autocorrect: use title-case instead of upper-case

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/view/controller/AutoCorrectAbbreviationsViewController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/controller/AutoCorrectAbbreviationsViewController.kt
@@ -47,7 +47,7 @@ class AutoCorrectAbbreviationsViewController(private val editText: EditText) {
             fixedReplace(s, wordStart, wordStart + lastWordBeforeCursor.length, replacement)
         } else if (lastWordBeforeCursor.length > 3) {
             val locale = abbrs.locale
-            val capital = lastWordBeforeCursor.substring(0, 1).uppercase(locale)
+            val capital = lastWordBeforeCursor.get(0).titlecase(locale)
             s.replace(wordStart, wordStart + 1, capital)
         }
     }


### PR DESCRIPTION
In some languages, title-case for letters is different from upper-case. This difference is captured by the [titlecase] function in Kotlin. Use it instead of [uppercase].

Fixes https://github.com/streetcomplete/StreetComplete/issues/4784

[titlecase]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/titlecase.html
[uppercase]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/uppercase.html