### PR TITLE
Fix keyboard not being dismissed in SearchFeaturesDialog

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
@@ -55,7 +55,8 @@ class ShopGoneDialog(
                 countryCode,
                 featureCtrl.feature?.name,
                 ::filterOnlyShops,
-                ::onSelectedFeature
+                ::onSelectedFeature,
+                true
             ).show()
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/SearchFeaturesDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/SearchFeaturesDialog.kt
@@ -15,6 +15,7 @@ import de.westnordost.osmfeatures.GeometryType
 import de.westnordost.streetcomplete.databinding.ViewFeatureBinding
 import de.westnordost.streetcomplete.databinding.ViewSelectPresetBinding
 import de.westnordost.streetcomplete.util.getLocalesForFeatureDictionary
+import de.westnordost.streetcomplete.util.ktx.hideKeyboard
 import de.westnordost.streetcomplete.util.ktx.nonBlankTextOrNull
 import de.westnordost.streetcomplete.view.ListAdapter
 import de.westnordost.streetcomplete.view.controller.FeatureViewController
@@ -27,7 +28,8 @@ class SearchFeaturesDialog(
     private val countryOrSubdivisionCode: String? = null,
     text: String? = null,
     private val filterFn: (Feature) -> Boolean = { true },
-    private val onSelectedFeatureFn: (Feature) -> Unit
+    private val onSelectedFeatureFn: (Feature) -> Unit,
+    private val dismissKeyboardOnClose: Boolean = false,
 ) : AlertDialog(context) {
 
     private val binding = ViewSelectPresetBinding.inflate(LayoutInflater.from(context))
@@ -86,6 +88,15 @@ class SearchFeaturesDialog(
         val list = if (text == null) defaultFeatures else getFeatures(text)
         adapter.list = list.toMutableList()
         binding.noResultsText.isGone = list.isNotEmpty()
+    }
+
+    override fun dismiss() {
+        if (dismissKeyboardOnClose) {
+            // Handle keyboard not being automatically dismissed on all Android versions. Has to be
+            // called before the super method, otherwise it won't work.
+            binding.searchEditText.hideKeyboard()
+        }
+        super.dismiss()
     }
 
     private inner class FeaturesAdapter : ListAdapter<Feature>() {


### PR DESCRIPTION
Fixes #4952 by manually closing the keyboard when the `SearchFeaturesDialog` is dismissed. The additional parameter `dismissKeyboardOnClose` is used so that in the `ShopsOverlayForm` the keyboard remains open to be able to enter the shop name without having to tap the `EditText` again. This is necessary because I was not able to reliably dismiss the keyboard in any other way but by overwriting the `dismiss` function in the dialog.

I tested this change on an API 24 emulator, where I could reproduce the issue, and on API 33, where I was unable to reproduce the issue.