### PR TITLE
always return complete ways on getMapDataWithGeometry

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDao.kt
@@ -45,12 +45,19 @@ class ElementDao(
 
     fun getAll(bbox: BoundingBox): List<Element> {
         val nodes = nodeDao.getAll(bbox)
-        val nodeIds = nodes.map { it.id }
+        val nodeIds = nodes.map { it.id }.toSet()
         val ways = wayDao.getAllForNodes(nodeIds)
         val wayIds = ways.map { it.id }
-        val relations = relationDao.getAllForElements(nodeIds = nodeIds, wayIds = wayIds)
-        val result = ArrayList<Element>(nodes.size + ways.size + relations.size)
+        val additionalWayNodeIds = ways
+            .asSequence()
+            .flatMap { it.nodeIds }
+            .filter { it !in nodeIds }
+            .toList()
+        val additionalNodes = nodeDao.getAll(additionalWayNodeIds)
+        val relations = relationDao.getAllForElements(nodeIds = additionalWayNodeIds + nodeIds, wayIds = wayIds)
+        val result = ArrayList<Element>(nodes.size + additionalNodes.size + ways.size + relations.size)
         result.addAll(nodes)
+        result.addAll(additionalNodes)
         result.addAll(ways)
         result.addAll(relations)
         return result

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCache.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCache.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryEntry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
 import de.westnordost.streetcomplete.util.SpatialCache
 import de.westnordost.streetcomplete.util.math.contains
+import de.westnordost.streetcomplete.util.math.isCompletelyInside
 
 /**
  * Cache for MapDataController that uses SpatialCache for nodes (i.e. geometry) and hash maps
@@ -22,6 +23,7 @@ class MapDataCache(
     val maxTiles: Int,
     initialCapacity: Int,
     private val fetchMapData: (BoundingBox) -> Pair<Collection<Element>, Collection<ElementGeometryEntry>>, // used if the tile is not contained
+    private val fetchNodes: (Collection<Long>) -> Collection<Node>,
 ) {
     private val spatialCache = SpatialCache(
         tileZoom,
@@ -34,6 +36,7 @@ class MapDataCache(
     //  approximately 80% of all elements were found to be nodes
     //  approximately every second node is part of a way
     //  more than 90% of elements are not part of a relation
+    private val nodeCache = HashMap<Long, Node>(initialCapacity)
     private val wayCache = HashMap<Long, Way>(initialCapacity / 6)
     private val relationCache = HashMap<Long, Relation>(initialCapacity / 10)
     private val wayGeometryCache = HashMap<Long, ElementGeometry>(initialCapacity / 6)
@@ -64,12 +67,15 @@ class MapDataCache(
             spatialCache.update(deleted = deletedNodeIds)
             spatialCache.replaceAllInBBox(updatedNodes, bbox)
         }
+        // remove all cached nodes that are now in spatialCache
+        nodeCache.keys.removeAll { spatialCache.get(it) != null }
 
         // delete nodes, ways and relations
         for (key in deletedKeys) {
             when (key.type) {
                 ElementType.NODE -> {
                     wayIdsByNodeIdCache.remove(key.id)
+                    nodeCache.remove(key.id)
                 }
                 ElementType.WAY -> {
                     val deletedWayNodeIds = wayCache.remove(key.id)?.nodeIds.orEmpty()
@@ -96,6 +102,9 @@ class MapDataCache(
                 relationGeometryCache[entry.elementId] = entry.geometry
             }
         }
+
+        // add nodes that are not in spatialCache to nodeCache
+        updatedNodes.forEach { if (spatialCache.get(it.id) == null) nodeCache[it.id] = it }
 
         // update ways
         val updatedWays = updatedElements.filterIsInstance<Way>()
@@ -178,8 +187,8 @@ class MapDataCache(
         id: Long,
         fetch: (ElementType, Long) -> Element?
     ): Element? = synchronized(this) {
-        return when (type) {
-            ElementType.NODE -> spatialCache.get(id) ?: fetch(type, id)
+        when (type) {
+            ElementType.NODE -> spatialCache.get(id) ?: nodeCache.getOrPutIfNotNull(id) { fetch(type, id) as? Node }
             ElementType.WAY -> wayCache.getOrPutIfNotNull(id) { fetch(type, id) as? Way }
             ElementType.RELATION -> relationCache.getOrPutIfNotNull(id) { fetch(type, id) as? Relation }
         }
@@ -195,7 +204,7 @@ class MapDataCache(
         fetch: (ElementType, Long) -> ElementGeometry?
     ): ElementGeometry? = synchronized(this) {
         return when (type) {
-            ElementType.NODE -> spatialCache.get(id)?.let { ElementPointGeometry(it.position) } ?: fetch(type, id)
+            ElementType.NODE -> (spatialCache.get(id) ?: nodeCache[id])?.let { ElementPointGeometry(it.position) } ?: fetch(type, id)
             ElementType.WAY -> wayGeometryCache.getOrPutIfNotNull(id) { fetch(type, id) }
             ElementType.RELATION -> relationGeometryCache.getOrPutIfNotNull(id) { fetch(type, id) }
         }
@@ -213,7 +222,7 @@ class MapDataCache(
     ): List<Element> = synchronized(this) {
         val cachedElements = keys.mapNotNull { key ->
             when (key.type) {
-                ElementType.NODE -> spatialCache.get(key.id)
+                ElementType.NODE -> spatialCache.get(key.id) ?: nodeCache[key.id]
                 ElementType.WAY -> wayCache[key.id]
                 ElementType.RELATION -> relationCache[key.id]
             }
@@ -228,9 +237,9 @@ class MapDataCache(
         val fetchedElements = fetch(keysToFetch)
         for (element in fetchedElements) {
             when (element.type) {
+                ElementType.NODE -> nodeCache[element.id] = element as Node
                 ElementType.WAY -> wayCache[element.id] = element as Way
                 ElementType.RELATION -> relationCache[element.id] = element as Relation
-                else -> Unit
             }
         }
         return cachedElements + fetchedElements
@@ -239,13 +248,14 @@ class MapDataCache(
     /** Gets the nodes with the given [ids] from cache. If any of the nodes are not cached, [fetch]
      *  is called for the missing nodes. */
     fun getNodes(ids: Collection<Long>, fetch: (Collection<Long>) -> List<Node>): List<Node> = synchronized(this) {
-        val cachedNodes = spatialCache.getAll(ids)
+        val cachedNodes = ids.mapNotNull { spatialCache.get(it) ?: nodeCache[it] }
         if (ids.size == cachedNodes.size) return cachedNodes
 
         // not all in cache: must fetch the rest from db
         val cachedNodeIds = cachedNodes.map { it.id }.toSet()
         val missingNodeIds = ids.filterNot { it in cachedNodeIds }
         val fetchedNodes = fetch(missingNodeIds)
+        fetchedNodes.forEach { nodeCache[it.id] = it }
         return cachedNodes + fetchedNodes
     }
 
@@ -279,7 +289,7 @@ class MapDataCache(
         // that geometries and not elements are returned and thus different caches are accessed
         val cachedEntries = keys.mapNotNull { key ->
             when (key.type) {
-                ElementType.NODE -> spatialCache.get(key.id)?.let { ElementPointGeometry(it.position) }
+                ElementType.NODE -> (spatialCache.get(key.id) ?: nodeCache[key.id])?.let { ElementPointGeometry(it.position) }
                 ElementType.WAY -> wayGeometryCache[key.id]
                 ElementType.RELATION -> relationGeometryCache[key.id]
             }?.let { ElementGeometryEntry(key.type, key.id, it) }
@@ -404,10 +414,33 @@ class MapDataCache(
             relationIdsByElementKeyCache[node.key]?.let { relationIds.addAll(it) }
             result.put(node, ElementPointGeometry(node.position))
         }
+
+        val nodesToFetch = hashSetOf<Long>()
         for (wayId in wayIds) {
-            result.put(wayCache[wayId]!!, wayGeometryCache[wayId])
-            relationIdsByElementKeyCache[ElementKey(ElementType.WAY, wayId)]?.let { relationIds.addAll(it) }
+            val way = wayCache[wayId]!!
+            val wayGeometry = wayGeometryCache[wayId]
+            result.put(way, wayGeometry)
+            relationIdsByElementKeyCache[way.key]?.let { relationIds.addAll(it) }
+
+            // find all nodes that are part of the way, but not in result
+            if (wayGeometry?.getBounds()?.isCompletelyInside(bbox) == true) continue // no need to check
+            for (nodeId in way.nodeIds) {
+                if (result.getNode(nodeId) != null) continue
+                val cachedNode = spatialCache.get(nodeId) ?: nodeCache[nodeId]
+                if (cachedNode != null) {
+                    result.put(cachedNode, ElementPointGeometry(cachedNode.position))
+                    continue
+                }
+                nodesToFetch.add(nodeId)
+            }
         }
+        if (nodesToFetch.isNotEmpty()) {
+            fetchNodes(nodesToFetch).forEach {
+                nodeCache[it.id] = it
+                result.put(it, ElementPointGeometry(it.position))
+            }
+        }
+
         for (relationId in relationIds) {
             result.put(relationCache[relationId]!!, relationGeometryCache[relationId])
             // don't add relations of relations, because elementDao.getAll(bbox) also isn't doing that
@@ -424,6 +457,7 @@ class MapDataCache(
     /** Clears the cache */
     fun clear() { synchronized(this) {
         spatialCache.clear()
+        nodeCache.clear()
         wayCache.clear()
         relationCache.clear()
         wayGeometryCache.clear()
@@ -437,6 +471,7 @@ class MapDataCache(
      */
     fun trim(tiles: Int) { synchronized(this) {
         spatialCache.trim(tiles)
+        nodeCache.clear() // simply clear nodeCache, as transferring some nodes from spatialCache is slow
 
         // ways and relations with at least one element in cache should not be removed
         val (wayIds, relationIds) = determineWayAndRelationIdsWithElementsInSpatialCache()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -41,14 +41,16 @@ class MapDataController internal constructor(
     private val cache = MapDataCache(
         SPATIAL_CACHE_TILE_ZOOM,
         SPATIAL_CACHE_TILES,
-        SPATIAL_CACHE_INITIAL_CAPACITY
-    ) { bbox ->
-        val elements = elementDB.getAll(bbox)
-        val elementGeometries = geometryDB.getAllEntries(
-            elements.mapNotNull { if (it !is Node) it.key else null }
-        )
-        elements to elementGeometries
-    }
+        SPATIAL_CACHE_INITIAL_CAPACITY,
+        { bbox ->
+            val elements = elementDB.getAll(bbox)
+            val elementGeometries = geometryDB.getAllEntries(
+                elements.mapNotNull { if (it !is Node) it.key else null }
+            )
+            elements to elementGeometries
+        },
+        { nodeDB.getAll(it) },
+    )
 
     /** update element data with [mapData] in the given [bbox] (fresh data from the OSM API has been
      *  downloaded) */

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
@@ -151,6 +151,30 @@ class ElementDaoTest {
         )
     }
 
+    @Test fun `getAllElementsByBbox includes nodes that are not in bbox, but part of ways contained in bbox`() {
+        val bbox = BoundingBox(0.0, 0.0, 1.0, 1.0)
+        val bboxNodes = listOf(node(1), node(2), node(3))
+        val bboxNodeIds = bboxNodes.map { it.id }
+        val outsideBboxNodes = listOf(node(4), node(5))
+        val outsideBboxNodeIds = outsideBboxNodes.map { it.id }
+        val ways = listOf(way(1), way(2, nodes = listOf(3L, 4L, 5L)))
+        val wayIds = ways.map { it.id }
+        val relations = listOf(rel(1))
+
+        on(nodeDao.getAll(bbox)).thenReturn(bboxNodes)
+        on(nodeDao.getAll(outsideBboxNodeIds)).thenReturn(outsideBboxNodes)
+        on(wayDao.getAllForNodes(eq(bboxNodeIds.toSet()))).thenReturn(ways)
+        on(relationDao.getAllForElements(
+            nodeIds = eq(outsideBboxNodeIds + bboxNodeIds),
+            wayIds = eq(wayIds),
+            relationIds = eq(emptyList())
+        )).thenReturn(relations)
+        assertEquals(
+            bboxNodes + outsideBboxNodes + ways + relations,
+            dao.getAll(bbox)
+        )
+    }
+
     @Test fun getAllElementKeysByBbox() {
         val bbox = BoundingBox(0.0, 0.0, 1.0, 1.0)
         val nodeIds = listOf<Long>(1, 2, 3)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
@@ -139,7 +139,7 @@ class ElementDaoTest {
         val relations = listOf(rel(1))
 
         on(nodeDao.getAll(bbox)).thenReturn(nodes)
-        on(wayDao.getAllForNodes(eq(nodeIds))).thenReturn(ways)
+        on(wayDao.getAllForNodes(eq(nodeIds.toSet()))).thenReturn(ways)
         on(relationDao.getAllForElements(
             nodeIds = eq(nodeIds),
             wayIds = eq(wayIds),

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCacheTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCacheTest.kt
@@ -18,7 +18,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update puts way`() {
         val way = way(1)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(way))
         val elementDB: ElementDao = mock()
         on(elementDB.get(ElementType.WAY, 1L)).thenThrow(IllegalStateException())
@@ -27,7 +27,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update puts relation`() {
         val relation = rel(1)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(relation))
         val elementDB: ElementDao = mock()
         on(elementDB.get(ElementType.RELATION, 1L)).thenThrow(IllegalStateException())
@@ -38,7 +38,7 @@ internal class MapDataCacheTest {
         val p = p(0.0, 0.0)
         val geo = ElementPolylinesGeometry(listOf(listOf(p)), p)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedGeometries = listOf(ElementGeometryEntry(ElementType.WAY, 1, geo)))
         val geometryDB: ElementGeometryDao = mock()
         on(geometryDB.get(ElementType.WAY, 1L)).thenThrow(IllegalStateException())
@@ -49,7 +49,7 @@ internal class MapDataCacheTest {
         val p = p(0.0, 0.0)
         val geo = ElementPolygonsGeometry(listOf(listOf(p)), p)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedGeometries = listOf(ElementGeometryEntry(ElementType.RELATION, 1, geo)))
         val geometryDB: ElementGeometryDao = mock()
         on(geometryDB.get(ElementType.RELATION, 1L)).thenThrow(IllegalStateException())
@@ -58,7 +58,7 @@ internal class MapDataCacheTest {
 
     @Test fun `getElement fetches node if not in spatialCache`() {
         val node = node(1)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val elementDB: ElementDao = mock()
         on(elementDB.get(ElementType.NODE, 1L)).thenReturn(node).thenReturn(null)
         assertEquals(node, cache.getElement(ElementType.NODE, 1L) { type, id -> elementDB.get(type, id) })
@@ -73,7 +73,7 @@ internal class MapDataCacheTest {
 
     @Test fun `getElement fetches and caches way`() {
         val way = way(2L)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val elementDB: ElementDao = mock()
         on(elementDB.get(ElementType.WAY, 2L)).thenReturn(way).thenThrow(IllegalStateException())
         // get way 2 and verify the fetch function is called, but only once
@@ -86,7 +86,7 @@ internal class MapDataCacheTest {
 
     @Test fun `getElement fetches and caches relation`() {
         val rel = rel(1L)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val elementDB: ElementDao = mock()
         on(elementDB.get(ElementType.RELATION, 1L)).thenReturn(rel).thenThrow(IllegalStateException())
         // get rel 1 and verify the fetch function is called, but only once
@@ -101,7 +101,7 @@ internal class MapDataCacheTest {
         val p = p(0.0, 0.0)
         val geo = ElementPointGeometry(p)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val geometryDB: ElementGeometryDao = mock()
         on(geometryDB.get(ElementType.NODE, 2L)).thenReturn(geo).thenThrow(IllegalStateException())
         // get node 2 and verify the fetch function is called, but only once
@@ -119,7 +119,7 @@ internal class MapDataCacheTest {
         val p = p(0.0, 0.0)
         val geo = ElementPolylinesGeometry(listOf(listOf(p)), p)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val geometryDB: ElementGeometryDao = mock()
         on(geometryDB.get(ElementType.WAY, 2L)).thenReturn(geo).thenThrow(IllegalStateException())
         // get geo and verify the fetch function is called, but only once
@@ -134,7 +134,7 @@ internal class MapDataCacheTest {
         val p = p(0.0, 0.0)
         val geo = ElementPolygonsGeometry(listOf(listOf(p)), p)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val geometryDB: ElementGeometryDao = mock()
         on(geometryDB.get(ElementType.RELATION, 2L)).thenReturn(geo).thenThrow(IllegalStateException())
         // get way 2 and verify the fetch function is called, but only once
@@ -153,7 +153,7 @@ internal class MapDataCacheTest {
         val nodesRect = listOf(node1.position, node2.position, node3.position).enclosingBoundingBox().enclosingTilesRect(16)
         assertTrue(nodesRect.size <= 4) // fits in cache
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes, bbox = nodesRect.asBoundingBox(16))
 
         assertTrue(cache.getNodes(nodes.map { it.id }) { throw IllegalStateException() }.containsExactlyInAnyOrder(nodes))
@@ -168,7 +168,7 @@ internal class MapDataCacheTest {
         val nodesRect = listOf(node1.position, node2.position, node3.position).enclosingBoundingBox().enclosingTilesRect(16)
         assertTrue(nodesRect.size <= 4) // fits in cache
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes, bbox = nodesRect.asBoundingBox(16))
 
         val nodeDB: NodeDao = mock()
@@ -184,7 +184,7 @@ internal class MapDataCacheTest {
         val node4 = node(4, LatLon(1.0, 1.0))
         val nodes = listOf(node1, node2, node3, node4)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes)
 
         val nodeDB: NodeDao = mock()
@@ -203,7 +203,7 @@ internal class MapDataCacheTest {
         val rel2 = rel(2)
         val elements = listOf(node1, way1, way2, way3, rel1, rel2)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(bbox = node1.position.enclosingTilePos(16).asBoundingBox(16))
         cache.update(updatedElements = elements)
 
@@ -220,7 +220,7 @@ internal class MapDataCacheTest {
         val elements = listOf(node1, way1, way2, way3, rel1, rel2)
         val cachedElements = listOf(way1, rel1)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = cachedElements)
         val keysNotInCache = elements.filterNot { it in cachedElements }.map { ElementKey(it.type, it.id) }.toHashSet()
 
@@ -244,7 +244,7 @@ internal class MapDataCacheTest {
         val rel2 = rel(2)
         val elements = listOf(node1, way1, way2, way3, rel1, rel2)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val keys = elements.map { ElementKey(it.type, it.id) }.toHashSet()
 
         val elementDB: ElementDao = mock()
@@ -269,7 +269,7 @@ internal class MapDataCacheTest {
         val nodeEntry = ElementGeometryEntry(ElementType.NODE, 1L, nodeGeo)
         val entries = listOf(entry1, entry2, nodeEntry)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(bbox = node.position.enclosingTilePos(16).asBoundingBox(16))
         cache.update(updatedElements = listOf(node), updatedGeometries = entries)
 
@@ -288,7 +288,7 @@ internal class MapDataCacheTest {
         val entries = listOf(entry1, entry2, nodeEntry)
         val cachedEntries = listOf(entry1)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedGeometries = cachedEntries)
         val keysNotInCache = entries.filterNot { it in cachedEntries }.map { ElementKey(it.elementType, it.elementId) }.toHashSet()
 
@@ -314,7 +314,7 @@ internal class MapDataCacheTest {
         val nodeEntry = ElementGeometryEntry(ElementType.NODE, 1L, nodeGeo)
         val entries = listOf(entry1, entry2, nodeEntry)
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val keys = entries.map { ElementKey(it.elementType, it.elementId) }.toHashSet()
 
         val geometryDB: ElementGeometryDao = mock()
@@ -330,7 +330,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update only puts nodes if tile is cached`() {
         val node = node(1, LatLon(0.0, 0.0))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         val nodeTile = node.position.enclosingTilePos(16)
         assertEquals(0, cache.getMapDataWithGeometry(nodeTile.asBoundingBox(16)).size)
         // now we have nodeTile cached
@@ -359,7 +359,7 @@ internal class MapDataCacheTest {
         val nodeKey = ElementKey(ElementType.NODE, 1L)
         val wayKey = ElementKey(ElementType.WAY, 2L)
         val relationKey = ElementKey(ElementType.RELATION, 3L)
-        val cache = MapDataCache(16, 4, 10) { listOf(node) to emptyList() }
+        val cache = MapDataCache(16, 4, 10, { listOf(node) to emptyList() }, { emptyList() })
         cache.getMapDataWithGeometry(node.position.enclosingTilePos(16).asBoundingBox(16))
         cache.update(updatedElements = listOf(way, rel))
         assertTrue(
@@ -376,7 +376,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
         val way3 = way(3, nodes = listOf(3L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(way1, way2, way3))
         val wayDB: WayDao = mock()
         on(wayDB.getAllForNode(1L)).thenReturn(listOf(way1, way2)).thenThrow(IllegalStateException())
@@ -396,7 +396,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
         val way3 = way(3, nodes = listOf(3L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, node3, way1, way2, way3), bbox = nodesRect.asBoundingBox(16))
 
         assertTrue(cache.getWaysForNode(1L) { emptyList() }.containsExactlyInAnyOrder(listOf(way1, way2)))
@@ -413,7 +413,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
         val way3 = way(3, nodes = listOf(3L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, node3, way1, way2, way3), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getWaysForNode(1L) { emptyList() }.containsExactlyInAnyOrder(listOf(way1, way2)))
 
@@ -430,7 +430,7 @@ internal class MapDataCacheTest {
         assertTrue(nodesRect.size <= 4) // fits in cache
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, node3, way1, way2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getWaysForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1, way2)))
         assertTrue(cache.getWaysForNode(2L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1)))
@@ -450,7 +450,7 @@ internal class MapDataCacheTest {
         assertTrue(nodesRect.size <= 4) // fits in cache
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, node3, way1, way2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getWaysForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1, way2)))
         assertTrue(cache.getWaysForNode(2L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1)))
@@ -471,7 +471,7 @@ internal class MapDataCacheTest {
         assertTrue(nodesRect.size <= 4) // fits in cache
         val way1 = way(1, nodes = listOf(1L, 2L))
         val way2 = way(2, nodes = listOf(3L, 1L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, node3, way1, way2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getWaysForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1, way2)))
         assertTrue(cache.getWaysForNode(2L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(way1)))
@@ -492,7 +492,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, "")))
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1, rel2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getRelationsForNode(1L) { emptyList() }.containsExactlyInAnyOrder(listOf(rel1)))
         assertTrue(cache.getRelationsForWay(1L) { emptyList() }.containsExactlyInAnyOrder(listOf(rel2)))
@@ -511,7 +511,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, "")))
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.NODE, 1L, ""), RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1, rel2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getRelationsForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel1, rel2)))
         assertTrue(cache.getRelationsForWay(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel2)))
@@ -529,7 +529,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, "")))
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1, rel2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getRelationsForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel1)))
         assertTrue(cache.getRelationsForWay(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel2)))
@@ -548,7 +548,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, ""), RelationMember(ElementType.WAY, 1L, "")))
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.WAY, 1L, ""), RelationMember(ElementType.NODE, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1, rel2), bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getRelationsForNode(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel1, rel2)))
         assertTrue(cache.getRelationsForWay(1L) { throw IllegalStateException() }.containsExactlyInAnyOrder(listOf(rel1, rel2)))
@@ -576,7 +576,7 @@ internal class MapDataCacheTest {
         val outsideWay = way(4, nodes = listOf(4L, 5L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, ""), RelationMember(ElementType.WAY, 5L, "")))
         val outsideRel = rel(2, members = listOf(RelationMember(ElementType.NODE, 4L, ""), RelationMember(ElementType.WAY, 5L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes + ways + listOf(outsideNode, outsideWay, rel1, outsideRel), bbox = nodesRect.asBoundingBox(16))
 
         val expectedMapData = MutableMapDataWithGeometry(nodes + ways + rel1, emptyList())
@@ -603,7 +603,7 @@ internal class MapDataCacheTest {
         val nodeRectBbox = node.position.enclosingBoundingBox(0.1).asBoundingBoxOfEnclosingTiles(16)
 
         val way = way(1, nodes = listOf(1L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(way, node), bbox = nodeRectBbox)
 
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1, "")))
@@ -622,7 +622,7 @@ internal class MapDataCacheTest {
         val way1 = way(1, nodes = listOf(1L, 2L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 1L, "")))
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1, rel2), bbox = nodesRect.asBoundingBox(16))
 
         // not empty
@@ -634,7 +634,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update doesn't create waysByNodeId entry if node is not in spatialCache`() {
         val way1 = way(1, nodes = listOf(1L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(way1))
 
         val wayDB: WayDao = mock()
@@ -655,7 +655,7 @@ internal class MapDataCacheTest {
         val nodesRect = listOf(node1.position, node2.position, node3.position).enclosingBoundingBox().enclosingTilesRect(16)
         assertTrue(nodesRect.size <= 4) // fits in cache
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes, bbox = nodesRect.asBoundingBox(16))
 
         val way1 = way(1, nodes = listOf(1L, 2L))
@@ -667,7 +667,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update does add way to waysByNodeId entry if entry already exists`() {
         val way1 = way(1, nodes = listOf(1L, 2L))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(way1))
 
         val wayDB: WayDao = mock()
@@ -689,7 +689,7 @@ internal class MapDataCacheTest {
         val node2 = node(2)
         val way1 = way(1, nodes = listOf(1L))
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.NODE, 2L, ""), RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(node1, node2, way1, rel1))
 
         val relationDB: RelationDao = mock()
@@ -709,7 +709,7 @@ internal class MapDataCacheTest {
         val nodesRect = listOf(node1.position, node2.position, node3.position).enclosingBoundingBox().enclosingTilesRect(16)
         assertTrue(nodesRect.size <= 4) // fits in cache
 
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = nodes, bbox = nodesRect.asBoundingBox(16))
 
         val way1 = way(1, nodes = listOf(1L, 2L))
@@ -722,7 +722,7 @@ internal class MapDataCacheTest {
 
     @Test fun `update does add way to relationsByElementKey entry if entry already exists`() {
         val rel1 = rel(1, members = listOf(RelationMember(ElementType.WAY, 1L, "")))
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
         cache.update(updatedElements = listOf(rel1))
 
         val relationDB: RelationDao = mock()
@@ -754,7 +754,7 @@ internal class MapDataCacheTest {
         val elementsInsideBBox = listOf(node1, node2, node3, way1, way2, way3, rel1, rel2)
         val elementDB: ElementDao = mock()
         on(elementDB.getAll(nodesRect.asBoundingBox(16))).thenReturn(elementsInsideBBox)
-        val cache = MapDataCache(16, 4, 10) { elementDB.getAll(it) to emptyList() }
+        val cache = MapDataCache(16, 4, 10, { elementDB.getAll(it) to emptyList() }, { emptyList() })
 
         val expectedMapData = MutableMapDataWithGeometry().apply {
             listOf(node1, node2, node3).forEach { put(it, ElementPointGeometry(it.position)) }
@@ -784,7 +784,7 @@ internal class MapDataCacheTest {
         val rel2 = rel(2, members = listOf(RelationMember(ElementType.WAY, 1L, "")))
         val elementDB: ElementDao = mock()
         on(elementDB.getAll(node1rect.asBoundingBox(16))).thenReturn(listOf(node1, node3, way2, way3, rel1))
-        val cache = MapDataCache(16, 4, 10) { elementDB.getAll(it) to emptyList() }
+        val cache = MapDataCache(16, 4, 10, { elementDB.getAll(it) to emptyList() }, { emptyList() })
 
         cache.update(updatedElements = listOf(node2, way1, rel2), bbox = node2rect.asBoundingBox(16))
 
@@ -816,7 +816,7 @@ internal class MapDataCacheTest {
         val outsideNode = node(4, LatLon(1.0, 1.0))
         val outsideWay = way(4)
         val outsideRel = rel(3)
-        val cache = MapDataCache(16, 4, 10) { emptyList<Element>() to emptyList() }
+        val cache = getEmptyMapDataCache()
 
         cache.update(updatedElements = elementsInsideBBox + outsideNode + outsideWay + outsideRel, bbox = nodesRect.asBoundingBox(16))
         assertTrue(cache.getMapDataWithGeometry(nodesBBox).toList().containsExactlyInAnyOrder(elementsInsideBBox))
@@ -830,7 +830,7 @@ internal class MapDataCacheTest {
         val rect2 = TilesRect(x, y + 1, x, y + 2).asBoundingBox(16)
         val node1 = node(1, LatLon(rect.min.latitude + 0.00001, rect.min.longitude + 0.00001)) // node in rect and rect2
         val node2 = node(2, LatLon(rect.max.latitude - 0.00001, rect.max.longitude - 0.00001)) // node in rect only
-        val cache = MapDataCache(16, 24, 10) {
+        val cache = MapDataCache(16, 24, 10, {
             val elements = when {
                 it == rect -> listOf(node1, node2) // may not be true if the bbox is extended because of the tilesRect issue (happens for x=2, y=5, but not for x=2, y=1)
                 rect.isCompletelyInside(it) -> listOf(node1, node2) // fix for above
@@ -838,7 +838,7 @@ internal class MapDataCacheTest {
                 else -> emptyList()
             }
             elements to emptyList()
-        }
+        }, { emptyList() })
         // fill cache
         assertTrue(cache.getMapDataWithGeometry(rect).toList().containsExactlyInAnyOrder(listOf(node1, node2)))
 
@@ -849,3 +849,5 @@ internal class MapDataCacheTest {
         assertTrue(cache.getMapDataWithGeometry(rect).toList().containsExactlyInAnyOrder(listOf(node1, node2)))
     }
 }
+
+private fun getEmptyMapDataCache() = MapDataCache(16, 4, 10, { emptyList<Element>() to emptyList() }, { emptyList() })


### PR DESCRIPTION
fixes #4980

`MapDataCache` can now fetch nodes if for some reason it's neither in `SpatialCache` nor in `nodeCache`. This can be because of trim (simply clears `nodeCache`), but also for other reasons, e.g. `SpatialCache` removing tiles unexpectedly (see #4985).

Performance:
* `getMatDataWithGeometry` is slower
  * for large bboxes (usually for overlays) 20-30% of total time is spend on finding / adding nodes needed for complete ways
  * for small bboxes (highlighted elements), this is more, around 30-90%. This may seem much, but even on a S4 mini and a debug APK data is returned within 5-20 ms
* `update` is typically around 10% slower due to properly handling `nodeCache` (25% observed, this was by far the worst case)
* fetching nodes happens only after trim and after encountering the `tilesRect.asBoundingBox(zoom).enclosingTilesRect(zoom)` issue
  * fetched nodes are cached in `nodeCache`, so even after trim this fetch does not happen often
  * for small bboxes, fetching nodes (if necessary) takes typically 50% of the total time of `getMatDataWithGeometry`
  * for large bboxes (overlays), it's more like 15-20% (up to 60% observed)

IMO the performance impact is acceptable, and likely any improvements will not be worth the effort.

Some work is still to be done: No new tests are added, and some old tests fail now.