### PR TITLE
Skip recycling quest on elements with "note" tag, as those are likely to be problematic 

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterials.kt
@@ -26,6 +26,7 @@ class AddRecyclingContainerMaterials : OsmElementQuestType<RecyclingContainerMat
           amenity = recycling
           and recycling_type = container
           and access !~ private|no
+          and !note and !recycling:note and !note:recycling
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify what can be recycled in recycling containers"


### PR DESCRIPTION
Recycling quest should be skipped on elements having `note=* `tag (as its existence likely indicates the issue is too complicated for AI, and human is required to evaluate specific issues detailed in freeform text of `note`)

(see https://github.com/streetcomplete/StreetComplete/issues/4303#issuecomment-1507617359 and around for  context)

(Tested in https://github.com/mnalis/StreetComplete/actions/runs/4737627521 on e.g. [n2486015492](https://www.openstreetmap.org/node/2486015492), [n2486015499](https://www.openstreetmap.org/node/2486015499) and others)