### PR TITLE
Also check ways when tag is not always a node

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.osm.applyTo
 class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
 
     override val elementFilter = """
-        nodes with
+        nodes, ways with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.osm.Tags
 class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
     override val elementFilter = """
-        nodes with (
+        nodes, ways with (
           man_made = water_tap
           or man_made = water_well
           or natural = spring

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlass.kt
@@ -15,7 +15,7 @@ import de.westnordost.streetcomplete.quests.recycling_glass.RecyclingGlass.BOTTL
 class DetermineRecyclingGlass : OsmFilterQuestType<RecyclingGlass>() {
 
     override val elementFilter = """
-        nodes with
+        nodes, ways with
           amenity = recycling
           and recycling_type = container
           and recycling:glass = yes


### PR DESCRIPTION
Inspired by discussion in #4929, debug apk see https://github.com/BenWiederhake/StreetComplete/actions/runs/4623509091.

Barriers, bus stops, water wells, and recycling containers occupy significant amounts of space. A quick look at the wiki suggests that indeed, more than 1% of them are tagged as ways/areas, and not as nodes:

https://wiki.openstreetmap.org/wiki/Tag:barrier=yes
https://wiki.openstreetmap.org/wiki/Tag:public_transport=platform
https://wiki.openstreetmap.org/wiki/Tag:man_made=water_well
https://wiki.openstreetmap.org/wiki/Tag:recycling:glass=yes

Therefore, StreetComplete should also check ways, and not only nodes.

---

This means some "new" quests markers should pop up that have been skipped before, example:

Before this PR:

![Screenshot_20230406-122736_censored](https://user-images.githubusercontent.com/2690845/230352336-adf9abf1-15bf-4b5f-9a06-dd2864b57bb3.png)

After this PR:

![Screenshot_20230406-122720](https://user-images.githubusercontent.com/2690845/230351722-ebfe628a-7c54-471b-aab8-d9491972ff38.png)
