### PR TITLE
Don't delete old nodes that are part of a way

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDao.kt
@@ -85,15 +85,6 @@ class ElementDao(
         wayDao.clear()
         nodeDao.clear()
     }
-
-    fun getIdsOlderThan(timestamp: Long, limit: Int? = null): List<ElementKey> {
-        val result = mutableListOf<ElementKey>()
-        // get relations first, then ways, then nodes because relations depend on ways depend on nodes.
-        result.addAll(relationDao.getIdsOlderThan(timestamp, limit?.minus(result.size)).map { ElementKey(RELATION, it) })
-        result.addAll(wayDao.getIdsOlderThan(timestamp, limit?.minus(result.size)).map { ElementKey(WAY, it) })
-        result.addAll(nodeDao.getIdsOlderThan(timestamp, limit?.minus(result.size)).map { ElementKey(NODE, it) })
-        return result
-    }
 }
 
 private fun Iterable<ElementKey>.filterByType(type: ElementType) =

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -226,16 +226,17 @@ class MapDataController internal constructor(
             val ways = wayDB.getIdsOlderThan(timestamp, limit?.minus(relations.size)).map { ElementKey(ElementType.WAY, it) }
 
             // delete now, so filterNodeIdsWithoutWays works as intended
+            cache.update(deletedKeys = ways + relations)
             val wayAndRelationCount = elementDB.deleteAll(ways + relations)
             val nodes = nodeDB.getIdsOlderThan(timestamp, limit?.minus(relations.size + ways.size))
             // filter nodes to only delete nodes that are not part of a ways in the database
-            val filteredNodes = wayDB.filterNodeIdsWithoutWays(nodes)
+            val filteredNodes = wayDB.filterNodeIdsWithoutWays(nodes).map { ElementKey(ElementType.NODE, it) }
 
-            elements = relations + ways + filteredNodes.map { ElementKey(ElementType.NODE, it) }
+            elements = relations + ways + filteredNodes
             if (elements.isEmpty()) return 0
 
-            cache.update(deletedKeys = elements)
-            elementCount = wayAndRelationCount + nodeDB.deleteAll(filteredNodes)
+            cache.update(deletedKeys = filteredNodes)
+            elementCount = wayAndRelationCount + elementDB.deleteAll(filteredNodes)
             geometryCount = geometryDB.deleteAll(elements)
             createdElementsController.deleteAll(elements)
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -222,11 +222,20 @@ class MapDataController internal constructor(
         val elementCount: Int
         val geometryCount: Int
         synchronized(this) {
-            elements = elementDB.getIdsOlderThan(timestamp, limit)
+            val relations = relationDB.getIdsOlderThan(timestamp, limit).map { ElementKey(ElementType.RELATION, it) }
+            val ways = wayDB.getIdsOlderThan(timestamp, limit?.minus(relations.size)).map { ElementKey(ElementType.WAY, it) }
+
+            // delete now, so filterNodeIdsWithoutWays works as intended
+            val wayAndRelationCount = elementDB.deleteAll(ways + relations)
+            val nodes = nodeDB.getIdsOlderThan(timestamp, limit?.minus(relations.size + ways.size))
+            // filter nodes to only delete nodes that are not part of a ways in the database
+            val filteredNodes = wayDB.filterNodeIdsWithoutWays(nodes)
+
+            elements = relations + ways + filteredNodes.map { ElementKey(ElementType.NODE, it) }
             if (elements.isEmpty()) return 0
 
             cache.update(deletedKeys = elements)
-            elementCount = elementDB.deleteAll(elements)
+            elementCount = wayAndRelationCount + nodeDB.deleteAll(filteredNodes)
             geometryCount = geometryDB.deleteAll(elements)
             createdElementsController.deleteAll(elements)
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/WayDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/WayDao.kt
@@ -124,4 +124,10 @@ class WayDao(private val db: Database) {
             limit = limit?.toString()
         ) { it.getLong(ID) }
     }
+
+    fun filterNodeIdsWithoutWays(nodeIds: Collection<Long>): Collection<Long> {
+        val idsString = nodeIds.joinToString(",")
+        val nodeIdsWithWays = db.query(NAME_NODES, where = "$NODE_ID IN ($idsString)", columns = arrayOf(NODE_ID)) { c -> c.getLong(NODE_ID) }
+        return nodeIds - nodeIdsWithWays.toHashSet()
+    }
 }


### PR DESCRIPTION
should fix #5066

This changes `deleteOlderThan` to first delete ways, and then deletes only nodes that are not part of any way in the database.

_Not_ yet tested, and not unit tests.
This can be solved in a bunch of different ways and I don't want to work out every detail before knowing the basic approach is ok.