### PR TITLE
Add support for the predictive back gesture

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
     <application
         android:name="de.westnordost.streetcomplete.StreetCompleteApplication"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/BackPressedListener.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/BackPressedListener.kt
@@ -1,6 +1,0 @@
-package de.westnordost.streetcomplete.screens
-
-interface BackPressedListener {
-    /** Return true to consume the event */
-    fun onBackPressed(): Boolean
-}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/FragmentContainerActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/FragmentContainerActivity.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.screens
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.commit
 import de.westnordost.streetcomplete.R
 
@@ -11,12 +12,15 @@ open class FragmentContainerActivity(
     @LayoutRes contentLayoutId: Int = R.layout.activity_fragment_container,
 ) : BaseActivity(contentLayoutId) {
 
-    var mainFragment: Fragment?
-        get() = supportFragmentManager.findFragmentById(R.id.fragment_container)
-        set(value) {
-            supportFragmentManager.popBackStack("main", FragmentManager.POP_BACK_STACK_INCLUSIVE)
-            if (value != null) {
-                supportFragmentManager.commit { replace(R.id.fragment_container, value) }
-            }
+    protected fun replaceMainFragment(
+        f: Fragment,
+        customOptions: (FragmentTransaction.() -> Unit)? = null,
+    ) {
+        supportFragmentManager.popBackStack("main", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        supportFragmentManager.commit {
+            customOptions?.invoke(this)
+            replace(R.id.fragment_container, f)
+            setPrimaryNavigationFragment(f)
         }
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/HandlesOnBackPressed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/HandlesOnBackPressed.kt
@@ -1,5 +1,0 @@
-package de.westnordost.streetcomplete.screens
-
-interface HandlesOnBackPressed {
-    fun onBackPressed(): Boolean
-}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
@@ -198,23 +198,6 @@ class MainActivity :
         uploadController.showNotification = false
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        if (!forwardBackPressedToChildren()) super.onBackPressed()
-    }
-
-    private fun forwardBackPressedToChildren(): Boolean {
-        val messagesContainerFragment = messagesContainerFragment
-        if (messagesContainerFragment != null) {
-            if (messagesContainerFragment.onBackPressed()) return true
-        }
-        val mainFragment = mainFragment
-        if (mainFragment != null) {
-            if (mainFragment.onBackPressed()) return true
-        }
-        return false
-    }
-
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val mainFragment = mainFragment
         if (event.keyCode == KeyEvent.KEYCODE_MENU && mainFragment != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutActivity.kt
@@ -8,7 +8,7 @@ class AboutActivity : FragmentContainerActivity() {
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
         if (savedInstanceState == null) {
-            mainFragment = TwoPaneAboutFragment()
+            replaceMainFragment(TwoPaneAboutFragment())
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.OvershootInterpolator
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AnyThread
 import androidx.annotation.DrawableRes
 import androidx.annotation.UiThread
@@ -73,7 +74,6 @@ import de.westnordost.streetcomplete.quests.AbstractQuestForm
 import de.westnordost.streetcomplete.quests.IsShowingQuestDetails
 import de.westnordost.streetcomplete.quests.LeaveNoteInsteadFragment
 import de.westnordost.streetcomplete.quests.note_discussion.NoteDiscussionForm
-import de.westnordost.streetcomplete.screens.HandlesOnBackPressed
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.CreateNoteFragment
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsCloseableBottomSheet
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapOrientationAware
@@ -162,7 +162,6 @@ class MainFragment :
     MapDataWithEditsSource.Listener,
     SelectedOverlaySource.Listener,
     // rest
-    HandlesOnBackPressed,
     ShowsGeometryMarkers {
 
     private val visibleQuestsSource: VisibleQuestsSource by inject()
@@ -200,6 +199,18 @@ class MainFragment :
 
     /* +++++++++++++++++++++++++++++++++++++++ CALLBACKS ++++++++++++++++++++++++++++++++++++++++ */
 
+    private val historyBackPressedCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            closeEditHistorySidebar()
+        }
+    }
+
+    private val sheetBackPressedCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            (bottomSheetFragment as IsCloseableBottomSheet).onClickClose { closeBottomSheet() }
+        }
+    }
+
     //region Lifecycle - Android Lifecycle Callbacks
 
     override fun onAttach(context: Context) {
@@ -234,6 +245,13 @@ class MainFragment :
         binding.createButton.setOnClickListener { onClickCreateButton() }
 
         updateOffsetWithOpenBottomSheet()
+
+        requireActivity().onBackPressedDispatcher
+            .addCallback(viewLifecycleOwner, historyBackPressedCallback)
+        historyBackPressedCallback.isEnabled = editHistoryFragment != null
+        requireActivity().onBackPressedDispatcher
+            .addCallback(viewLifecycleOwner, sheetBackPressedCallback)
+        sheetBackPressedCallback.isEnabled = bottomSheetFragment is IsCloseableBottomSheet
     }
 
     @UiThread
@@ -264,23 +282,6 @@ class MainFragment :
         selectedOverlaySource.addListener(this)
         locationAvailabilityReceiver.addListener(::updateLocationAvailability)
         updateLocationAvailability(requireContext().run { hasLocationPermission && isLocationEnabled })
-    }
-
-    /** Called by the activity when the user presses the back button.
-     *  Returns true if the event should be consumed. */
-    override fun onBackPressed(): Boolean {
-        if (editHistoryFragment != null) {
-            closeEditHistorySidebar()
-            return true
-        }
-
-        val f = bottomSheetFragment
-        if (f is IsCloseableBottomSheet) {
-            f.onClickClose { closeBottomSheet() }
-            return true
-        }
-
-        return false
     }
 
     override fun onStop() {
@@ -891,6 +892,7 @@ class MainFragment :
         }
         mapFragment?.hideOverlay()
         mapFragment?.pinMode = MainMapFragment.PinMode.EDITS
+        historyBackPressedCallback.isEnabled = true
     }
 
     private fun closeEditHistorySidebar() {
@@ -900,6 +902,7 @@ class MainFragment :
         clearHighlighting()
         mapFragment?.clearFocus()
         mapFragment?.pinMode = MainMapFragment.PinMode.QUESTS
+        historyBackPressedCallback.isEnabled = false
     }
 
     //endregion
@@ -917,6 +920,7 @@ class MainFragment :
         clearHighlighting()
         unfreezeMap()
         mapFragment?.endFocus()
+        sheetBackPressedCallback.isEnabled = false
     }
 
     /** Open or replace the bottom sheet. If the bottom sheet is replaces, no appear animation is
@@ -934,6 +938,7 @@ class MainFragment :
             replace(R.id.map_bottom_sheet_container, f, BOTTOM_SHEET)
             addToBackStack(BOTTOM_SHEET)
         }
+        sheetBackPressedCallback.isEnabled = f is IsCloseableBottomSheet
     }
 
     /** Make the map not follow the user's location anymore temporarily */

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/messages/MessagesContainerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/messages/MessagesContainerFragment.kt
@@ -8,7 +8,6 @@ import de.westnordost.streetcomplete.data.messages.NewAchievementMessage
 import de.westnordost.streetcomplete.data.messages.NewVersionMessage
 import de.westnordost.streetcomplete.data.messages.OsmUnreadMessagesMessage
 import de.westnordost.streetcomplete.data.messages.QuestSelectionHintMessage
-import de.westnordost.streetcomplete.screens.HandlesOnBackPressed
 import de.westnordost.streetcomplete.screens.about.WhatsNewDialog
 import de.westnordost.streetcomplete.screens.settings.SettingsActivity
 import de.westnordost.streetcomplete.screens.user.achievements.AchievementInfoFragment
@@ -16,9 +15,7 @@ import de.westnordost.streetcomplete.screens.user.achievements.AchievementInfoFr
 /** A fragment that contains any fragments that would show messages.
  *  Usually, messages are shown as dialogs, however there is currently one exception which
  *  makes this necessary as a fragment */
-class MessagesContainerFragment :
-    Fragment(R.layout.fragment_messages_container),
-    HandlesOnBackPressed {
+class MessagesContainerFragment : Fragment(R.layout.fragment_messages_container) {
 
     fun showMessage(message: Message) {
         val ctx = context ?: return
@@ -49,12 +46,4 @@ class MessagesContainerFragment :
         }
     }
 
-    override fun onBackPressed(): Boolean {
-        for (f in childFragmentManager.fragments) {
-            if (f is HandlesOnBackPressed) {
-                if (f.onBackPressed()) return true
-            }
-        }
-        return false
-    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsActivity.kt
@@ -10,7 +10,7 @@ class SettingsActivity : FragmentContainerActivity() {
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
         if (savedInstanceState == null) {
-            mainFragment = TwoPaneSettingsFragment()
+            replaceMainFragment(TwoPaneSettingsFragment())
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.core.view.isGone
 import androidx.fragment.app.commit
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -64,15 +65,20 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.fragment_show_quest_forms)
         binding.toolbarLayout.toolbar.navigationIcon = getDrawable(R.drawable.ic_close_24dp)
-        binding.toolbarLayout.toolbar.setNavigationOnClickListener { onBackPressed() }
+        binding.toolbarLayout.toolbar.setNavigationOnClickListener { finish() }
         binding.toolbarLayout.toolbar.title = "Show Quest Forms"
 
-        binding.questFormContainer.setOnClickListener { onBackPressed() }
+        binding.questFormContainer.setOnClickListener { popQuestForm() }
 
         binding.showQuestFormsList.apply {
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
             layoutManager = LinearLayoutManager(context)
             adapter = showQuestFormAdapter
+        }
+
+        updateContainerVisibility()
+        supportFragmentManager.addOnBackStackChangedListener {
+            updateContainerVisibility()
         }
     }
 
@@ -84,19 +90,14 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
         )
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        if (supportFragmentManager.backStackEntryCount > 0) {
-            popQuestForm()
-        } else {
-            super.onBackPressed()
-        }
-    }
-
     private fun popQuestForm() {
         binding.questFormContainer.visibility = View.GONE
         supportFragmentManager.popBackStack()
         currentQuestType = null
+    }
+
+    private fun updateContainerVisibility() {
+        binding.questFormContainer.isGone = supportFragmentManager.findFragmentById(R.id.questForm) == null
     }
 
     inner class ShowQuestFormAdapter : ListAdapter<QuestType>() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserActivity.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.EditType
@@ -46,8 +45,8 @@ class UserActivity :
         supportFragmentManager.findFragmentById(R.id.achievementDetailsFragment) as AchievementInfoFragment?
 
     private val loginStatusListener = object : UserLoginStatusSource.Listener {
-        override fun onLoggedIn() { lifecycleScope.launch { replaceMainFragment(UserFragment()) } }
-        override fun onLoggedOut() { lifecycleScope.launch { replaceMainFragment(LoginFragment()) } }
+        override fun onLoggedIn() { lifecycleScope.launch { replaceMainFragmentAnimated(UserFragment()) } }
+        override fun onLoggedOut() { lifecycleScope.launch { replaceMainFragmentAnimated(LoginFragment()) } }
     }
 
     private val fragmentLifecycleCallbacks = object : FragmentManager.FragmentLifecycleCallbacks() {
@@ -64,11 +63,11 @@ class UserActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null) {
-            mainFragment = when {
+            replaceMainFragment(when {
                 intent.getBooleanExtra(EXTRA_LAUNCH_AUTH, false) -> LoginFragment.create(true)
                 userLoginStatusSource.isLoggedIn -> UserFragment()
                 else -> LoginFragment.create()
-            }
+            })
         }
         userLoginStatusSource.addListener(loginStatusListener)
 
@@ -87,26 +86,6 @@ class UserActivity :
             finish()
             return true
         } else super.onOptionsItemSelected(item)
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        val countryDetailsFragment = countryDetailsFragment
-        if (countryDetailsFragment != null && countryDetailsFragment.isShowing) {
-            countryDetailsFragment.dismiss()
-            return
-        }
-        val editTypeDetailsFragment = editTypeDetailsFragment
-        if (editTypeDetailsFragment != null && editTypeDetailsFragment.isShowing) {
-            editTypeDetailsFragment.dismiss()
-            return
-        }
-        val achievementDetailsFragment = achievementDetailsFragment
-        if (achievementDetailsFragment != null && achievementDetailsFragment.isShowing) {
-            achievementDetailsFragment.dismiss()
-            return
-        }
-        super.onBackPressed()
     }
 
     override fun onDestroy() {
@@ -132,14 +111,12 @@ class UserActivity :
 
     /* ------------------------------------------------------------------------------------------ */
 
-    private fun replaceMainFragment(fragment: Fragment) {
-        supportFragmentManager.popBackStack("main", FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        supportFragmentManager.commit {
+    private fun replaceMainFragmentAnimated(fragment: Fragment) {
+        replaceMainFragment(fragment) {
             setCustomAnimations(
                 R.anim.fade_in_from_bottom, R.anim.fade_out_to_top,
                 R.anim.fade_in_from_bottom, R.anim.fade_out_to_top
             )
-            replace(R.id.fragment_container, fragment)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginFragment.kt
@@ -17,9 +17,7 @@ import de.westnordost.streetcomplete.data.osmConnection
 import de.westnordost.streetcomplete.data.user.UserLoginStatusController
 import de.westnordost.streetcomplete.data.user.UserUpdater
 import de.westnordost.streetcomplete.databinding.FragmentLoginBinding
-import de.westnordost.streetcomplete.screens.BackPressedListener
 import de.westnordost.streetcomplete.screens.HasTitle
-import de.westnordost.streetcomplete.util.ktx.childFragmentManagerOrNull
 import de.westnordost.streetcomplete.util.ktx.toast
 import de.westnordost.streetcomplete.util.ktx.viewLifecycleScope
 import de.westnordost.streetcomplete.util.viewBinding
@@ -34,7 +32,6 @@ import org.koin.android.ext.android.inject
 class LoginFragment :
     Fragment(R.layout.fragment_login),
     HasTitle,
-    BackPressedListener,
     OAuthFragment.Listener {
 
     private val unsyncedChangesCountSource: UnsyncedChangesCountSource by inject()
@@ -44,9 +41,6 @@ class LoginFragment :
     override val title: String get() = getString(R.string.user_login)
 
     private val binding by viewBinding(FragmentLoginBinding::bind)
-
-    private val oAuthFragment: OAuthFragment? get() =
-        childFragmentManagerOrNull?.findFragmentById(R.id.oauthFragmentContainer) as? OAuthFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -66,16 +60,6 @@ class LoginFragment :
             binding.unpublishedEditCountText.text = getString(R.string.unsynced_quests_not_logged_in_description, unsyncedChanges)
             binding.unpublishedEditCountText.isGone = unsyncedChanges <= 0
         }
-    }
-
-    override fun onBackPressed(): Boolean {
-        val f = oAuthFragment
-        if (f != null) {
-            if (f.onBackPressed()) return true
-            childFragmentManager.popBackStack("oauth", POP_BACK_STACK_INCLUSIVE)
-            return true
-        }
-        return false
     }
 
     /* ------------------------------- OAuthFragment.Listener ----------------------------------- */

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/statistics/AbstractInfoFakeDialogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/statistics/AbstractInfoFakeDialogFragment.kt
@@ -8,6 +8,7 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.OvershootInterpolator
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import de.westnordost.streetcomplete.view.Transforms
 import de.westnordost.streetcomplete.view.ViewPropertyAnimatorsPlayer
@@ -23,9 +24,6 @@ abstract class AbstractInfoFakeDialogFragment(layoutId: Int) : Fragment(layoutId
     /** View from which the title image view is animated from (and back on dismissal)*/
     private var sharedTitleView: View? = null
 
-    var isShowing: Boolean = false
-        private set
-
     private var animatorsPlayer: ViewPropertyAnimatorsPlayer? = null
 
     protected abstract val dialogAndBackgroundContainer: ViewGroup
@@ -34,11 +32,18 @@ abstract class AbstractInfoFakeDialogFragment(layoutId: Int) : Fragment(layoutId
     protected abstract val dialogBubbleBackground: View
     protected abstract val titleView: View
 
+    private val backPressedCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            dismiss()
+        }
+    }
+
     /* ---------------------------------------- Lifecycle --------------------------------------- */
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         dialogAndBackgroundContainer.setOnClickListener { dismiss() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
     }
 
     override fun onDestroyView() {
@@ -51,14 +56,14 @@ abstract class AbstractInfoFakeDialogFragment(layoutId: Int) : Fragment(layoutId
 
     open fun dismiss(): Boolean {
         if (animatorsPlayer != null) return false
-        isShowing = false
+        backPressedCallback.isEnabled = false
         animateOut(sharedTitleView)
         return true
     }
 
     protected fun show(sharedView: View): Boolean {
         if (animatorsPlayer != null) return false
-        isShowing = true
+        backPressedCallback.isEnabled = true
         this.sharedTitleView = sharedView
         animateIn(sharedView)
         return true


### PR DESCRIPTION
This PR adds support for the the predictive back gesture introduced in Android 13 (see [here](https://developer.android.com/guide/navigation/predictive-back-gesture) for details). The predictive back gestures use an ahead-of-time model for back event handling (implemented using the AndroidX `onBackPressedDispatcher` and `FragmentManager`) instead of the deprecated `onBackPressed` callback that is only called once the back button was already pressed. According to the developer documentation, supporting this functionality will be mandatory for a future Android version.

The following video shows this feature in action on an Android 14 device with "Predictive back animations" enabled in the developer settings:

https://user-images.githubusercontent.com/6892794/235721284-7ccdce95-48a8-4094-8943-4c43700125dd.mp4

I tested that the back button still works correctly with the following features (including after recreation of the `Activity` or `Fragment`):
- Map screen: bottom sheets, messages (hints, unread messages, change log, achievements), and history side bar
- Settings and about screens: detail fragments and debug menu
- User screen: achievements, edit stats, and login

I hope this covers all the places where the back button is used.
