### PR TITLE
Request map render after setting pins and elements

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -170,6 +170,7 @@ class QuestPinsManager(
         synchronized(pinsMapComponent) {
             if (coroutineContext.isActive) {
                 pinsMapComponent.set(pins)
+                ctrl.requestRender()
             }
         }
     }
@@ -187,6 +188,7 @@ class QuestPinsManager(
             synchronized(pinsMapComponent) {
                 if (coroutineContext.isActive) {
                     pinsMapComponent.set(pins)
+                    ctrl.requestRender()
                 }
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/StyleableOverlayManager.kt
@@ -150,6 +150,7 @@ class StyleableOverlayManager(
             }
             if (coroutineContext.isActive) {
                 mapComponent.set(mapDataInView.values)
+                ctrl.requestRender()
             }
         }
     }
@@ -169,6 +170,7 @@ class StyleableOverlayManager(
             deleted.forEach { if (mapDataInView.remove(it) != null) changedAnything = true }
             if (changedAnything && coroutineContext.isActive) {
                 mapComponent.set(mapDataInView.values)
+                ctrl.requestRender()
             }
         }
     }


### PR DESCRIPTION
fixes #2780

This fixes rare cases of the map not being updated e.g. after switching overlays.
Usually the map is re-drawn frequently as consequence of user interaction, position update or view direction update. But if none of this happens, the effects are as described in #2780.

I found no noticeable performance impact (on S4 mini).