### PR TITLE
Store tangram geometries in styled element 

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
@@ -154,5 +154,7 @@ data class StyledElement(
     val geometry: ElementGeometry,
     val style: Style
 ) {
+    // geometries may contain road color, which depends on current theme
+    // however, storing is not an issue as styled elements are cleared on theme switch (both automatic and manual)
     var tangramGeometries: List<Geometry>? = null
 }


### PR DESCRIPTION
This is essentially the same as #4897, but geometry is stored in a var instead of created by lazy because creating the geometries requires `resources`.