### PR TITLE
Ask toilet part wheelchair access only if wheelchair=limited

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -11,8 +11,8 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccessToilet
 
     override val elementFilter = """
         nodes, ways with
-         wheelchair = limited
-         (
+          wheelchair = limited
+          and (
            toilets = yes
            or !toilets and (
              amenity ~ restaurant|pub|bar

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -11,6 +11,7 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccessToilet
 
     override val elementFilter = """
         nodes, ways with
+         wheelchair = limited
          (
            toilets = yes
            or !toilets and (


### PR DESCRIPTION
See https://github.com/streetcomplete/StreetComplete/pull/4868#issuecomment-1467439875 and below, where @matkoniecz and @mnalis came to the conclusion this would make sense.

In short: the quest is unnecessary if `wheelchair=yes`, and the answer is very likely to be _no_ if `wheelchair=no`.