### PR TITLE
Don't set newer tile timestamp when invalidating

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
@@ -67,7 +67,7 @@ class DownloadedTilesDaoTest : ApplicationDbTestCase() {
 
     @Test fun updateTime() {
         dao.put(r(0, 0, 0, 1))
-        dao.updateTime(TilePos(0, 0), 0)
+        dao.updateTimeIfNewer(TilePos(0, 0), 0)
         assertEquals(
             listOf(TilePos(0, 1)),
             dao.getAll(1)
@@ -76,13 +76,13 @@ class DownloadedTilesDaoTest : ApplicationDbTestCase() {
 
     @Test fun updateAllTimes() {
         dao.put(r(0, 0, 0, 1))
-        dao.updateAllTimes(0)
+        dao.updateAllTimesIfNewer(0)
         assertTrue(dao.getAll(1).isEmpty())
     }
 
     @Test fun deleteOlderThan() {
         dao.put(r(0, 0, 1, 0))
-        dao.updateTime(TilePos(0, 0), 1)
+        dao.updateTimeIfNewer(TilePos(0, 0), 1)
         assertEquals(1, dao.deleteOlderThan(2))
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
@@ -27,12 +27,12 @@ class DownloadedTilesController(
     }
 
     fun invalidate(tilePos: TilePos) {
-        dao.updateTime(tilePos, getOldTime())
+        dao.updateTimeIfNewer(tilePos, getOldTime())
         onUpdated()
     }
 
     fun invalidateAll() {
-        dao.updateAllTimes(getOldTime())
+        dao.updateAllTimesIfNewer(getOldTime())
         onUpdated()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDao.kt
@@ -31,16 +31,20 @@ class DownloadedTilesDao(private val db: Database) {
         db.exec("DELETE FROM $NAME")
     }
 
-    fun updateTime(tile: TilePos, time: Long) {
+    fun updateTimeIfNewer(tile: TilePos, time: Long) {
         db.update(NAME,
             values = listOf(DATE to time),
-            where = "$X = ? AND $Y = ?",
-            args = arrayOf(tile.x.toString(), tile.y.toString()),
+            where = "$X = ? AND $Y = ? AND $DATE > ?",
+            args = arrayOf(tile.x.toString(), tile.y.toString(), time.toString()),
         )
     }
 
-    fun updateAllTimes(time: Long) {
-        db.update(NAME, values = listOf(DATE to time))
+    fun updateAllTimesIfNewer(time: Long) {
+        db.update(NAME,
+            values = listOf(DATE to time),
+            where = "$DATE > ?",
+            args = arrayOf(time.toString()),
+        )
     }
 
     fun deleteOlderThan(time: Long): Int =

--- a/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesControllerTest.kt
@@ -38,13 +38,13 @@ class DownloadedTilesControllerTest {
     @Test fun invalidate() {
         val t = TilePos(0, 0)
         ctrl.invalidate(t)
-        verify(dao).updateTime(eq(t), anyLong()) // hm, difficult to test the exact time...
+        verify(dao).updateTimeIfNewer(eq(t), anyLong()) // hm, difficult to test the exact time...
         verify(listener).onUpdated()
     }
 
     @Test fun invalidateAll() {
         ctrl.invalidateAll()
-        verify(dao).updateAllTimes(anyLong()) // hm, difficult to test the exact time...
+        verify(dao).updateAllTimesIfNewer(anyLong()) // hm, difficult to test the exact time...
         verify(listener).onUpdated()
     }
 


### PR DESCRIPTION
fixes #5068

Tested by logging tile timestamps before and after invalidating: works as intended.