### PR TITLE
Remove confirmation step from overlay selection

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionAdapter.kt
@@ -22,6 +22,8 @@ class OverlaySelectionAdapter : RecyclerView.Adapter<OverlaySelectionAdapter.Vie
 
     var selectedOverlay: Overlay? = null
         set(value) {
+            // To match other preference dialogs, also invoke callback when nothing changed to allow
+            // dismissing the selection dialog when the active overlay is selected again.
             onSelectedOverlay?.invoke(value)
             if (field == value) return
             field = value

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionAdapter.kt
@@ -22,9 +22,9 @@ class OverlaySelectionAdapter : RecyclerView.Adapter<OverlaySelectionAdapter.Vie
 
     var selectedOverlay: Overlay? = null
         set(value) {
+            onSelectedOverlay?.invoke(value)
             if (field == value) return
             field = value
-            onSelectedOverlay?.invoke(value)
             notifyDataSetChanged()
         }
 
@@ -44,16 +44,13 @@ class OverlaySelectionAdapter : RecyclerView.Adapter<OverlaySelectionAdapter.Vie
 
         fun onBind(with: Overlay?) {
             val ctx = binding.root.context
-            binding.radioButton.setText(with?.title ?: R.string.overlay_none)
+            binding.overlayTitle.setText(with?.title ?: R.string.overlay_none)
             val icon = with?.icon?.let { ctx.getDrawable(it) }
             icon?.setBounds(0, 0, ctx.dpToPx(32).toInt(), ctx.dpToPx(32).toInt())
-            binding.radioButton.setCompoundDrawables(icon, null, null, null)
-            binding.radioButton.compoundDrawablePadding = ctx.dpToPx(4).toInt()
-            binding.radioButton.setOnCheckedChangeListener(null)
+            binding.overlayTitle.setCompoundDrawables(icon, null, null, null)
+            binding.overlayTitle.compoundDrawablePadding = ctx.dpToPx(4).toInt()
             binding.radioButton.isChecked = with == selectedOverlay
-            binding.radioButton.setOnCheckedChangeListener { _, isChecked ->
-                if (isChecked) selectedOverlay = with
-            }
+            binding.root.setOnClickListener { selectedOverlay = with }
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionDialog.kt
@@ -18,13 +18,18 @@ class OverlaySelectionDialog(context: Context) : AlertDialog(context), KoinCompo
     private val overlayRegistry: OverlayRegistry by inject()
 
     init {
+        val currentOverlay = selectedOverlayController.selectedOverlay
+
         val adapter = OverlaySelectionAdapter()
         adapter.overlays = overlayRegistry
-        adapter.selectedOverlay = selectedOverlayController.selectedOverlay
-        adapter.onSelectedOverlay = {
-            selectedOverlayController.selectedOverlay = it
+        adapter.selectedOverlay = currentOverlay
+        adapter.onSelectedOverlay = { selectedOverlay ->
+            if (currentOverlay != selectedOverlay) {
+                selectedOverlayController.selectedOverlay = selectedOverlay
+            }
             dismiss()
         }
+
         val binding = DialogOverlaySelectionBinding.inflate(LayoutInflater.from(context))
         binding.overlaysList.adapter = adapter
         binding.overlaysList.layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/overlays/OverlaySelectionDialog.kt
@@ -8,7 +8,6 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
 import de.westnordost.streetcomplete.data.overlays.SelectedOverlayController
 import de.westnordost.streetcomplete.databinding.DialogOverlaySelectionBinding
-import de.westnordost.streetcomplete.overlays.Overlay
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -18,21 +17,21 @@ class OverlaySelectionDialog(context: Context) : AlertDialog(context), KoinCompo
     private val selectedOverlayController: SelectedOverlayController by inject()
     private val overlayRegistry: OverlayRegistry by inject()
 
-    private val binding = DialogOverlaySelectionBinding.inflate(LayoutInflater.from(context))
-    private var selectedOverlay: Overlay? = selectedOverlayController.selectedOverlay
-
     init {
         val adapter = OverlaySelectionAdapter()
         adapter.overlays = overlayRegistry
         adapter.selectedOverlay = selectedOverlayController.selectedOverlay
-        adapter.onSelectedOverlay = { selectedOverlay = it }
+        adapter.onSelectedOverlay = {
+            selectedOverlayController.selectedOverlay = it
+            dismiss()
+        }
+        val binding = DialogOverlaySelectionBinding.inflate(LayoutInflater.from(context))
         binding.overlaysList.adapter = adapter
         binding.overlaysList.layoutManager = LinearLayoutManager(context)
 
         setTitle(R.string.select_overlay)
 
-        setButton(BUTTON_POSITIVE, context.resources.getText(android.R.string.ok)) { _, _ ->
-            selectedOverlayController.selectedOverlay = selectedOverlay
+        setButton(BUTTON_NEGATIVE, context.resources.getText(android.R.string.cancel)) { _, _ ->
             dismiss()
         }
 

--- a/app/src/main/res/layout/dialog_overlay_selection.xml
+++ b/app/src/main/res/layout/dialog_overlay_selection.xml
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
     android:paddingTop="@dimen/dialog_vertical_margin"
-    android:paddingLeft="@dimen/dialog_horizontal_margin"
-    android:paddingRight="@dimen/dialog_horizontal_margin"
-    android:showDividers="middle"
-    android:divider="@drawable/space_8dp"
-    >
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/overlaysList"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:itemCount="8"
-        tools:listitem="@layout/row_overlay_selection" />
-
-</LinearLayout>
-
+    android:id="@+id/overlaysList"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:itemCount="8"
+    tools:listitem="@layout/row_overlay_selection" />

--- a/app/src/main/res/layout/row_overlay_selection.xml
+++ b/app/src/main/res/layout/row_overlay_selection.xml
@@ -1,7 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RadioButton
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/radioButton"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:textAppearance="@android:style/TextAppearance.Theme.Dialog"/>
+    android:orientation="horizontal"
+    android:background="?android:attr/selectableItemBackground"
+    android:paddingLeft="@dimen/dialog_horizontal_margin"
+    android:paddingRight="@dimen/dialog_horizontal_margin">
+
+    <RadioButton
+        android:id="@+id/radioButton"
+        android:layout_width="32dp"
+        android:focusable="false"
+        android:clickable="false"
+        android:background="@null"
+        android:gravity="center_vertical"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/overlayTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:gravity="center_vertical"
+        android:textAppearance="@android:style/TextAppearance.Theme.Dialog" />
+
+</LinearLayout>


### PR DESCRIPTION
This PR changes the `OverlaySelectionDialog` to require one less tap to change overlays by replacing the "OK" button with a "cancel" button and directly switching the active overlay when a row is tapped. The updated dialog looks like this:

![image](https://user-images.githubusercontent.com/6892794/230920894-fb3ffedf-d8ce-4ad9-8e93-7953c9387fbc.png)

As a button on the main screen to change overlays is currently not planned (see #4686), I think this change is still a step in the right direction to allow faster switching between overlays.