### PR TITLE
make roof:levels mandatory

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -11,11 +11,14 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
 
     override val elementFilter = """
         ways, relations with
-         building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}
-         and !building:levels
-         and !man_made
-         and location != underground
-         and ruins != yes
+           building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}
+           and (
+               !building:levels
+               or !roof:levels and roof:shape and roof:shape != flat
+           )
+           and !man_made
+           and location != underground
+           and ruins != yes
     """
     override val changesetComment = "Specify building and roof levels"
     override val wikiLink = "Key:building:levels"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -27,10 +27,6 @@ class AddBuildingLevelsForm : AbstractOsmQuestForm<BuildingLevelsAnswer>() {
         AnswerItem(R.string.quest_buildingLevels_answer_multipleLevels) { showMultipleLevelsHint() }
     )
 
-    private val roofsAreUsuallyFlat get() = countryInfo.roofsAreUsuallyFlat
-    private val hasNonFlatRoofShape get() =
-        element.tags.containsKey("roof:shape") && element.tags["roof:shape"] != "flat"
-
     private val levels get() = binding.levelsInput.intOrNull?.takeIf { it >= 0 }
     private val roofLevels get() = binding.roofLevelsInput.intOrNull?.takeIf { it >= 0 }
 
@@ -91,8 +87,11 @@ class AddBuildingLevelsForm : AbstractOsmQuestForm<BuildingLevelsAnswer>() {
         }
     }
 
-    override fun isFormComplete() =
-        levels != null && (roofsAreUsuallyFlat && !hasNonFlatRoofShape || roofLevels != null)
+    override fun isFormComplete(): Boolean {
+        val hasNonFlatRoofShape = element.tags.containsKey("roof:shape") && element.tags["roof:shape"] != "flat"
+        val roofLevelsAreOptional = countryInfo.roofsAreUsuallyFlat && !hasNonFlatRoofShape
+        return levels != null && (roofLevelsAreOptional || roofLevels != null)
+    }
 }
 
 private class LastPickedAdapter(


### PR DESCRIPTION
Fixes #4821 (also fixes #4661)

- Ask building levels quest again for buildings that have no `roof:levels` but a `roof:shape` that is not `flat`
- make specifying `roof:levels` mandatory in countries where [roofs are not usually flat](https://github.com/streetcomplete/countrymetadata/blob/master/data/roofsAreUsuallyFlat.yml) and in cases where `roof:shape` has already been supplied and it is not `flat`

@biketeur