### PR TITLE
healthcare ways should be treated as areas

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Area.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Area.kt
@@ -41,5 +41,6 @@ private fun isAreaExpressionFragment(prefix: String? = null): String {
         or (${p}military and ${p}military != trench)
         or ${p}aerialway = station
         or ${p}allotments
+        or ${p}healthcare
     """.trimIndent()
 }


### PR DESCRIPTION
This PR ensures that ways tagged with `healthcare`=`*` are considered to be areas, not ways. Before this PR, an healthcare=audiologist would show up as the boundary of the shop:

![image](https://user-images.githubusercontent.com/12725310/218448990-b054e2dd-715d-4620-9dc9-b67da6287a90.png)

With this PR, it correctly shows up as an area:

![image](https://user-images.githubusercontent.com/12725310/218449214-e11a704b-e50b-4ab9-845e-b2177a3d5f11.png)
