### PR TITLE
Visualize downloaded area

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
@@ -16,79 +16,74 @@ class DownloadedTilesDaoTest : ApplicationDbTestCase() {
     }
 
     @Test fun putGetOne() {
-        dao.put(r(5, 8, 5, 8), "Huhu")
+        dao.put(r(5, 8, 5, 8))
 
-        assertEquals(
-            listOf("Huhu"),
-            dao.get(r(5, 8, 5, 8), 0)
-        )
+        assertTrue(dao.contains(r(5, 8, 5, 8), 0))
 
         assertEquals(
             listOf(TilePos(5, 8)),
-            dao.getAll("Huhu", 0)
+            dao.getAll(0)
         )
     }
 
     @Test fun putGetOld() {
-        dao.put(r(5, 8, 5, 8), "Huhu")
+        dao.put(r(5, 8, 5, 8))
         val then = nowAsEpochMilliseconds() + 1000
-        assertTrue(dao.get(r(5, 8, 5, 8), then).isEmpty())
-        assertTrue(dao.getAll("Huhu", then).isEmpty())
+        assertFalse(dao.contains(r(5, 8, 5, 8), then))
+        assertTrue(dao.getAll(then).isEmpty())
     }
 
     @Test fun putSomeOld() {
-        dao.put(r(0, 0, 1, 3), "Huhu")
+        dao.put(r(0, 0, 1, 3))
         Thread.sleep(2000)
-        dao.put(r(2, 0, 5, 5), "Huhu")
+        dao.put(r(2, 0, 5, 5))
         val before = nowAsEpochMilliseconds() - 1000
-        assertTrue(dao.get(r(0, 0, 2, 2), before).isEmpty())
-        assertEquals(24, dao.getAll("Huhu", before).size)
+        assertFalse(dao.contains(r(0, 0, 2, 2), before))
+        assertEquals(24, dao.getAll(before).size)
     }
 
     @Test fun putMoreGetOne() {
-        dao.put(r(5, 8, 6, 10), "Huhu")
-        assertEquals(
-            listOf("Huhu"),
-            dao.get(r(5, 8, 5, 8), 0)
-        )
-        assertEquals(
-            listOf("Huhu"),
-            dao.get(r(6, 10, 6, 10), 0)
-        )
-        assertEquals(6, dao.getAll("Huhu", 0).size)
+        dao.put(r(5, 8, 6, 10))
+        assertTrue(dao.contains(r(5, 8, 5, 8), 0))
+        assertTrue(dao.contains(r(6, 10, 6, 10), 0))
+        assertEquals(6, dao.getAll(0).size)
     }
 
     @Test fun putOneGetMore() {
-        dao.put(r(5, 8, 5, 8), "Huhu")
-        assertTrue(dao.get(r(5, 8, 5, 9), 0).isEmpty())
+        dao.put(r(5, 8, 5, 8))
+        assertFalse(dao.contains(r(5, 8, 5, 9), 0))
     }
 
     @Test fun remove() {
-        dao.put(r(0, 0, 3, 3), "Huhu")
-        dao.put(r(0, 0, 0, 0), "Haha")
-        dao.put(r(1, 1, 3, 3), "Hihi")
-        assertEquals(2, dao.remove(TilePos(0, 0))) // removes huhu, haha at 0,0
+        dao.put(r(0, 0, 3, 3))
+        assertEquals(1, dao.delete(TilePos(0, 0)))
     }
 
-    @Test fun putSeveralQuestTypes() {
-        dao.put(r(0, 0, 5, 5), "Huhu")
-        dao.put(r(4, 4, 6, 6), "hoho")
-        dao.put(r(4, 0, 4, 7), "hihi")
+    @Test fun putRemoveAll() {
+        dao.put(r(0, 0, 3, 3))
+        dao.deleteAll()
+        assertTrue(dao.getAll(0).isEmpty())
+    }
 
-        var check = dao.get(r(0, 0, 2, 2), 0)
-        assertEquals(1, check.size)
-        assertTrue(check.contains("Huhu"))
+    @Test fun updateTime() {
+        dao.put(r(0, 0, 0, 1))
+        dao.updateTime(TilePos(0, 0), 0)
+        assertEquals(
+            listOf(TilePos(0, 1)),
+            dao.getAll(1)
+        )
+    }
 
-        check = dao.get(r(4, 4, 4, 4), 0)
-        assertEquals(3, check.size)
+    @Test fun updateAllTimes() {
+        dao.put(r(0, 0, 0, 1))
+        dao.updateAllTimes(0)
+        assertTrue(dao.getAll(1).isEmpty())
+    }
 
-        check = dao.get(r(5, 5, 5, 5), 0)
-        assertEquals(2, check.size)
-        assertTrue(check.contains("hoho"))
-        assertTrue(check.contains("Huhu"))
-
-        check = dao.get(r(0, 0, 6, 6), 0)
-        assertTrue(check.isEmpty())
+    @Test fun deleteOlderThan() {
+        dao.put(r(0, 0, 1, 0))
+        dao.updateTime(TilePos(0, 0), 1)
+        assertEquals(1, dao.deleteOlderThan(2))
     }
 
     private fun r(left: Int, top: Int, right: Int, bottom: Int) = TilesRect(left, top, right, bottom)

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
@@ -39,19 +39,22 @@ class DownloadedTilesDaoTest : ApplicationDbTestCase() {
     @Test fun putSomeOld() {
         dao.put(r(0, 0, 1, 3), "Huhu")
         Thread.sleep(2000)
-        dao.put(r(1, 3, 5, 5), "Huhu")
+        dao.put(r(2, 0, 5, 5), "Huhu")
         val before = nowAsEpochMilliseconds() - 1000
         assertTrue(dao.get(r(0, 0, 2, 2), before).isEmpty())
-        assertTrue(dao.getAll("Huhu", before).isEmpty())
+        assertEquals(24, dao.getAll("Huhu", before).size)
     }
 
     @Test fun putMoreGetOne() {
         dao.put(r(5, 8, 6, 10), "Huhu")
         assertEquals(
-            listOf(TilePos(5, 8)),
+            listOf("Huhu"),
             dao.get(r(5, 8, 5, 8), 0)
         )
-        assertEquals(6, dao.get(r(6, 10, 6, 10), 0).size)
+        assertEquals(
+            listOf("Huhu"),
+            dao.get(r(6, 10, 6, 10), 0)
+        )
         assertEquals(6, dao.getAll("Huhu", 0).size)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
@@ -17,30 +17,42 @@ class DownloadedTilesDaoTest : ApplicationDbTestCase() {
 
     @Test fun putGetOne() {
         dao.put(r(5, 8, 5, 8), "Huhu")
-        val huhus = dao.get(r(5, 8, 5, 8), 0)
 
-        assertEquals(1, huhus.size)
-        assertTrue(huhus.contains("Huhu"))
+        assertEquals(
+            listOf("Huhu"),
+            dao.get(r(5, 8, 5, 8), 0)
+        )
+
+        assertEquals(
+            listOf(TilePos(5, 8)),
+            dao.getAll("Huhu", 0)
+        )
     }
 
     @Test fun putGetOld() {
         dao.put(r(5, 8, 5, 8), "Huhu")
-        val huhus = dao.get(r(5, 8, 5, 8), nowAsEpochMilliseconds() + 1000)
-        assertTrue(huhus.isEmpty())
+        val then = nowAsEpochMilliseconds() + 1000
+        assertTrue(dao.get(r(5, 8, 5, 8), then).isEmpty())
+        assertTrue(dao.getAll("Huhu", then).isEmpty())
     }
 
     @Test fun putSomeOld() {
         dao.put(r(0, 0, 1, 3), "Huhu")
         Thread.sleep(2000)
         dao.put(r(1, 3, 5, 5), "Huhu")
-        val huhus = dao.get(r(0, 0, 2, 2), nowAsEpochMilliseconds() - 1000)
-        assertTrue(huhus.isEmpty())
+        val before = nowAsEpochMilliseconds() - 1000
+        assertTrue(dao.get(r(0, 0, 2, 2), before).isEmpty())
+        assertTrue(dao.getAll("Huhu", before).isEmpty())
     }
 
     @Test fun putMoreGetOne() {
         dao.put(r(5, 8, 6, 10), "Huhu")
-        assertFalse(dao.get(r(5, 8, 5, 8), 0).isEmpty())
-        assertFalse(dao.get(r(6, 10, 6, 10), 0).isEmpty())
+        assertEquals(
+            listOf(TilePos(5, 8)),
+            dao.get(r(5, 8, 5, 8), 0)
+        )
+        assertEquals(6, dao.get(r(6, 10, 6, 10), 0).size)
+        assertEquals(6, dao.getAll("Huhu", 0).size)
     }
 
     @Test fun putOneGetMore() {

--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -121,7 +121,15 @@ styles:
     downloaded_area:
         base: polygons
         blend: overlay
-
+        texcoords: true
+        shaders:
+            blocks:
+                color: |
+                    float z = u_map_position.z;
+                    color.a *= pow(max(1.0, z - 6.0) / (19.0 - 6.0), 2.0);
+                    // for hatching effect:
+                    float x = fract((v_texcoord.x + v_texcoord.y) * 50.0);
+                    color.a *= step(0.75, x);
 layers:
     # quest pins & dots
     streetcomplete_selected_pins:
@@ -392,5 +400,5 @@ layers:
         data: { source: streetcomplete_downloaded_area }
         draw:
             downloaded_area:
-                color: [0.3, 0.3, 0.3, 0.2]
                 order: 500
+                color: [0.5, 0.5, 0.5, 0.3]

--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -118,6 +118,9 @@ styles:
                     float x = smoothstep(-0.49, -0.51, (v_texcoord.x - 0.5) * 2.0);
                     float y = step(0.4, mod(v_texcoord.y, 1.0));
                     color.a = color.a * x * y;
+    downloaded_area:
+        base: polygons
+        blend: overlay
 
 layers:
     # quest pins & dots
@@ -384,3 +387,10 @@ layers:
                     width: 1m
                     cap: round
                     join: round
+    # downloaded area
+    streetcomplete_downloaded_area:
+        data: { source: streetcomplete_downloaded_area }
+        draw:
+            downloaded_area:
+                color: [0.3, 0.3, 0.3, 0.2]
+                order: 500

--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -154,7 +154,7 @@ class StreetCompleteApplication : Application() {
 
     private fun onNewVersion() {
         // on each new version, invalidate quest cache
-        downloadedTilesController.removeAll()
+        downloadedTilesController.invalidateAll()
     }
 
     override fun onTerminate() {

--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.data.CleanerWorker
 import de.westnordost.streetcomplete.data.Preloader
 import de.westnordost.streetcomplete.data.dbModule
 import de.westnordost.streetcomplete.data.download.downloadModule
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.edithistory.EditHistoryController
 import de.westnordost.streetcomplete.data.edithistory.editHistoryModule
 import de.westnordost.streetcomplete.data.maptiles.maptilesModule
@@ -68,7 +68,7 @@ class StreetCompleteApplication : Application() {
     private val preloader: Preloader by inject()
     private val crashReportExceptionHandler: CrashReportExceptionHandler by inject()
     private val resurveyIntervalsUpdater: ResurveyIntervalsUpdater by inject()
-    private val downloadedTilesDao: DownloadedTilesDao by inject()
+    private val downloadedTilesController: DownloadedTilesController by inject()
     private val prefs: SharedPreferences by inject()
     private val editHistoryController: EditHistoryController by inject()
     private val userLoginStatusController: UserLoginStatusController by inject()
@@ -154,7 +154,7 @@ class StreetCompleteApplication : Application() {
 
     private fun onNewVersion() {
         // on each new version, invalidate quest cache
-        downloadedTilesDao.removeAll()
+        downloadedTilesController.removeAll()
     }
 
     override fun onTerminate() {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/Cleaner.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/Cleaner.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.data
 
 import android.util.Log
 import de.westnordost.streetcomplete.ApplicationConstants
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 import de.westnordost.streetcomplete.data.osmnotes.NoteController
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
@@ -12,7 +13,8 @@ import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 class Cleaner(
     private val noteController: NoteController,
     private val mapDataController: MapDataController,
-    private val questTypeRegistry: QuestTypeRegistry
+    private val questTypeRegistry: QuestTypeRegistry,
+    private val downloadedTilesController: DownloadedTilesController
 ) {
     fun clean() {
         val time = nowAsEpochMilliseconds()
@@ -20,6 +22,7 @@ class Cleaner(
         val oldDataTimestamp = nowAsEpochMilliseconds() - ApplicationConstants.DELETE_OLD_DATA_AFTER
         noteController.deleteOlderThan(oldDataTimestamp, MAX_DELETE_ELEMENTS)
         mapDataController.deleteOlderThan(oldDataTimestamp, MAX_DELETE_ELEMENTS)
+        downloadedTilesController.deleteOlderThan(oldDataTimestamp)
         /* do this after cleaning map data and notes, because some metadata rely on map data */
         questTypeRegistry.forEach { it.deleteMetadataOlderThan(oldDataTimestamp) }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
@@ -16,7 +16,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val osmApiModule = module {
-    factory { Cleaner(get(), get(), get()) }
+    factory { Cleaner(get(), get(), get(), get()) }
     factory { CacheTrimmer(get(), get()) }
     factory<MapDataApi> { MapDataApiImpl(get()) }
     factory<NotesApi> { NotesApiImpl(get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/StreetCompleteSQLiteOpenHelper.kt
@@ -190,10 +190,14 @@ class StreetCompleteSQLiteOpenHelper(context: Context, dbName: String) :
         if (oldVersion <= 8 && newVersion > 8) {
             db.renameQuest("AddPicnicTableCover", "AddAmenityCover")
         }
+        if (oldVersion <= 9 && newVersion > 9) {
+            db.execSQL("DROP TABLE ${DownloadedTilesTable.NAME};")
+            db.execSQL(DownloadedTilesTable.CREATE)
+        }
     }
 }
 
-private const val DB_VERSION = 9
+private const val DB_VERSION = 10
 
 private fun SQLiteDatabase.renameQuest(old: String, new: String) {
     renameValue(ElementEditsTable.NAME, ElementEditsTable.Columns.QUEST_TYPE, old, new)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/DownloadModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/DownloadModule.kt
@@ -2,7 +2,9 @@ package de.westnordost.streetcomplete.data.download
 
 import de.westnordost.streetcomplete.data.download.strategy.MobileDataAutoDownloadStrategy
 import de.westnordost.streetcomplete.data.download.strategy.WifiAutoDownloadStrategy
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -15,4 +17,7 @@ val downloadModule = module {
 
     single<DownloadProgressSource> { get<DownloadController>() }
     single { DownloadController(get()) }
+
+    single<DownloadedTilesSource> { get<DownloadedTilesController>() }
+    single { DownloadedTilesController(get()) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/Downloader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/Downloader.kt
@@ -2,8 +2,7 @@ package de.westnordost.streetcomplete.data.download
 
 import android.util.Log
 import de.westnordost.streetcomplete.ApplicationConstants
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesType
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.download.tiles.TilesRect
 import de.westnordost.streetcomplete.data.maptiles.MapTilesDownloader
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataDownloader
@@ -22,7 +21,7 @@ class Downloader(
     private val notesDownloader: NotesDownloader,
     private val mapDataDownloader: MapDataDownloader,
     private val mapTilesDownloader: MapTilesDownloader,
-    private val downloadedTilesDb: DownloadedTilesDao,
+    private val downloadedTilesController: DownloadedTilesController,
     private val mutex: Mutex
 ) {
     suspend fun download(tiles: TilesRect, ignoreCache: Boolean) {
@@ -55,11 +54,11 @@ class Downloader(
     private fun hasDownloadedAlready(tiles: TilesRect): Boolean {
         val freshTime = ApplicationConstants.REFRESH_DATA_AFTER
         val ignoreOlderThan = max(0, nowAsEpochMilliseconds() - freshTime)
-        return downloadedTilesDb.get(tiles, ignoreOlderThan).contains(DownloadedTilesType.ALL)
+        return downloadedTilesController.contains(tiles, ignoreOlderThan)
     }
 
     private fun putDownloadedAlready(tiles: TilesRect) {
-        downloadedTilesDb.put(tiles, DownloadedTilesType.ALL)
+        downloadedTilesController.put(tiles)
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/AVariableRadiusStrategy.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/AVariableRadiusStrategy.kt
@@ -2,8 +2,7 @@ package de.westnordost.streetcomplete.data.download.strategy
 
 import android.util.Log
 import de.westnordost.streetcomplete.ApplicationConstants
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesType
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import de.westnordost.streetcomplete.data.download.tiles.TilesRect
 import de.westnordost.streetcomplete.data.download.tiles.enclosingTilePos
 import de.westnordost.streetcomplete.data.download.tiles.enclosingTilesRect
@@ -23,7 +22,7 @@ import kotlin.math.sqrt
 /** Auto download strategy decides how big of an area to download based on the OSM map data density */
 abstract class AVariableRadiusStrategy(
     private val mapDataController: MapDataController,
-    private val downloadedTilesDao: DownloadedTilesDao
+    private val downloadedTilesSource: DownloadedTilesSource
 ) : AutoDownloadStrategy {
 
     protected abstract val maxDownloadAreaInKm2: Double
@@ -81,9 +80,7 @@ abstract class AVariableRadiusStrategy(
     private suspend fun hasMissingDataFor(tilesRect: TilesRect): Boolean {
         val dataExpirationTime = ApplicationConstants.REFRESH_DATA_AFTER
         val ignoreOlderThan = max(0, nowAsEpochMilliseconds() - dataExpirationTime)
-        val downloadedTiles =
-            withContext(Dispatchers.IO) { downloadedTilesDao.get(tilesRect, ignoreOlderThan) }
-        return !downloadedTiles.contains(DownloadedTilesType.ALL)
+        return withContext(Dispatchers.IO) { !downloadedTilesSource.contains(tilesRect, ignoreOlderThan) }
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/MobileDataAutoDownloadStrategy.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/MobileDataAutoDownloadStrategy.kt
@@ -1,13 +1,13 @@
 package de.westnordost.streetcomplete.data.download.strategy
 
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 
 /** Download strategy if user is on mobile data */
 class MobileDataAutoDownloadStrategy(
     mapDataController: MapDataController,
-    downloadedTilesDao: DownloadedTilesDao
-) : AVariableRadiusStrategy(mapDataController, downloadedTilesDao) {
+    downloadedTilesSource: DownloadedTilesSource
+) : AVariableRadiusStrategy(mapDataController, downloadedTilesSource) {
 
     override val maxDownloadAreaInKm2 = 10.0 // that's a radius of about 1.5 km
     override val desiredScoredMapDataCountInVicinity = 7500

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/WifiAutoDownloadStrategy.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/strategy/WifiAutoDownloadStrategy.kt
@@ -1,13 +1,13 @@
 package de.westnordost.streetcomplete.data.download.strategy
 
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 
 /** Download strategy if user is on wifi */
 class WifiAutoDownloadStrategy(
     mapDataController: MapDataController,
-    downloadedTilesDao: DownloadedTilesDao
-) : AVariableRadiusStrategy(mapDataController, downloadedTilesDao) {
+    downloadedTilesSource: DownloadedTilesSource
+) : AVariableRadiusStrategy(mapDataController, downloadedTilesSource) {
 
     /** Let's assume that if the user is on wifi, he is either at home, at work, in the hotel, at a
      * café,... in any case, somewhere that would act as a "base" from which he can go on an

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
@@ -1,0 +1,38 @@
+package de.westnordost.streetcomplete.data.download.tiles
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class DownloadedTilesController(
+    private val dao: DownloadedTilesDao
+): DownloadedTilesSource {
+
+    private val listeners = CopyOnWriteArrayList<DownloadedTilesSource.Listener>()
+
+    fun put(tilesRect: TilesRect) {
+        dao.put(tilesRect, DownloadedTilesType.ALL)
+        listeners.forEach { it.onUpdated() }
+    }
+
+    override fun contains(tilesRect: TilesRect, ignoreOlderThan: Long): Boolean =
+        dao.get(tilesRect, ignoreOlderThan).contains(DownloadedTilesType.ALL)
+
+    override fun getAll(ignoreOlderThan: Long): List<TilePos> =
+        dao.getAll(DownloadedTilesType.ALL, ignoreOlderThan)
+
+    fun remove(tile: TilePos) {
+        dao.remove(tile)
+        listeners.forEach { it.onUpdated() }
+    }
+
+    fun removeAll() {
+        dao.removeAll()
+        listeners.forEach { it.onUpdated() }
+    }
+
+    override fun addListener(listener: DownloadedTilesSource.Listener) {
+        listeners.add(listener)
+    }
+    override fun removeListener(listener: DownloadedTilesSource.Listener) {
+        listeners.remove(listener)
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
@@ -52,4 +52,11 @@ class DownloadedTilesDao(private val db: Database) {
             having = "COUNT(*) >= $tileCount"
         ) { it.getString(TYPE) }
     }
+
+    fun getAll(typeName: String, ignoreOlderThan: Long): List<TilePos> =
+        db.query(NAME,
+            columns = arrayOf(X, Y),
+            where = "$DATE > ? AND $TYPE = ?",
+            args = arrayOf(ignoreOlderThan, typeName),
+        ) { TilePos(it.getInt(X), it.getInt(Y)) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
@@ -2,7 +2,6 @@ package de.westnordost.streetcomplete.data.download.tiles
 
 import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesTable.Columns.DATE
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesTable.Columns.TYPE
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesTable.Columns.X
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesTable.Columns.Y
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesTable.NAME
@@ -11,35 +10,46 @@ import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 /** Keeps info in which areas things have been downloaded already in a tile grid */
 class DownloadedTilesDao(private val db: Database) {
 
-    /** Persist that the given type has been downloaded in every tile in the given tile range  */
-    fun put(tilesRect: TilesRect, typeName: String) {
+    /** Persist that the given tile range has been downloaded (now) */
+    fun put(tilesRect: TilesRect) {
         val time = nowAsEpochMilliseconds()
+        val tiles = tilesRect.asTilePosSequence()
         db.replaceMany(NAME,
-            arrayOf(X, Y, TYPE, DATE),
-            tilesRect.asTilePosSequence().map { arrayOf<Any?>(
-                it.x,
-                it.y,
-                typeName,
-                time
-            ) }.asIterable()
+            columnNames = arrayOf(X, Y, DATE),
+            valuesList = tiles.map { arrayOf<Any?>(it.x, it.y, time) }.asIterable()
         )
     }
 
-    /** Invalidate all types within the given tile. (consider them as not-downloaded) */
-    fun remove(tile: TilePos): Int =
-        db.delete(NAME, "$X = ? AND $Y = ?", arrayOf(tile.x.toString(), tile.y.toString()))
+    /** Remove that given tile has been downloaded */
+    fun delete(tile: TilePos): Int =
+        db.delete(NAME,
+            where = "$X = ? AND $Y = ?",
+            args = arrayOf(tile.x.toString(), tile.y.toString())
+        )
 
-    fun removeAll() {
+    fun deleteAll() {
         db.exec("DELETE FROM $NAME")
     }
 
-    /** @return a list of type names which have already been downloaded in every tile in the
-     *  given tile range
-     */
-    fun get(tilesRect: TilesRect, ignoreOlderThan: Long): List<String> {
-        val tileCount = tilesRect.size
-        return db.query(NAME,
-            columns = arrayOf(TYPE),
+    fun updateTime(tile: TilePos, time: Long) {
+        db.update(NAME,
+            values = listOf(DATE to time),
+            where = "$X = ? AND $Y = ?",
+            args = arrayOf(tile.x.toString(), tile.y.toString()),
+        )
+    }
+
+    fun updateAllTimes(time: Long) {
+        db.update(NAME, values = listOf(DATE to time))
+    }
+
+    fun deleteOlderThan(time: Long): Int =
+        db.delete(NAME, where = "$DATE < $time")
+
+    /** @return whether the given tiles range has been completely downloaded */
+    fun contains(tilesRect: TilesRect, ignoreOlderThan: Long): Boolean {
+         val tileCount = db.queryOne(NAME,
+            columns = arrayOf("COUNT(*) as c"),
             where = "$X BETWEEN ? AND ? AND $Y BETWEEN ? AND ? AND $DATE > ?",
             args = arrayOf(
                 tilesRect.left,
@@ -47,16 +57,16 @@ class DownloadedTilesDao(private val db: Database) {
                 tilesRect.top,
                 tilesRect.bottom,
                 ignoreOlderThan
-            ),
-            groupBy = TYPE,
-            having = "COUNT(*) >= $tileCount"
-        ) { it.getString(TYPE) }
+            )
+        ) { it.getInt("c") } ?: 0
+        return tilesRect.size <= tileCount
     }
 
-    fun getAll(typeName: String, ignoreOlderThan: Long): List<TilePos> =
+    /** @return all tiles that have been downloaded */
+    fun getAll(ignoreOlderThan: Long): List<TilePos> =
         db.query(NAME,
             columns = arrayOf(X, Y),
-            where = "$DATE > ? AND $TYPE = ?",
-            args = arrayOf(ignoreOlderThan, typeName),
+            where = "$DATE > ?",
+            args = arrayOf(ignoreOlderThan),
         ) { TilePos(it.getInt(X), it.getInt(Y)) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesSource.kt
@@ -1,0 +1,14 @@
+package de.westnordost.streetcomplete.data.download.tiles
+
+interface DownloadedTilesSource {
+    interface Listener {
+        fun onUpdated()
+    }
+
+    fun contains(tilesRect: TilesRect, ignoreOlderThan: Long): Boolean
+
+    fun getAll(ignoreOlderThan: Long): List<TilePos>
+
+    fun addListener(listener: Listener)
+    fun removeListener(listener: Listener)
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesTable.kt
@@ -6,7 +6,6 @@ object DownloadedTilesTable {
     object Columns {
         const val X = "x"
         const val Y = "y"
-        const val TYPE = "quest_type"
         const val DATE = "date"
     }
 
@@ -14,9 +13,8 @@ object DownloadedTilesTable {
         CREATE TABLE $NAME (
             ${Columns.X} int NOT NULL,
             ${Columns.Y} int NOT NULL,
-            ${Columns.TYPE} varchar(255) NOT NULL,
             ${Columns.DATE} int NOT NULL,
-            CONSTRAINT primary_key PRIMARY KEY (${Columns.X}, ${Columns.Y}, ${Columns.TYPE})
+            CONSTRAINT primary_key PRIMARY KEY (${Columns.X}, ${Columns.Y})
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesType.kt
@@ -1,5 +1,0 @@
-package de.westnordost.streetcomplete.data.download.tiles
-
-object DownloadedTilesType {
-    const val ALL = "quests"
-}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/BoundingBox.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/BoundingBox.kt
@@ -36,3 +36,13 @@ fun BoundingBox.splitAt180thMeridian(): List<BoundingBox> {
         )
     } else listOf(this)
 }
+
+/** @return a polygon with the same extent as this bounding box, defined in counter-clockwise order
+ * */
+fun BoundingBox.toPolygon() = listOf(
+    min,
+    LatLon(min.latitude, max.longitude),
+    max,
+    LatLon(max.latitude, min.longitude),
+    min,
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
@@ -18,7 +18,7 @@ import de.westnordost.streetcomplete.data.download.DownloadProgressListener
 import de.westnordost.streetcomplete.data.download.DownloadProgressSource
 import de.westnordost.streetcomplete.data.download.strategy.MobileDataAutoDownloadStrategy
 import de.westnordost.streetcomplete.data.download.strategy.WifiAutoDownloadStrategy
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.upload.UploadController
 import de.westnordost.streetcomplete.data.user.UserLoginStatusSource
@@ -47,7 +47,7 @@ class QuestAutoSyncer(
     private val userLoginStatusSource: UserLoginStatusSource,
     private val prefs: SharedPreferences,
     private val teamModeQuestFilter: TeamModeQuestFilter,
-    private val downloadedTilesDao: DownloadedTilesDao
+    private val downloadedTilesController: DownloadedTilesController
 ) : DefaultLifecycleObserver {
 
     private val coroutineScope = CoroutineScope(SupervisorJob() + CoroutineName("QuestAutoSyncer"))
@@ -103,7 +103,7 @@ class QuestAutoSyncer(
         override fun onTeamModeChanged(enabled: Boolean) {
             if (!enabled) {
                 // because other team members will have solved some of the quests already
-                downloadedTilesDao.removeAll()
+                downloadedTilesController.removeAll()
                 triggerAutoDownload()
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
@@ -103,7 +103,7 @@ class QuestAutoSyncer(
         override fun onTeamModeChanged(enabled: Boolean) {
             if (!enabled) {
                 // because other team members will have solved some of the quests already
-                downloadedTilesController.removeAll()
+                downloadedTilesController.invalidateAll()
                 triggerAutoDownload()
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/upload/Uploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/upload/Uploader.kt
@@ -69,7 +69,7 @@ class Uploader(
         // called after a conflict. If there is a conflict, the user is not the only one in that
         // area, so best invalidate all downloaded quests here and redownload on next occasion
         val tile = pos.enclosingTilePos(ApplicationConstants.DOWNLOAD_TILE_ZOOM)
-        downloadedTilesController.remove(tile)
+        downloadedTilesController.invalidate(tile)
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/upload/Uploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/upload/Uploader.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.data.upload
 
 import android.util.Log
 import de.westnordost.streetcomplete.ApplicationConstants
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.download.tiles.enclosingTilePos
 import de.westnordost.streetcomplete.data.osm.edits.upload.ElementEditsUploader
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 class Uploader(
     private val noteEditsUploader: NoteEditsUploader,
     private val elementEditsUploader: ElementEditsUploader,
-    private val downloadedTilesDB: DownloadedTilesDao,
+    private val downloadedTilesController: DownloadedTilesController,
     private val userLoginStatusSource: UserLoginStatusSource,
     private val versionIsBannedChecker: VersionIsBannedChecker,
     private val mutex: Mutex
@@ -69,7 +69,7 @@ class Uploader(
         // called after a conflict. If there is a conflict, the user is not the only one in that
         // area, so best invalidate all downloaded quests here and redownload on next occasion
         val tile = pos.enclosingTilePos(ApplicationConstants.DOWNLOAD_TILE_ZOOM)
-        downloadedTilesDB.remove(tile)
+        downloadedTilesController.remove(tile)
     }
 
     companion object {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/DownloadedAreaManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/DownloadedAreaManager.kt
@@ -1,0 +1,47 @@
+package de.westnordost.streetcomplete.screens.main.map
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
+import de.westnordost.streetcomplete.screens.main.map.components.DownloadedAreaMapComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
+
+class DownloadedAreaManager(
+    private val mapComponent: DownloadedAreaMapComponent,
+    private val downloadedTilesSource: DownloadedTilesSource
+) : DefaultLifecycleObserver {
+
+    private val viewLifecycleScope: CoroutineScope = CoroutineScope(SupervisorJob())
+
+    private val downloadedTilesListener = object : DownloadedTilesSource.Listener {
+        override fun onUpdated() {
+            update()
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        update()
+        downloadedTilesSource.addListener(downloadedTilesListener)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        viewLifecycleScope.coroutineContext.cancelChildren()
+        downloadedTilesSource.removeListener(downloadedTilesListener)
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        viewLifecycleScope.cancel()
+    }
+
+    private fun update() {
+        viewLifecycleScope.launch {
+            mapComponent.set(downloadedTilesSource.getAll(0))
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/DownloadedAreaManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/DownloadedAreaManager.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.screens.main.map
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import de.westnordost.streetcomplete.screens.main.map.components.DownloadedAreaMapComponent
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +42,7 @@ class DownloadedAreaManager(
 
     private fun update() {
         viewLifecycleScope.launch {
-            mapComponent.set(downloadedTilesSource.getAll(0))
+            mapComponent.set(downloadedTilesSource.getAll(ApplicationConstants.DELETE_OLD_DATA_AFTER))
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -14,6 +14,7 @@ import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.quest.VisibleQuestsSource
 import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderSource
+import de.westnordost.streetcomplete.screens.main.map.components.DownloadedAreaMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.FocusGeometryMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.GeometryMarkersMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.PinsMapComponent
@@ -49,6 +50,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
     private var editHistoryPinsManager: EditHistoryPinsManager? = null
     private var styleableOverlayMapComponent: StyleableOverlayMapComponent? = null
     private var styleableOverlayManager: StyleableOverlayManager? = null
+    private var downloadedAreaMapComponent: DownloadedAreaMapComponent? = null
 
     interface Listener {
         fun onClickedQuest(questKey: QuestKey)
@@ -118,6 +120,9 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
         styleableOverlayMapComponent = StyleableOverlayMapComponent(resources, ctrl)
         styleableOverlayManager = StyleableOverlayManager(ctrl, styleableOverlayMapComponent!!, mapDataSource, selectedOverlaySource)
         viewLifecycleOwner.lifecycle.addObserver(styleableOverlayManager!!)
+
+        downloadedAreaMapComponent = DownloadedAreaMapComponent(ctrl)
+        downloadedAreaMapComponent?.set()
 
         selectedOverlaySource.addListener(overlayListener)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.screens.main.map
 import android.graphics.PointF
 import android.graphics.RectF
 import androidx.annotation.DrawableRes
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
 import de.westnordost.streetcomplete.data.edithistory.EditHistorySource
 import de.westnordost.streetcomplete.data.edithistory.EditKey
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
@@ -41,6 +42,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
     private val editHistorySource: EditHistorySource by inject()
     private val mapDataSource: MapDataWithEditsSource by inject()
     private val selectedOverlaySource: SelectedOverlaySource by inject()
+    private val downloadedTilesSource: DownloadedTilesSource by inject()
 
     private var geometryMarkersMapComponent: GeometryMarkersMapComponent? = null
     private var pinsMapComponent: PinsMapComponent? = null
@@ -51,6 +53,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
     private var styleableOverlayMapComponent: StyleableOverlayMapComponent? = null
     private var styleableOverlayManager: StyleableOverlayManager? = null
     private var downloadedAreaMapComponent: DownloadedAreaMapComponent? = null
+    private var downloadedAreaManager: DownloadedAreaManager? = null
 
     interface Listener {
         fun onClickedQuest(questKey: QuestKey)
@@ -122,7 +125,8 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
         viewLifecycleOwner.lifecycle.addObserver(styleableOverlayManager!!)
 
         downloadedAreaMapComponent = DownloadedAreaMapComponent(ctrl)
-        downloadedAreaMapComponent?.set()
+        downloadedAreaManager = DownloadedAreaManager(downloadedAreaMapComponent!!, downloadedTilesSource)
+        viewLifecycleOwner.lifecycle.addObserver(downloadedAreaManager!!)
 
         selectedOverlaySource.addListener(overlayListener)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -125,7 +125,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
         viewLifecycleOwner.lifecycle.addObserver(styleableOverlayManager!!)
 
         downloadedAreaMapComponent = DownloadedAreaMapComponent(ctrl)
-        downloadedAreaManager = DownloadedAreaManager(downloadedAreaMapComponent!!, downloadedTilesSource)
+        downloadedAreaManager = DownloadedAreaManager(ctrl, downloadedAreaMapComponent!!, downloadedTilesSource)
         viewLifecycleOwner.lifecycle.addObserver(downloadedAreaManager!!)
 
         selectedOverlaySource.addListener(overlayListener)
@@ -137,6 +137,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
         super.onMapIsChanging(position, rotation, tilt, zoom)
         questPinsManager?.onNewScreenPosition()
         styleableOverlayManager?.onNewScreenPosition()
+        downloadedAreaManager?.onNewScreenPosition()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/DownloadedAreaMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/DownloadedAreaMapComponent.kt
@@ -1,0 +1,42 @@
+package de.westnordost.streetcomplete.screens.main.map.components
+
+import com.mapzen.tangram.LngLat
+import com.mapzen.tangram.MapData
+import com.mapzen.tangram.geometry.Polygon
+import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
+
+class DownloadedAreaMapComponent(private val ctrl: KtMapController) {
+    private val layer: MapData = ctrl.addDataLayer(DOWNLOADED_AREA_LAYER)
+
+    fun set() {
+        layer.setFeatures(listOf(
+            Polygon(listOf(
+                // whole world
+                listOf(
+                    LngLat(-180.0, 90.0),
+                    LngLat(-180.0, -90.0),
+                    LngLat(180.0, -90.0),
+                    LngLat(180.0, 90.0),
+                    LngLat(-180.0, 90.0)
+                ),
+                // a hole = downloaded area...
+                listOf(
+                    LngLat(-1.0, 1.0),
+                    LngLat(-1.0, -1.0),
+                    LngLat(1.0, -1.0),
+                    LngLat(1.0, 1.0),
+                    LngLat(-1.0, 1.0),
+                ).reversed()
+            ), mapOf())
+        ))
+    }
+
+    fun clear() {
+        layer.clear()
+    }
+
+    companion object {
+        // see streetcomplete.yaml for the definitions of the below layers
+        private const val DOWNLOADED_AREA_LAYER = "streetcomplete_downloaded_area"
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
@@ -236,7 +236,7 @@ class SettingsFragment :
 
     private suspend fun deleteCache() = withContext(Dispatchers.IO) {
         context?.externalCacheDir?.purge()
-        downloadedTilesController.removeAll()
+        downloadedTilesController.clear()
         mapDataController.clear()
         noteController.clear()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
@@ -19,7 +19,7 @@ import de.westnordost.streetcomplete.ApplicationConstants.REFRESH_DATA_AFTER
 import de.westnordost.streetcomplete.BuildConfig
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestController
 import de.westnordost.streetcomplete.data.osmnotes.NoteController
@@ -56,7 +56,7 @@ class SettingsFragment :
     SharedPreferences.OnSharedPreferenceChangeListener {
 
     private val prefs: SharedPreferences by inject()
-    private val downloadedTilesDao: DownloadedTilesDao by inject()
+    private val downloadedTilesController: DownloadedTilesController by inject()
     private val noteController: NoteController by inject()
     private val mapDataController: MapDataController by inject()
     private val osmQuestController: OsmQuestController by inject()
@@ -236,7 +236,7 @@ class SettingsFragment :
 
     private suspend fun deleteCache() = withContext(Dispatchers.IO) {
         context?.externalCacheDir?.purge()
-        downloadedTilesDao.removeAll()
+        downloadedTilesController.removeAll()
         mapDataController.clear()
         noteController.clear()
     }


### PR DESCRIPTION
fixes the other thing for #4970

Turned out to be relatively straightforward after all. The further you zoom out, the less visible the hatching will be.

When one is zoomed out very far when the app initializes the map, I could reproduce that the entire world is hatched, even the downloaded tiles. The display is only updated after one downloads a tile or tabs out of the app and in again. I checked, it is definitely not an issue with the data but apparently with the rendering 🤷 
Not sure what to do about that. But otherwise, it works.

![Screenshot_20230502_220341](https://user-images.githubusercontent.com/4661658/235773771-9db9064e-a2c6-4991-949f-9eca012eb299.png)
![Screenshot_20230502_220009](https://user-images.githubusercontent.com/4661658/235773781-e30300df-448f-470b-8d00-23efc22a5726.png)
![Screenshot_20230502_220126](https://user-images.githubusercontent.com/4661658/235773793-0cec8adc-0b7e-49f1-ab88-fe3de0da8b2d.png)
![Screenshot_20230502_220158](https://user-images.githubusercontent.com/4661658/235773797-b262b922-8a8b-48e9-a50e-d74646f376a8.png)
![Screenshot_20230502_220213](https://user-images.githubusercontent.com/4661658/235773801-8913093b-576e-45a6-990a-4820b1db992f.png)

