### PR TITLE
Don't start multiple MainActivity when tapping sync notification

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/sync/SyncNotification.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/sync/SyncNotification.kt
@@ -1,15 +1,13 @@
 package de.westnordost.streetcomplete.data.sync
 
 import android.app.Notification
-import android.app.PendingIntent
-import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.NotificationManagerCompat.IMPORTANCE_LOW
+import androidx.core.app.PendingIntentCompat
 import de.westnordost.streetcomplete.ApplicationConstants.NAME
 import de.westnordost.streetcomplete.ApplicationConstants.NOTIFICATIONS_CHANNEL_SYNC
 import de.westnordost.streetcomplete.R
@@ -19,11 +17,10 @@ import de.westnordost.streetcomplete.screens.MainActivity
  *  and by the download service. */
 fun createSyncNotification(context: Context): Notification {
     val intent = Intent(context, MainActivity::class.java)
-    val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        PendingIntent.getActivity(context, 0, intent, FLAG_IMMUTABLE)
-    } else {
-        PendingIntent.getActivity(context, 0, intent, 0)
-    }
+    intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    // Intent has to be mutable, otherwise the intent flags defined above are not applied
+    val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, true)
+
     val manager = NotificationManagerCompat.from(context)
     if (manager.getNotificationChannelCompat(NOTIFICATIONS_CHANNEL_SYNC) == null) {
         manager.createNotificationChannel(


### PR DESCRIPTION
Fixes #4975 by ensuring that there is only one `MainActivity` instance on top of the task stack after the sync notification is tapped. Activities that are potentially on top of an already existing `MainActivity` instance (e.g. the settings menu) are cleared.

I tested the change on an Android 9 and 12L emulator as well as on an Android 11 phone, where StreetMeasure still worked correctly. On newer API levels the notification is not shown anyway.