### PR TITLE
Fix crash when adding node after modifying a node in the same way

### DIFF
--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -823,6 +823,25 @@ class MapDataWithEditsSourceTest {
         assertEquals(newWay, data.ways.single())
     }
 
+    @Test fun `getMapDataWithGeometry returns updated nodes of unchanged way`() {
+        val nd1 = node(1, p(0.5, 0.5))
+        val nd2 = node(2, p(2.5, 2.5))
+        val w1 = way(1, listOf(1, 2))
+        originalElementsAre(nd1, nd2, w1)
+        originalGeometriesAre(
+            ElementGeometryEntry(NODE, 1, pGeom(0.5, 0.5)),
+            ElementGeometryEntry(NODE, 2, pGeom(2.5, 2.5)),
+            ElementGeometryEntry(WAY, 1, geometryCreator.create(w1, listOf(nd1.position, nd2.position))!!)
+        )
+        val updatedNode = node(2, p(2.5, 2.5), version = 2)
+        mapDataChangesAre(creations = listOf(updatedNode))
+        val s = create()
+        val data = s.getMapDataWithGeometry(bbox())
+
+        assertTrue(data.nodes.containsExactlyInAnyOrder(listOf(nd1, updatedNode)))
+        assertEquals(w1, data.ways.single())
+    }
+
     //endregion
 
     //region ElementEditsSource.Listener ::onAddedEdit


### PR DESCRIPTION
closely related to #5005
When editing a node near one end of a long way, and trying to insert a node near the other end, there is a crash because the edited node is not in map data.

This is because nodes outside the bbox are removed in `modifyBBoxMapData`, and only re-added if they are part of a modified way.
But in this case the way is not modified, so the node is missing.

This fix checks before removing a node whether it is part of a way in `mapData`. Since we want updated ways, the loop over `(key, geometry)` is done for ways before nodes.
This might not be optimal for performance, as for each updated node `getWaysForNode` is called.
An alterative idea would be looping over all nodes of all ways in `mapData`, which could be clearly faster or much slower (depending on the number of edits and size of map data).

@westnordost 
If you have some alternative solution, feel free to update the PR, or scrap it and implement it some different way.