### PR TITLE
Check shop existence

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -125,6 +125,7 @@ import de.westnordost.streetcomplete.quests.roof_shape.AddRoofShape
 import de.westnordost.streetcomplete.quests.seating.AddSeating
 import de.westnordost.streetcomplete.quests.segregated.AddCyclewaySegregation
 import de.westnordost.streetcomplete.quests.self_service.AddSelfServiceLaundry
+import de.westnordost.streetcomplete.quests.shop_type.CheckShopExistence
 import de.westnordost.streetcomplete.quests.shop_type.CheckShopType
 import de.westnordost.streetcomplete.quests.shop_type.SpecifyShopType
 import de.westnordost.streetcomplete.quests.sidewalk.AddSidewalk
@@ -451,6 +452,7 @@ fun questTypeRegistry(
     132 to AddAcceptsCash(),
 
     133 to AddFuelSelfService(),
+    156 to CheckShopExistence(), // after opening hours and similar so they will be preferred if enabled
 
     /* ↓ 5.quests that are very numerous ---------------------------------------------------- */
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -27,7 +27,6 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
     override val elementFilter = """
         nodes with (
           (${isShopExpressionFragment()})
-          or (${isShopExpressionFragment("disused")}
              and !man_made
              and !historic
              and !military

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -36,7 +36,6 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
              and !railway
              and amenity !~ clinic|library|music_school|post_office
              and healthcare !~ clinic
-          )
         ) and (
           older today -2 years
           or ${LAST_CHECK_DATE_KEYS.joinToString(" or ") { "$it < today -2 years" }}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -30,8 +30,6 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
              and !attraction
              and !aeroway
              and !railway
-             and amenity !~ clinic|library|music_school|post_office
-             and healthcare !~ clinic
         ) and (
           older today -2 years
           or ${LAST_CHECK_DATE_KEYS.joinToString(" or ") { "$it < today -2 years" }}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -1,21 +1,17 @@
 package de.westnordost.streetcomplete.quests.shop_type
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
-import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
-import de.westnordost.streetcomplete.osm.IS_SHOP_EXPRESSION
 import de.westnordost.streetcomplete.osm.IS_SHOP_OR_DISUSED_SHOP_EXPRESSION
 import de.westnordost.streetcomplete.osm.LAST_CHECK_DATE_KEYS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.isShopExpressionFragment
 import de.westnordost.streetcomplete.osm.updateCheckDate
-import de.westnordost.streetcomplete.quests.existence.CheckShopExistenceForm
 
 class CheckShopExistence : OsmFilterQuestType<Unit>() {
 
@@ -26,7 +22,7 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
 
     override val elementFilter = """
         nodes with (
-          (${isShopExpressionFragment()})
+             ${isShopExpressionFragment()}
              and !man_made
              and !historic
              and !military

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -34,6 +34,8 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
              and !attraction
              and !aeroway
              and !railway
+             and amenity !~ hospital|clinic|library|music_school|post_office
+             and healthcare !~ hospital|clinic
           )
         ) and (
           older today -2 years

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -1,0 +1,60 @@
+package de.westnordost.streetcomplete.quests.shop_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.osm.IS_SHOP_EXPRESSION
+import de.westnordost.streetcomplete.osm.IS_SHOP_OR_DISUSED_SHOP_EXPRESSION
+import de.westnordost.streetcomplete.osm.LAST_CHECK_DATE_KEYS
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.isShopExpressionFragment
+import de.westnordost.streetcomplete.osm.updateCheckDate
+import de.westnordost.streetcomplete.quests.existence.CheckShopExistenceForm
+
+class CheckShopExistence : OsmFilterQuestType<Unit>() {
+
+    // opening hours quest acts as a de facto checker of shop existence, but some people disabled it.
+    // separate from CheckExistence as very old shop with opening hours should show
+    // opening hours resurvey quest rather than this one (which would cause edit date to be changed
+    // and silence all resurvey quests)
+
+    override val elementFilter = """
+        nodes with (
+          (${isShopExpressionFragment()})
+          or (${isShopExpressionFragment("disused")}
+             and !man_made
+             and !historic
+             and !military
+             and !power
+             and !attraction
+             and !aeroway
+             and !railway
+          )
+        ) and (
+          older today -2 years
+          or ${LAST_CHECK_DATE_KEYS.joinToString(" or ") { "$it < today -2 years" }}
+        )
+    """
+
+    override val changesetComment = "Survey if places (shops and other shop-like) still exist"
+    override val wikiLink = "Key:disused:"
+    override val icon = R.drawable.ic_quest_check_shop
+    override val achievements = listOf(CITIZEN)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_existence_title2
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter(IS_SHOP_OR_DISUSED_SHOP_EXPRESSION)
+
+    override fun createForm() = CheckShopExistenceForm()
+
+    override fun applyAnswerTo(answer: Unit, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags.updateCheckDate()
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -34,8 +34,8 @@ class CheckShopExistence : OsmFilterQuestType<Unit>() {
              and !attraction
              and !aeroway
              and !railway
-             and amenity !~ hospital|clinic|library|music_school|post_office
-             and healthcare !~ hospital|clinic
+             and amenity !~ clinic|library|music_school|post_office
+             and healthcare !~ clinic
           )
         ) and (
           older today -2 years

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
@@ -5,13 +5,8 @@ import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
 
 class CheckShopExistenceForm : AbstractOsmQuestForm<Unit>() {
-    override val buttonPanelAnswers get() =
-        listOf(
-            AnswerItem(R.string.quest_generic_hasFeature_no) {
-                replaceShop()
-            },
-            AnswerItem(R.string.quest_generic_hasFeature_yes) {
-                applyAnswer(Unit)
-            }
-        )
+    override val buttonPanelAnswers = listOf(
+        AnswerItem(R.string.quest_generic_hasFeature_no) { replaceShop() },
+        AnswerItem(R.string.quest_generic_hasFeature_yes) { applyAnswer(Unit) },
+    )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.existence
+package de.westnordost.streetcomplete.quests.shop_type
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
@@ -6,18 +6,12 @@ import de.westnordost.streetcomplete.quests.AnswerItem
 
 class CheckShopExistenceForm : AbstractOsmQuestForm<Unit>() {
     override val buttonPanelAnswers get() =
-        if (isAskingAboutExistence) {
-            listOf(
-                AnswerItem(R.string.quest_generic_hasFeature_no) {
-                    replaceShop()
-                },
-                AnswerItem(R.string.quest_generic_hasFeature_yes) {
-                    applyAnswer(Unit)
-                }
-            )
-        } else {
-            emptyList()
-        }
-
-    private var isAskingAboutExistence: Boolean = true
+        listOf(
+            AnswerItem(R.string.quest_generic_hasFeature_no) {
+                replaceShop()
+            },
+            AnswerItem(R.string.quest_generic_hasFeature_yes) {
+                applyAnswer(Unit)
+            }
+        )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceForm.kt
@@ -1,0 +1,23 @@
+package de.westnordost.streetcomplete.quests.existence
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
+import de.westnordost.streetcomplete.quests.AnswerItem
+
+class CheckShopExistenceForm : AbstractOsmQuestForm<Unit>() {
+    override val buttonPanelAnswers get() =
+        if (isAskingAboutExistence) {
+            listOf(
+                AnswerItem(R.string.quest_generic_hasFeature_no) {
+                    replaceShop()
+                },
+                AnswerItem(R.string.quest_generic_hasFeature_yes) {
+                    applyAnswer(Unit)
+                }
+            )
+        } else {
+            emptyList()
+        }
+
+    private var isAskingAboutExistence: Boolean = true
+}


### PR DESCRIPTION
fixes https://github.com/streetcomplete/StreetComplete/discussions/4232

Seems OK and plan on merging if noone will have feedback about this, but I want to give chance to review. No new text is being used here.

Why as a separate quest? Check existence quest is before opening hours, wheelchair quest and so on.

This one should be after opening hours etc, otherwise they would not be resurveyed in some cases. For example if check existence AND opening hours quests are enabled AND shop has `opening_hours` tagged AND shop node was not edited for 13 years, then opening hours resurvey quest should be asked, not check existence quest.

Otherwise user would confirm existence, what would update object and opening hours resurvey would not be asked.

And why it is useful at all if opening hours already acts as a de facto existence checker? OH is quite time-consuming and some people could disable it without enabling wheelchair quest or similar.
