### PR TITLE
Ask sidewalk quest if nearby paths are not foot accessible

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -24,7 +24,10 @@ import de.westnordost.streetcomplete.util.math.isNearAndAligned
 
 class AddSidewalk : OsmElementQuestType<LeftAndRightSidewalk> {
     private val maybeSeparatelyMappedSidewalksFilter by lazy { """
-        ways with highway ~ path|footway|cycleway|construction and foot !~ no|private and access !~ no|private
+        ways with
+          highway ~ path|footway|cycleway|construction
+          and foot !~ no|private
+          and access !~ no|private
     """.toElementFilterExpression() }
     // highway=construction included, as situation often changes during and after construction
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -24,7 +24,7 @@ import de.westnordost.streetcomplete.util.math.isNearAndAligned
 
 class AddSidewalk : OsmElementQuestType<LeftAndRightSidewalk> {
     private val maybeSeparatelyMappedSidewalksFilter by lazy { """
-        ways with highway ~ path|footway|cycleway|construction
+        ways with highway ~ path|footway|cycleway|construction and foot !~ no|private and access !~ no|private
     """.toElementFilterExpression() }
     // highway=construction included, as situation often changes during and after construction
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkTest.kt
@@ -109,6 +109,29 @@ class AddSidewalkTest {
         assertNull(questType.isApplicableTo(road))
     }
 
+    @Test fun `applicable to road with nearby footway that is private`() {
+        val road = way(1, listOf(1, 2), mapOf(
+            "highway" to "primary",
+            "lit" to "yes",
+            "width" to "18"
+        ))
+        val footway = way(2, listOf(3, 4), mapOf(
+            "access" to "private",
+            "highway" to "footway"
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(road, footway))
+        val p1 = p(0.0, 0.0)
+        val p2 = p1.translate(50.0, 45.0)
+        val p3 = p1.translate(12.999, 135.0)
+        val p4 = p3.translate(50.0, 45.0)
+
+        mapData.wayGeometriesById[1L] = ElementPolylinesGeometry(listOf(listOf(p1, p2)), p1)
+        mapData.wayGeometriesById[2L] = ElementPolylinesGeometry(listOf(listOf(p3, p4)), p3)
+
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+        assertNull(questType.isApplicableTo(road))
+    }
+
     @Test fun `applicable to road with nearby footway that is not aligned to the road`() {
         val road = way(1, listOf(1, 2), mapOf(
             "highway" to "primary",


### PR DESCRIPTION
Ways not accessible by foot should be excluded from `maybeSeparatelyMappedSidewalksFilter`, as they are most likely not sidewalks.

I don't know how to find a situation where this is relevant, so I only tested in SCEE where I can change the tags of nearby paths for creating such a situation.