### PR TITLE
Show steps dashes in overlays

### DIFF
--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -65,6 +65,10 @@ styles:
     map_data-lines:
         base: lines
         blend: translucent
+    map_data-steps-dashes:
+        base: lines
+        blend: translucent
+        dash: [0.6,0.4]
     map_data-lines-dashed:
         base: lines
         blend: translucent
@@ -321,6 +325,14 @@ layers:
                           color: function() { return feature.strokeColor; }
                           width: 1m
                           order: function() { return 702 + Number(feature.layer)*5; }
+        steps-dashes:
+            filter: { type: [line], color: true, steps: true }
+            draw:
+                map_data-steps-dashes:
+                    order: function() { return 702 + Number(feature.layer)*5; }
+                    cap: butt
+                    color: function() { return feature.strokeColor; }
+                    width: function() { return feature.width; }
         line-left:
             filter: { type: [line], colorLeft: true, dashedLeft: false }
             draw:

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
@@ -78,6 +78,8 @@ class StyleableOverlayMapComponent(private val resources: Resources, ctrl: KtMap
                     if (style.stroke.dashed) props["dashed"] = "1"
                     props["color"] = style.stroke.color
                     props["strokeColor"] = getDarkenedColor(style.stroke.color)
+                    if (element.tags["highway"] == "steps")
+                        props["steps"] = "1"
                 } else if (style.strokeLeft != null || style.strokeRight != null) {
                     // must have a color for the center if left or right is defined because
                     // there are really ugly overlaps in tangram otherwise


### PR DESCRIPTION
Currently highlighted steps use the same style as other ways. This is confusing, as it's not immediately clear that they are steps.
With these changes, step dashes show up using outline color.
(the map style changes should also go to the mapstyle repo, but this makes things awkward for anyone wanting to test this PR)