### PR TITLE
Enable cycleways/tactile paving quests in Israel

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -53,6 +53,8 @@ class AddCycleway(
         "GB", "IE", "NL", "BE", "FR", "LU",
         "DE", "PL", "CZ", "HU", "AT", "CH", "LI",
         "ES", "IT", "HR",
+        // Middle east
+        "IL",
         // East Asia
         "JP", "KR", "TW",
         // some of China (East Coast)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/TactilePavingUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/TactilePavingUtil.kt
@@ -12,7 +12,7 @@ val COUNTRIES_WHERE_TACTILE_PAVING_IS_COMMON = NoCountriesExcept(
     // America
     "US", "CA", "AR",
     // Asia
-    "HK", "SG", "KR", "JP",
+    "HK", "SG", "KR", "JP", "IL",
     // Oceania
     "AU", "NZ"
 )


### PR DESCRIPTION
Tactile paving is pretty common in Israel, having been mandatory in new developments and street rennovations for at least 5 years, if not more. Bike paths are also common in the flat areas of Central Israel and the bike path network is slowly being expanded.

I think enabling these quests make sense as it will help gather this kind of data. There's no reason to outright disable these quests in Israel.