### PR TITLE
Make note edit text (and some more) selectable

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/UndoDialog.kt
@@ -155,6 +155,7 @@ class UndoDialog(
         val txt = TextView(context)
         txt.layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
         txt.setText(text)
+        txt.setTextIsSelectable(true)
         return txt
     }
 


### PR DESCRIPTION
fixes #4924 

Makes text created by `UndoDialog.createTextView` selectable. This is used for all edits except for the actions `UpdateElementTagsAction` and `CreateNodeAction`.

Only question I have is about consistency: should all actions lead to selectable text? Or only notes? Or is current PR fine?