### PR TITLE
Vacant office fixes

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
@@ -125,7 +125,7 @@ fun isShopExpressionFragment(prefix: String? = null): String {
     val p = if (prefix != null) "$prefix:" else ""
     return ("""(
         ${p}shop and ${p}shop !~ no|vacant|mall
-        or ${p}office and ${p}office != no|vacant
+        or ${p}office and ${p}office !~ no|vacant
         or ${p}healthcare and healthcare != hospital
         or ${p}craft
         or ${p}tourism = information and ${p}information = office

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
@@ -267,4 +267,5 @@ val IS_DISUSED_SHOP_EXPRESSION = """
     nodes, ways, relations with
       ${isShopExpressionFragment("disused")}
       or shop = vacant
+      or office = vacant
 """.toElementFilterExpression()

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Shop.kt
@@ -125,7 +125,7 @@ fun isShopExpressionFragment(prefix: String? = null): String {
     val p = if (prefix != null) "$prefix:" else ""
     return ("""(
         ${p}shop and ${p}shop !~ no|vacant|mall
-        or ${p}office and ${p}office != vacant
+        or ${p}office and ${p}office != no|vacant
         or ${p}healthcare and healthcare != hospital
         or ${p}craft
         or ${p}tourism = information and ${p}information = office

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -22,7 +22,7 @@ class AddPlaceName(
         nodes, ways with
         (
           shop and shop !~ no|vacant
-          or office and office ~= no|vacant
+          or office and office !~ no|vacant
           or craft
           or amenity = recycling and recycling_type = centre
           or tourism = information and information = office

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -22,8 +22,8 @@ class AddPlaceName(
         nodes, ways with
         (
           shop and shop !~ no|vacant
+          or office and office ~= no|vacant
           or craft
-          or office
           or amenity = recycling and recycling_type = centre
           or tourism = information and information = office
           or """ +

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -21,6 +21,7 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
     private val disusedShopsFilter by lazy { """
         nodes, ways with (
           shop = vacant
+          or office = vacant
           or (${isShopExpressionFragment("disused")}
              and !man_made
              and !historic


### PR DESCRIPTION
Changes to make SC treat `office`=`vacant` similar to `shop`=`vacant`. While there aren't that many worldwide ([813](https://taginfo.openstreetmap.org/tags/office=vacant)), this stops vacant offices coming up in the name quest or any of the other shop-related quests.

This also ensures that vacant offices are resurveyed on occasion to check if they are still vacant.