### PR TITLE
New quest: Roof colour

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -122,6 +122,7 @@ import de.westnordost.streetcomplete.quests.religion.AddReligionToPlaceOfWorship
 import de.westnordost.streetcomplete.quests.religion.AddReligionToWaysideShrine
 import de.westnordost.streetcomplete.quests.road_name.AddRoadName
 import de.westnordost.streetcomplete.quests.road_name.RoadNameSuggestionsSource
+import de.westnordost.streetcomplete.quests.roof_colour.AddRoofColour
 import de.westnordost.streetcomplete.quests.roof_shape.AddRoofShape
 import de.westnordost.streetcomplete.quests.seating.AddSeating
 import de.westnordost.streetcomplete.quests.segregated.AddCyclewaySegregation
@@ -491,6 +492,7 @@ fun questTypeRegistry(
     150 to AddBuildingType(),
     151 to AddBuildingLevels(),
     152 to AddRoofShape(countryInfos, countryBoundariesFuture),
+    200 to AddRoofColour(countryInfos, countryBoundariesFuture),
 
     153 to AddStepCount(), // can only be gathered when walking along this way, also needs the most effort and least useful
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColour.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColour.kt
@@ -1,0 +1,71 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+import de.westnordost.countryboundaries.CountryBoundaries
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.meta.CountryInfos
+import de.westnordost.streetcomplete.data.meta.getByLocation
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BUILDING
+import de.westnordost.streetcomplete.osm.BUILDINGS_WITH_LEVELS
+import de.westnordost.streetcomplete.osm.Tags
+import java.util.concurrent.FutureTask
+
+class AddRoofColour(
+    private val countryInfos: CountryInfos,
+    private val countryBoundariesFuture: FutureTask<CountryBoundaries>,
+) : OsmElementQuestType<RoofColour> {
+
+    private val filter by lazy { """
+        ways, relations with
+          ((building:levels or roof:levels) or (building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}))
+          and !roof:colour
+          and building
+          and building !~ no|construction
+          and location != underground
+          and ruins != yes
+    """.toElementFilterExpression() }
+
+    override val changesetComment = "Specify roof colour"
+    override val wikiLink = "Key:roof:colour"
+    override val icon = R.drawable.ic_quest_roof_colour
+    override val achievements = listOf(BUILDING)
+    override val defaultDisabledMessage = R.string.default_disabled_msg_roofColour
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_roofColour_title
+
+    override fun createForm() = AddRoofColourForm()
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry) =
+        mapData.filter { element ->
+            filter.matches(element) && (
+                (element.tags["roof:levels"]?.toFloatOrNull() ?: 0f) > 0f
+                    || roofsAreUsuallyFlatAt(element, mapData) == false
+                )
+        }
+
+    override fun isApplicableTo(element: Element): Boolean? {
+        if (!filter.matches(element)) return false
+        /* if it has 0 roof levels, or the roof levels aren't specified,
+           the quest should only be shown in certain countries. But whether
+           the element is in a certain country cannot be ascertained without the element's geometry */
+        if ((element.tags["roof:levels"]?.toFloatOrNull() ?: 0f) == 0f) return null
+        return true
+    }
+
+    private fun roofsAreUsuallyFlatAt(element: Element, mapData: MapDataWithGeometry): Boolean? {
+        val center = mapData.getGeometry(element.type, element.id)?.center ?: return null
+        return countryInfos.getByLocation(
+            countryBoundariesFuture.get(),
+            center.longitude,
+            center.latitude,
+        ).roofsAreUsuallyFlat
+    }
+
+    override fun applyAnswerTo(answer: RoofColour, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags["roof:colour"] = answer.osmValue
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColourForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColourForm.kt
@@ -1,0 +1,25 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+import android.os.Bundle
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.AImageListQuestForm
+import de.westnordost.streetcomplete.quests.AnswerItem
+import de.westnordost.streetcomplete.quests.roof_colour.RoofColour.MANY
+
+class AddRoofColourForm : AImageListQuestForm<RoofColour, RoofColour>() {
+
+    override val otherAnswers = listOf(
+        AnswerItem(R.string.quest_roofColour_answer_many) { applyAnswer(MANY) }
+    )
+
+    override val items get() = RoofColour.values().mapNotNull { it.asItem(requireContext()) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        imageSelector.cellLayoutId = R.layout.cell_icon_select_with_label_below
+    }
+
+    override fun onClickOk(selectedItems: List<RoofColour>) {
+        applyAnswer(selectedItems.single())
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColour.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColour.kt
@@ -1,0 +1,20 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+enum class RoofColour(val osmValue: String) {
+    BRIGHT_RED("#c75d4d"),
+    RED("#a3331e"),
+    MAROON("maroon"),
+    DARK_RED("#4a0505"),
+
+    BLACK("#28282d"),
+    GRAY("gray"),
+    LIGHT_GRAY("#A2A0A0"),
+
+    VERDIGRIS("#43b3ae"),
+
+    TRADITIONAL_CHINESE("#21373d"),
+
+    WHITE("white"),
+
+    MANY("many"),
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColourItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColourItem.kt
@@ -1,0 +1,21 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.LightingColorFilter
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.view.DrawableImage
+import de.westnordost.streetcomplete.view.image_select.DisplayItem
+import de.westnordost.streetcomplete.view.image_select.Item2
+
+fun RoofColour.asItem(context: Context): DisplayItem<RoofColour>? {
+    if (this == RoofColour.MANY) {
+        return null;
+    }
+
+    val color = Color.parseColor(this.osmValue)
+    val drawable = context.getDrawable(R.drawable.ic_roof_colour)!!
+    drawable.colorFilter = LightingColorFilter(color, Color.BLACK)
+    val image = DrawableImage(drawable)
+    return Item2(this, image)
+}

--- a/app/src/main/res/drawable/ic_quest_roof_colour.xml
+++ b/app/src/main/res/drawable/ic_quest_roof_colour.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="128dp"
+        android:height="128dp"
+        android:viewportWidth="34"
+        android:viewportHeight="34">
+    <path
+        android:pathData="m32.64,23.28c-3.51,8.67 -13.38,12.85 -22.05,9.35 -8.67,-3.51 -12.85,-13.38 -9.35,-22.05 3.51,-8.67 13.38,-12.85 22.05,-9.35 8.67,3.51 12.85,13.38 9.35,22.05"
+        android:fillColor="#c8c4b7"/>
+    <path
+        android:pathData="m16.98,5.29 l-9.53,3.17 -0.05,17.99 9.57,-3.17 9.48,3.17 0.05,-17.99z"
+        android:fillAlpha="0.2"
+        android:fillColor="#000"/>
+    <path
+        android:pathData="m8.21,26.72 l8.73,-2.91 8.73,2.91v2.91h-6.35v-2.38h-4.76v2.38L8.21,29.63Z"
+        android:fillAlpha="0.2"
+        android:fillColor="#000"/>
+    <path
+        android:pathData="m7.41,7.41 l9.52,-3.17v17.99l-9.53,3.17z"
+        android:fillColor="#43b3ae"/>
+    <path
+        android:pathData="m16.94,4.23 l9.52,3.17v17.99l-9.52,-3.17z"
+        android:fillColor="#21373d"/>
+    <path
+        android:pathData="m8.21,25.67 l8.78,-2.91 8.68,2.91v2.91h-6.35v-2.38h-4.76v2.38L8.21,28.58Z"
+        android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/drawable/ic_roof_colour.xml
+++ b/app/src/main/res/drawable/ic_roof_colour.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="96"
+    android:viewportHeight="96">
+  <path
+      android:pathData="M4.845,49.768h2.74l10.96,-13.7 -1.37,-1.37 -12.33,15.07z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#fff"
+      android:strokeColor="#bbb"/>
+  <path
+      android:pathData="m29.505,74.428 l61.65,-20.55 -12.33,-39.73 -61.65,20.55 12.33,39.73z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#fff"
+      android:strokeColor="#bbb"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1328,6 +1328,10 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_road_width_explanation">"The roadway width from curb to curb: This includes anything on the street surface, including on-street parking or bicycle lanes but excluding anything beyond the curb like sidewalks, off-street parking or adjacent bicycle paths."</string>
     <string name="quest_road_width_unusualInput_confirmation_description">"This width looks implausible. Remember, this should be the width from curb to curb, including on-street parking, bicycle lanes etc."</string>
 
+    <string name="quest_roofColour_title">"What overall colour does this building’s roof have?"</string>
+    <string name="quest_roofColour_answer_many">"It has several different colours"</string>
+    <string name="default_disabled_msg_roofColour">This quest type is disabled by default because roof colours are often not easily visible from the street. This quest type is also quite time-consuming; in most cases it is easier and more efficient to map this from aerial imagery at home.</string>
+
     <string name="quest_roofShape_title">"What basic shape does this building’s roof have?"</string>
     <string name="quest_roofShape_answer_many">"It has several different shapes"</string>
     <string name="default_disabled_msg_roofShape">This quest type is disabled by default because roof shapes are often not easily visible from the street. This quest type is also quite time-consuming; in most cases it is easier and more efficient to map this from aerial imagery at home.</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColourTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/roof_colour/AddRoofColourTest.kt
@@ -1,0 +1,134 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+import de.westnordost.countryboundaries.CountryBoundaries
+import de.westnordost.streetcomplete.data.meta.CountryInfo
+import de.westnordost.streetcomplete.data.meta.CountryInfos
+import de.westnordost.streetcomplete.data.meta.IncompleteCountryInfo
+import de.westnordost.streetcomplete.data.meta.getByLocation
+import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
+import de.westnordost.streetcomplete.testutils.mock
+import de.westnordost.streetcomplete.testutils.on
+import de.westnordost.streetcomplete.testutils.pGeom
+import de.westnordost.streetcomplete.testutils.way
+import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyDouble
+import java.util.concurrent.FutureTask
+
+class AddRoofColourTest {
+    private lateinit var countryInfos: CountryInfos
+    private lateinit var questType: AddRoofColour
+    private lateinit var countryBoundaries: CountryBoundaries
+
+    @Before fun setUp() {
+        countryBoundaries = mock()
+        val futureTask = FutureTask { countryBoundaries }
+        futureTask.run()
+
+        countryInfos = mock()
+        questType = AddRoofColour(countryInfos, futureTask)
+    }
+
+    @Test fun `not applicable to roofs with colour already set`() {
+        assertEquals(false, questType.isApplicableTo(
+            way(tags = mapOf("roof:levels" to "1", "roof:colour" to "something"))
+        ))
+    }
+
+    @Test fun `not applicable to building parts`() {
+        assertEquals(false, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "1", "building:part" to "something"))
+        ))
+    }
+
+    @Test fun `not applicable to demolished building`() {
+        assertEquals(false, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "1", "demolished:building" to "something"))
+        ))
+    }
+
+    @Test fun `not applicable to negated building`() {
+        assertEquals(false, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "1", "building" to "no"))
+        ))
+    }
+
+    @Test fun `not applicable to building under construction`() {
+        assertEquals(false, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "1", "building" to "construction"))
+        ))
+    }
+
+    @Test fun `applicable to roofs`() {
+        assertEquals(true, questType.isApplicableTo(
+            way(tags = mapOf("roof:levels" to "1", "building" to "apartments"))
+        ))
+    }
+
+    @Test fun `applicable to buildings with many levels and enough roof levels to be visible from below`() {
+        assertEquals(true, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "6", "roof:levels" to "1.5", "building" to "apartments"))
+        ))
+        assertEquals(true, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "8", "roof:levels" to "3", "building" to "apartments"))
+        ))
+        assertEquals(true, questType.isApplicableTo(
+            way(tags = mapOf("building:levels" to "4.5", "roof:levels" to "0.5", "building" to "apartments"))
+        ))
+    }
+
+    @Test fun `unknown if applicable to buildings with no or few levels and 0 or no roof levels`() {
+        assertEquals(null, questType.isApplicableTo(
+            way(tags = mapOf("roof:levels" to "0", "building" to "apartments"))
+        ))
+        assertEquals(null, questType.isApplicableTo(
+            way(tags = mapOf("roof:levels" to "0", "building" to "apartments", "building:levels" to "3"))
+        ))
+        assertEquals(null, questType.isApplicableTo(
+            way(tags = mapOf("building" to "apartments", "building:levels" to "2"))
+        ))
+    }
+
+    @Test fun `create quest for roofs`() {
+        val element = way(tags = mapOf("roof:levels" to "1", "building" to "apartments"))
+
+        val quests = questType.getApplicableElements(TestMapDataWithGeometry(listOf(element)))
+
+        assertEquals(element, quests.single())
+    }
+
+    @Test fun `create quest for 0 or null-level roofs only in countries with no flat roofs`() {
+        val noFlatRoofs = CountryInfo(listOf(IncompleteCountryInfo(countryCode = "foo", roofsAreUsuallyFlat = false)))
+        on(countryInfos.getByLocation(countryBoundaries, anyDouble(), anyDouble())).thenReturn(noFlatRoofs)
+
+        val element = way(1, tags = mapOf("roof:levels" to "0", "building" to "apartments"))
+        val element2 = way(2, tags = mapOf("building:levels" to "3", "building" to "apartments"))
+
+        val mapData = TestMapDataWithGeometry(listOf(element, element2))
+        mapData.wayGeometriesById[1L] = pGeom()
+        mapData.wayGeometriesById[2L] = pGeom()
+
+        val quests = questType.getApplicableElements(mapData)
+
+        assertTrue(quests.containsExactlyInAnyOrder(listOf(element, element2)))
+    }
+
+    @Test fun `create quest for 0 or null-level roofs not in countries with flat roofs`() {
+        val flatRoofs = CountryInfo(listOf(IncompleteCountryInfo(countryCode = "foo", roofsAreUsuallyFlat = true)))
+        on(countryInfos.getByLocation(countryBoundaries, anyDouble(), anyDouble())).thenReturn(flatRoofs)
+
+        val element = way(1, tags = mapOf("roof:levels" to "0", "building" to "apartments"))
+        val element2 = way(1, tags = mapOf("building:levels" to "3", "building" to "apartments"))
+
+        val mapData = TestMapDataWithGeometry(listOf(element, element2))
+        mapData.wayGeometriesById[1L] = pGeom()
+        mapData.wayGeometriesById[2L] = pGeom()
+
+        val quests = questType.getApplicableElements(mapData)
+
+        assertTrue(quests.isEmpty())
+    }
+}

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColourItemTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/roof_colour/RoofColourItemTest.kt
@@ -1,0 +1,15 @@
+package de.westnordost.streetcomplete.quests.roof_colour
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class RoofColourItemTest {
+    @Test
+    fun `parsable as Color`() {
+        RoofColour.values().mapNotNull {
+            assertNotNull(
+                it.asItem()
+            )
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic quest asking for roof colours. 

![image](https://github.com/streetcomplete/StreetComplete/assets/87124/b8ba75bb-2baa-48ea-8a9a-09cdbe9c10bf)
![image](https://github.com/streetcomplete/StreetComplete/assets/87124/3d4d1f87-d769-442d-a804-16962900e40d)

As my first attempt at adding new quests to StreetComplete, this is heavily based on the existing AddRoofShape quest. The conditions that define whether the quest is shown, are the same as the original. This quest currently uses the example colours from [key:roof:colour](https://wiki.openstreetmap.org/wiki/Key:roof:colour), but changing the colour palette is simple enough.