### PR TITLE
Factorize picnic table and barbecue cover quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.quests.address.AddHousenumber
 import de.westnordost.streetcomplete.quests.air_conditioning.AddAirConditioning
 import de.westnordost.streetcomplete.quests.air_pump.AddAirCompressor
 import de.westnordost.streetcomplete.quests.air_pump.AddBicyclePump
+import de.westnordost.streetcomplete.quests.amenity_cover.AddAmenityCover
 import de.westnordost.streetcomplete.quests.atm_cashin.AddAtmCashIn
 import de.westnordost.streetcomplete.quests.atm_operator.AddAtmOperator
 import de.westnordost.streetcomplete.quests.baby_changing_table.AddBabyChangingTable
@@ -104,7 +105,6 @@ import de.westnordost.streetcomplete.quests.parking_access.AddParkingAccess
 import de.westnordost.streetcomplete.quests.parking_fee.AddBikeParkingFee
 import de.westnordost.streetcomplete.quests.parking_fee.AddParkingFee
 import de.westnordost.streetcomplete.quests.parking_type.AddParkingType
-import de.westnordost.streetcomplete.quests.picnic_table_cover.AddPicnicTableCover
 import de.westnordost.streetcomplete.quests.pitch_lit.AddPitchLit
 import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
 import de.westnordost.streetcomplete.quests.playground_access.AddPlaygroundAccess
@@ -243,7 +243,7 @@ fun questTypeRegistry(
     9 to AddCarWashType(),
 
     10 to AddBenchBackrest(),
-    11 to AddPicnicTableCover(),
+    11 to AddAmenityCover(),
 
     12 to AddBridgeStructure(),
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_cover/AddAmenityCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_cover/AddAmenityCover.kt
@@ -1,4 +1,4 @@
-package de.westnordost.streetcomplete.quests.picnic_table_cover
+package de.westnordost.streetcomplete.quests.amenity_cover
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
@@ -11,22 +11,23 @@ import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddPicnicTableCover : OsmFilterQuestType<Boolean>() {
+class AddAmenityCover : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes with
-          leisure = picnic_table
+          (leisure = picnic_table
+           or amenity = bbq)
           and access !~ private|no
           and !covered
           and (!seasonal or seasonal = no)
     """
-    override val changesetComment = "Specify whether picnic tables are covered"
+    override val changesetComment = "Specify whether various amenities are covered"
     override val wikiLink = "Key:covered"
     override val icon = R.drawable.ic_quest_picnic_table_cover
     override val isDeleteElementEnabled = true
     override val achievements = listOf(OUTDOORS)
 
-    override fun getTitle(tags: Map<String, String>) = R.string.quest_picnicTableCover_title
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_amenityCover_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter("nodes with leisure = picnic_table")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1237,7 +1237,7 @@ If there are no signs along the whole street which apply for the highlighted sec
 
     <string name="quest_pedestrian_crossing_island">"Does this pedestrian crossing have an island?"</string>
 
-    <string name="quest_picnicTableCover_title">Is this picnic table covered (protected from rain)?</string>
+    <string name="quest_amenityCover_title">Is this covered (protected from rain)?</string>
 
     <string name="quest_placeName_title">"What’s the name of this place?"</string>
     <string name="quest_placeName_no_name_answer">"There is no name sign…"</string>


### PR DESCRIPTION
After discussion in #4875 we discussed the possibility of grouping "covered" quests together. This PR implements that for grouping picnic table and barbecue cover quests. I haven't changed the icon, but of course it should be changed.