### PR TITLE
Fix toolbar being displayed in the WhatsNewDialog

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.DividerItemDecoration
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.databinding.DialogWhatsNewBinding
 import de.westnordost.streetcomplete.databinding.FragmentChangelogBinding
 import de.westnordost.streetcomplete.databinding.RowChangelogBinding
 import de.westnordost.streetcomplete.screens.HasTitle
@@ -50,7 +51,7 @@ class WhatsNewDialog(context: Context, sinceVersion: String) : AlertDialog(conte
     private val scope = CoroutineScope(Dispatchers.Main)
 
     init {
-        val binding = FragmentChangelogBinding.inflate(LayoutInflater.from(context))
+        val binding = DialogWhatsNewBinding.inflate(LayoutInflater.from(context))
         binding.changelogList.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
 
         setTitle(R.string.title_whats_new)

--- a/app/src/main/res/layout/dialog_whats_new.xml
+++ b/app/src/main/res/layout/dialog_whats_new.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    android:orientation="vertical"
+    android:id="@+id/changelogList" />


### PR DESCRIPTION
This PR removes an empty toolbar being incorrectly displayed in the `WhatsNewDialog`. This regression was introduced in #4954, which moved the toolbars to the individual fragment layouts. Unfortunately, I was not aware that the now modified `ChangelogFragment` layout was also used by this dialog.