### PR TITLE
Handle disused/ruined springs

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -20,6 +20,8 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
         and access !~ private|no and indoor != yes
         and !drinking_water and !drinking_water:legal and amenity != drinking_water
         and (!seasonal or seasonal = no)
+        and (!disused or disused = no)
+        and (!ruins or ruins = no)
     """
     override val changesetComment = "Specify whether water is drinkable"
     override val wikiLink = "Key:drinking_water"


### PR DESCRIPTION
Closes: #4928 

This prevents StreetComplete from asking whether the (usually non-existent) water in a disused/historic/ruined well is potable.

I can't easily test this, sorry. :(