### PR TITLE
Skip Building Level quest with existing building:min_level

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -16,6 +16,7 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevelsAnswer>() {
                !building:levels
                or !roof:levels and roof:shape and roof:shape != flat
            )
+           and !building:min_level
            and !man_made
            and location != underground
            and ruins != yes


### PR DESCRIPTION
If the building has an existing `building:min_level` tag, this object is too complicated without having more information.

I got it on a miss tagged roof, but there are other elements which would hit

https://www.openstreetmap.org/way/245685307
https://www.openstreetmap.org/way/851896988

https://overpass-turbo.eu/s/1uS4