### PR TITLE
Request render after setting pins layer visiblity

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -7,14 +7,17 @@ import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
 import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
-class PinsMapComponent(ctrl: KtMapController) {
+class PinsMapComponent(private val ctrl: KtMapController) {
 
     private val pinsLayer: MapData = ctrl.addDataLayer(PINS_LAYER)
 
     /** Shows/hides the pins */
     var isVisible: Boolean
         get() = pinsLayer.visible
-        set(value) { pinsLayer.visible = value }
+        set(value) {
+            pinsLayer.visible = value
+            ctrl.requestRender()
+        }
 
     /** Show given pins. Previously shown pins are replaced with these.  */
     fun set(pins: Collection<Pin>) {


### PR DESCRIPTION
This is an addition to #4880

When selecting a quest or element from overlay, the map is not updated unless there is some zoom animation, position update or user interaction. Same can happen when closing the form.
For quests this is only a small issue, as usually when focusing the camera is moved. Since there is no focusing when selecting an element, the issue shows more often in overlays.

Pins layer visibility appears to be the best place for `ctrl.requestRender`, as it is changed when selecting an element or quest, and when closing the form.