### PR TITLE
Fix #4899 : Restore driving_school in the add opening hours quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -51,7 +51,7 @@ class AddOpeningHours(
                 "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library", // civic
                 "bank", "bureau_de_change", "money_transfer", "post_office", "marketplace",         // commercial
                 "internet_cafe", "payment_centre",
-                "car_wash", "car_rental", "fuel",                                                   // car stuff
+                "car_wash", "car_rental", "fuel","driving_school",                                  // car stuff
                 "dentist", "doctors", "clinic", "pharmacy", "veterinary",                           // health
                 "animal_boarding", "animal_shelter", "animal_breeding",                             // animals
                 "coworking_space",                                                                  // work


### PR DESCRIPTION
amenity driving_school was lost in the migration from java to kotlin