### PR TITLE
Allow viewing photos after attaching to note

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,6 +187,9 @@ dependencies {
 
     // opening hours parser
     implementation("ch.poole:OpeningHoursParser:0.27.0")
+
+    // image view that allows zoom and pan
+    implementation("com.github.chrisbanes:PhotoView:2.3.0")
 }
 
 /** Localizations that should be pulled from POEditor */

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteImageAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteImageAdapter.kt
@@ -1,14 +1,20 @@
 package de.westnordost.streetcomplete.quests.note_discussion
 
+import android.app.Dialog
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.doOnLayout
-import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.CellImageThumbnailBinding
 import de.westnordost.streetcomplete.util.decodeScaledBitmapAndNormalize
+import de.westnordost.streetcomplete.util.getRotationMatrix
 import de.westnordost.streetcomplete.view.ListAdapter
+import com.github.chrisbanes.photoview.PhotoView
+import de.westnordost.streetcomplete.R
 import java.io.File
 
 class NoteImageAdapter(list: List<String>, private val context: Context) : ListAdapter<String>(list) {
@@ -23,6 +29,10 @@ class NoteImageAdapter(list: List<String>, private val context: Context) : ListA
         init {
             binding.imageView.setOnClickListener {
                 val index = adapterPosition
+                if (index > -1) onClickImage(index)
+            }
+            binding.deleteButton.setOnClickListener {
+                val index = adapterPosition
                 if (index > -1) onClickDelete(index)
             }
         }
@@ -33,6 +43,28 @@ class NoteImageAdapter(list: List<String>, private val context: Context) : ListA
                 binding.imageView.setImageBitmap(bitmap)
             }
         }
+    }
+
+    private fun onClickImage(index: Int) {
+        val imagePath = list[index]
+        val image = File(imagePath)
+        if (!image.exists()) return
+
+        val dialog = Dialog(context)
+        val imageView = PhotoView(context).apply {
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            val bitmap = BitmapFactory.decodeFile(imagePath)
+            val matrix = getRotationMatrix(imagePath)
+            val result = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+            if (result != bitmap) {
+                bitmap.recycle()
+            }
+            setImageBitmap(result)
+            setOnOutsidePhotoTapListener { dialog.dismiss() }
+        }
+        dialog.setContentView(imageView)
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        dialog.show()
     }
 
     private fun onClickDelete(index: Int) {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/BitmapFactoryUtils.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/BitmapFactoryUtils.kt
@@ -56,7 +56,7 @@ private fun getImageSize(imagePath: String): Size? {
     return Size(width, height)
 }
 
-private fun getRotationMatrix(imagePath: String): Matrix =
+fun getRotationMatrix(imagePath: String): Matrix =
     try {
         ExifInterface(imagePath).rotationMatrix
     } catch (ignore: IOException) {

--- a/app/src/main/res/layout/cell_image_thumbnail.xml
+++ b/app/src/main/res/layout/cell_image_thumbnail.xml
@@ -11,16 +11,19 @@
         tools:src="@drawable/surface_paving_stones"
         android:id="@+id/imageView"
         android:scaleType="centerCrop"
-        android:layout_width="56dp"
-        android:layout_height="56dp"/>
+        android:layout_width="90dp"
+        android:layout_height="90dp"/>
 
     <ImageView
         android:id="@+id/deleteButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="4dp"
+        android:padding="0dp"
         android:src="@drawable/ic_close_24dp"
         app:tint="#fff"
+        android:scaleX="2"
+        android:scaleY="2"
+        android:layout_margin="10dp"
         android:background="#9333"
         android:layout_alignEnd="@id/imageView"/>
 

--- a/app/src/main/res/layout/fragment_attach_photo.xml
+++ b/app/src/main/res/layout/fragment_attach_photo.xml
@@ -24,8 +24,8 @@
     <ImageView
         android:id="@+id/attachedGpxView"
         android:layout_toEndOf="@id/takePhotoButton"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
         android:src="@drawable/ic_attach_gpx_24dp"
         app:tint="@color/disabled_text"
         android:visibility="gone"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io" ) }
     }
 }
 


### PR DESCRIPTION
See discussion in https://github.com/Helium314/SCEE/issues/392. The photo is shown in a dialog with transparent background.
I hope the delete button is now big enough.

![screen](https://user-images.githubusercontent.com/43007630/217259632-29cf2027-365f-4a0e-9084-5e0682282917.png)
