### PR TITLE
Don't ask for private benches and recycling containers

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -22,6 +22,7 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
           and !backrest
           and !bench:type
           and (!seasonal or seasonal = no)
+          and access !~ private|no
     """
     override val changesetComment = "Survey whether benches have backrests"
     override val wikiLink = "Tag:amenity=bench"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -20,6 +20,7 @@ class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
           and recycling_type = container
           and recycling:glass = yes
           and !recycling:glass_bottles
+          and access !~ private|no
     """
     override val changesetComment = "Determine whether any glass or just glass bottles can be recycled here"
     override val wikiLink = "Key:recycling"


### PR DESCRIPTION
Similar quests also exclude `access ~ private|no`, so I think it makes sense to do the same for bench backrest and glass recycling quests.