### PR TITLE
Correctly sort sports by popularity

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
@@ -15,7 +15,7 @@ class AddSportForm : AImageListQuestForm<Sport, List<Sport>>() {
 
     override val items get() = Sport.values()
         .mapNotNull { it.asItem() }
-        .sortedBy { countryInfo.popularSports.indexOf(it.value!!.osmValue) }
+        .sortedBy { sportPosition(it.value!!.osmValue) }
 
     override val maxSelectableItems = -1
 
@@ -39,5 +39,14 @@ class AddSportForm : AImageListQuestForm<Sport, List<Sport>>() {
 
     private fun applyMultiAnswer() {
         applyAnswer(listOf(MULTI))
+    }
+
+    private fun sportPosition(osmValue: String): Int {
+        val position = countryInfo.popularSports.indexOf(osmValue)
+        if (position < 0) {
+            // not present at all in config, so should be put at the end
+            return Integer.MAX_VALUE
+        }
+        return position
     }
 }


### PR DESCRIPTION
Fixes #4922 by sorting the popular sports in the [same way](https://github.com/streetcomplete/StreetComplete/blob/40cfcdd9b3ab1cb4ad84bcd76abc37ab8b9f595a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionForm.kt#L19-L26) as the popular religions. I have tested the change and it works.

