### PR TITLE
Fix wheelchair toilet tagging

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -31,7 +31,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccessToiletsAns
     override fun applyAnswerTo(answer: WheelchairAccessToiletsAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
             is WheelchairAccessToilets -> tags.updateWithCheckDate("wheelchair", answer.access.osmValue)
-            is NoToilet -> answer.applyTo(tags)
+            is NoToilet -> throw IllegalStateException()
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -30,10 +30,7 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccessToiletsAns
 
     override fun applyAnswerTo(answer: WheelchairAccessToiletsAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
-            is WheelchairAccessToilets -> {
-                tags.updateWithCheckDate("wheelchair", answer.access.osmValue)
-                tags["toilets"] = "yes"
-            }
+            is WheelchairAccessToilets -> tags.updateWithCheckDate("wheelchair", answer.access.osmValue)
             is NoToilet -> answer.applyTo(tags)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccessToiletsAnswer>() {
 
@@ -28,6 +29,12 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccessToiletsAns
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
     override fun applyAnswerTo(answer: WheelchairAccessToiletsAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        answer.applyTo(tags)
+        when (answer) {
+            is WheelchairAccessToilets -> {
+                tags.updateWithCheckDate("wheelchair", answer.access.osmValue)
+                tags["toilets"] = "yes"
+            }
+            is NoToilet -> answer.applyTo(tags)
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsForm.kt
@@ -16,7 +16,12 @@ class AddWheelchairAccessToiletsForm : AbstractOsmQuestForm<WheelchairAccessToil
         AnswerItem(R.string.quest_wheelchairAccess_limited) { applyAnswer(WheelchairAccessToilets(LIMITED)) },
     )
 
-    override val otherAnswers get() = listOf(
-        AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NoToilet) }
+    override val otherAnswers get() = listOfNotNull(
+        createNoToiletsAnswer()
     )
+
+    private fun createNoToiletsAnswer(): AnswerItem? {
+        return if (element.tags["amenity"] == "toilets") null
+        else AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NoToilet) }
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.RARE
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccessToiletsAnswer>() {
 
@@ -37,6 +38,12 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccessToilet
     override fun createForm() = AddWheelchairAccessToiletsForm()
 
     override fun applyAnswerTo(answer: WheelchairAccessToiletsAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        answer.applyTo(tags)
+        when (answer) {
+            is WheelchairAccessToilets -> {
+                tags.updateWithCheckDate("toilets:wheelchair", answer.access.osmValue)
+                tags["toilets"] = "yes"
+            }
+            is NoToilet -> answer.applyTo(tags)
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccessToiletsAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/WheelchairAccessToiletsAnswer.kt
@@ -7,12 +7,6 @@ sealed interface WheelchairAccessToiletsAnswer
 data class WheelchairAccessToilets(val access: WheelchairAccess) : WheelchairAccessToiletsAnswer
 object NoToilet : WheelchairAccessToiletsAnswer
 
-fun WheelchairAccessToiletsAnswer.applyTo(tags: Tags) = when (this) {
-    is WheelchairAccessToilets -> {
-        tags.updateWithCheckDate("toilets:wheelchair", access.osmValue)
-        tags["toilets"] = "yes"
-    }
-    NoToilet -> {
-        tags.updateWithCheckDate("toilets", "no")
-    }
+fun NoToilet.applyTo(tags: Tags) {
+    tags.updateWithCheckDate("toilets", "no")
 }


### PR DESCRIPTION
Thanks @Helium314 for spotting this

See https://github.com/streetcomplete/StreetComplete/pull/4868#discussion_r1137291635

In reducing duplication, it incidentally changed it so that `amenity=toilets` would get tagged with `toilets:wheelchair` rather than `wheelchair`.

This reverts that change.