### PR TITLE
Use FragmentContainerView in more places

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.kt
@@ -9,8 +9,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.widget.doAfterTextChanged
-import androidx.fragment.app.add
-import androidx.fragment.app.commit
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.R
@@ -87,10 +85,6 @@ class NoteDiscussionForm : AbstractQuestForm() {
         viewLifecycleScope.launch {
             val comments = withContext(Dispatchers.IO) { noteSource.get(noteId) }!!.comments
             inflateNoteDiscussion(comments)
-        }
-
-        if (savedInstanceState == null) {
-            childFragmentManager.commit { add<AttachPhotoFragment>(R.id.attachPhotoFragment) }
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/AbstractCreateNoteFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/bottom_sheet/AbstractCreateNoteFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.EditText
 import androidx.core.widget.doAfterTextChanged
-import androidx.fragment.app.add
-import androidx.fragment.app.commit
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.note_discussion.AttachPhotoFragment
 import de.westnordost.streetcomplete.util.ktx.nonBlankTextOrNull
@@ -26,10 +24,6 @@ abstract class AbstractCreateNoteFragment : AbstractBottomSheetFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        if (savedInstanceState == null) {
-            childFragmentManager.commit { add<AttachPhotoFragment>(R.id.attachPhotoFragment) }
-        }
 
         noteInput.doAfterTextChanged { updateOkButtonEnablement() }
         okButton.setOnClickListener { onClickOk() }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/activity_user.xml
+++ b/app/src/main/res/layout/activity_user.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/form_leave_note.xml
+++ b/app/src/main/res/layout/form_leave_note.xml
@@ -30,8 +30,9 @@
         android:background="@drawable/background_edittext_outline"
         />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/attachPhotoFragment"
+        android:name="de.westnordost.streetcomplete.quests.note_discussion.AttachPhotoFragment"
         android:layout_marginTop="8dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -41,7 +41,7 @@
 
     </RelativeLayout>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/oauthFragmentContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -182,6 +182,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <!-- is a RelativeLayout so that the child layout can, if it is not matching parent, use layout_alignParent* -->
     <RelativeLayout
         android:id="@+id/edit_history_container"
         android:layout_width="match_parent"
@@ -196,15 +197,11 @@
         android:layout_height="0dp"
         tools:ignore="MissingConstraints" />
 
-    <!-- it is relative layout so that the child layout can, if it is not matching parent, use layout_alignParent* -->
+    <!-- is a RelativeLayout so that the child layout can, if it is not matching parent, use layout_alignParent* -->
     <RelativeLayout
         android:id="@+id/map_bottom_sheet_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipChildren="false"
-        tools:ignore="RtlHardcoded">
-    </RelativeLayout>
-
-    <!-- it is relative layout so that the child layout can, if it is not matching parent, use layout_alignParent* -->
+        android:clipChildren="false" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_messages_container.xml
+++ b/app/src/main/res/layout/fragment_messages_container.xml
@@ -1,15 +1,6 @@
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/achievement_info_fragment"
+    android:name="de.westnordost.streetcomplete.screens.user.achievements.AchievementInfoFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/achievement_info_fragment"
-        android:name="de.westnordost.streetcomplete.screens.user.achievements.AchievementInfoFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:visibility="gone"/>
-
- </RelativeLayout >
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_show_quest_forms.xml
+++ b/app/src/main/res/layout/fragment_show_quest_forms.xml
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/toolbarContainer"
+    <include
+        android:id="@+id/toolbarLayout"
+        layout="@layout/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <include android:id="@+id/toolbarLayout"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-
-    </FrameLayout>
+        android:layout_height="wrap_content" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/showQuestFormsList"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/toolbarContainer"
-        tools:listitem="@layout/row_quest_display"/>
+        android:layout_below="@+id/toolbarLayout"
+        tools:listitem="@layout/row_quest_display" />
 
     <RelativeLayout
         android:id="@+id/questFormContainer"
@@ -31,11 +25,11 @@
         android:visibility="gone"
         tools:visibility="visible">
 
+        <!-- is a RelativeLayout so that the child layout can, if it is not matching parent, use layout_alignParent* -->
         <RelativeLayout
             android:id="@+id/questForm"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
+            android:layout_height="match_parent" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/quest_note_discussion_content.xml
+++ b/app/src/main/res/layout/quest_note_discussion_content.xml
@@ -17,8 +17,9 @@
         android:background="@drawable/background_edittext_outline"
         />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/attachPhotoFragment"
+        android:name="de.westnordost.streetcomplete.quests.note_discussion.AttachPhotoFragment"
         android:layout_marginTop="8dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>


### PR DESCRIPTION
This PR replaces FrameLayouts that are used as fragment containers with [FragmentContainerViews](https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView). This ensures that animations of fragment transactions are shown correctly on all API levels. During testing, I did not notice any issues with these changes.

There are also some RelativeLayouts used as fragment containers that I did not replace, because many inner fragments rely on `layout_alignParent*` to be displayed on the left screen side even for RTL languages. These places are now all correctly annotated in the layout files. Theoretically, however, it should also be possible to use FragmentContainerViews in these cases, but then `layout_alignParent*` would have to be replaced by `layout_gravity` everywhere.