### PR TITLE
Check location time difference using elapsedRealtime

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
@@ -86,7 +86,7 @@ class FineLocationManager(context: Context, locationUpdateCallback: (Location) -
 
 // Based on https://web.archive.org/web/20180424190538/https://developer.android.com/guide/topics/location/strategies.html#BestEstimate
 
-private const val TWO_MINUTES = 1000L * 60 * 2
+private const val TWO_MINUTES = 1000L * 1000 * 1000 * 60 * 2
 
 /** Determines whether this Location reading is better than the previous Location fix */
 private fun Location.isBetterThan(previous: Location?): Boolean {
@@ -98,7 +98,7 @@ private fun Location.isBetterThan(previous: Location?): Boolean {
     if (previous == null) return true
 
     // Check whether the new location fix is newer or older
-    val timeDelta = this.time - previous.time
+    val timeDelta = this.elapsedRealtimeNanos - previous.elapsedRealtimeNanos
     val isMuchNewer = timeDelta > TWO_MINUTES
     val isMuchOlder = timeDelta < -TWO_MINUTES
     val isNewer = timeDelta > 0L

--- a/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
@@ -86,7 +86,7 @@ class FineLocationManager(context: Context, locationUpdateCallback: (Location) -
 
 // Based on https://web.archive.org/web/20180424190538/https://developer.android.com/guide/topics/location/strategies.html#BestEstimate
 
-private const val TWO_MINUTES = 1000L * 1000 * 1000 * 60 * 2
+private const val TWO_MINUTES_IN_NANOSECONDS = 1000L * 1000 * 1000 * 60 * 2
 
 /** Determines whether this Location reading is better than the previous Location fix */
 private fun Location.isBetterThan(previous: Location?): Boolean {
@@ -98,9 +98,13 @@ private fun Location.isBetterThan(previous: Location?): Boolean {
     if (previous == null) return true
 
     // Check whether the new location fix is newer or older
+    // we use elapsedRealtimeNanos instead of epoch time because some devices have issues
+    // that may lead to incorrect GPS location.time (e.g. GPS week rollover, but also others)
+    // the use of nanoseconds is necessary because it iss the only way to get
+    // elapsedRealtime of a location before API level 33
     val timeDelta = this.elapsedRealtimeNanos - previous.elapsedRealtimeNanos
-    val isMuchNewer = timeDelta > TWO_MINUTES
-    val isMuchOlder = timeDelta < -TWO_MINUTES
+    val isMuchNewer = timeDelta > TWO_MINUTES_IN_NANOSECONDS
+    val isMuchOlder = timeDelta < -TWO_MINUTES_IN_NANOSECONDS
     val isNewer = timeDelta > 0L
 
     // Check whether the new location fix is more or less accurate


### PR DESCRIPTION
should fix #4652

This is the most (I think) minimal fix for GPS locations having a wrong `location.time`.
If everything is working correctly, it shouldn't matter whether `elapsedRealtimeNanos` or `time` is used, but `elapsedRealtimeNanos` shouldn't have issues with system and GPS clock being slightly different.

A short test / comparison on my S4 mini plus:
`gpsLocation.time` is about 1.6 s ahead (!) of `nowAsEpochMilliseconds()` when the phone was running a few days, and about 1.45 s ahead after a restart of the phone.
`gpsLocation.elapsedRealtimeNanos` is about 5-20 ms behind `SystemClock.elapsedRealtimeNanos()`, and this time difference doesn't change with restart.