### PR TITLE
Add getDouble/putDouble extensions to SharedPreferences

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
@@ -54,6 +54,7 @@ import de.westnordost.streetcomplete.screens.tutorial.TutorialFragment
 import de.westnordost.streetcomplete.util.CrashReportExceptionHandler
 import de.westnordost.streetcomplete.util.ktx.hasLocationPermission
 import de.westnordost.streetcomplete.util.ktx.isLocationEnabled
+import de.westnordost.streetcomplete.util.ktx.putDouble
 import de.westnordost.streetcomplete.util.ktx.toast
 import de.westnordost.streetcomplete.util.location.LocationAvailabilityReceiver
 import de.westnordost.streetcomplete.util.location.LocationRequestFragment
@@ -213,8 +214,8 @@ class MainActivity :
         super.onPause()
         val pos = mainFragment?.getCameraPosition()?.position ?: return
         prefs.edit {
-            putLong(Prefs.MAP_LATITUDE, java.lang.Double.doubleToRawLongBits(pos.latitude))
-            putLong(Prefs.MAP_LONGITUDE, java.lang.Double.doubleToRawLongBits(pos.longitude))
+            putDouble(Prefs.MAP_LATITUDE, pos.latitude)
+            putDouble(Prefs.MAP_LONGITUDE, pos.longitude)
         }
         downloadController.showNotification = true
         uploadController.showNotification = true

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -40,6 +40,7 @@ import de.westnordost.streetcomplete.screens.main.map.tangram.MapChangingListene
 import de.westnordost.streetcomplete.screens.main.map.tangram.initMap
 import de.westnordost.streetcomplete.util.ktx.awaitLayout
 import de.westnordost.streetcomplete.util.ktx.containsAll
+import de.westnordost.streetcomplete.util.ktx.putDouble
 import de.westnordost.streetcomplete.util.ktx.setMargins
 import de.westnordost.streetcomplete.util.ktx.tryStartActivity
 import de.westnordost.streetcomplete.util.ktx.viewLifecycleScope
@@ -353,8 +354,8 @@ open class MapFragment :
             putFloat(PREF_ROTATION, camera.rotation)
             putFloat(PREF_TILT, camera.tilt)
             putFloat(PREF_ZOOM, camera.zoom)
-            putLong(PREF_LAT, java.lang.Double.doubleToRawLongBits(camera.position.latitude))
-            putLong(PREF_LON, java.lang.Double.doubleToRawLongBits(camera.position.longitude))
+            putDouble(PREF_LAT, camera.position.latitude)
+            putDouble(PREF_LON, camera.position.longitude)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/TangramPinsSpriteSheet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/TangramPinsSpriteSheet.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
+import de.westnordost.streetcomplete.util.ktx.getDouble
 import de.westnordost.streetcomplete.util.ktx.isApril1st
 import kotlin.math.ceil
 import kotlin.math.sqrt
@@ -88,7 +89,7 @@ class TangramPinsSpriteSheet(
     }
 
     private fun shouldBeUpsideDown(): Boolean {
-        val isBelowEquator = Double.fromBits(prefs.getLong(Prefs.MAP_LATITUDE, 0.0.toBits())) < 0.0
+        val isBelowEquator = prefs.getDouble(Prefs.MAP_LATITUDE) < 0.0
         return isBelowEquator && isApril1st()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsActivity.kt
@@ -38,6 +38,7 @@ import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
 import de.westnordost.streetcomplete.quests.AbstractQuestForm
 import de.westnordost.streetcomplete.screens.BaseActivity
 import de.westnordost.streetcomplete.screens.settings.genericQuestTitle
+import de.westnordost.streetcomplete.util.ktx.getDouble
 import de.westnordost.streetcomplete.util.math.translate
 import de.westnordost.streetcomplete.util.viewBinding
 import de.westnordost.streetcomplete.view.ListAdapter
@@ -84,10 +85,7 @@ class ShowQuestFormsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
 
     override fun onStart() {
         super.onStart()
-        pos = LatLon(
-            Double.fromBits(prefs.getLong(Prefs.MAP_LATITUDE, 0.0.toBits())),
-            Double.fromBits(prefs.getLong(Prefs.MAP_LONGITUDE, 0.0.toBits()))
-        )
+        pos = LatLon(prefs.getDouble(Prefs.MAP_LATITUDE), prefs.getDouble(Prefs.MAP_LONGITUDE))
     }
 
     private fun popQuestForm() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
@@ -36,6 +36,7 @@ import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeSource
 import de.westnordost.streetcomplete.databinding.RowQuestSelectionBinding
 import de.westnordost.streetcomplete.screens.settings.genericQuestTitle
 import de.westnordost.streetcomplete.util.ktx.containsAny
+import de.westnordost.streetcomplete.util.ktx.getDouble
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -57,7 +58,8 @@ class QuestSelectionAdapter(
     prefs: SharedPreferences
 ) : ListAdapter<QuestVisibility, QuestSelectionAdapter.QuestVisibilityViewHolder>(QuestDiffUtil), DefaultLifecycleObserver {
 
-    private val currentCountryCodes: List<String>
+    private val currentCountryCodes = countryBoundaries.get()
+        .getIds(prefs.getDouble(Prefs.MAP_LONGITUDE), prefs.getDouble(Prefs.MAP_LATITUDE))
     private val itemTouchHelper by lazy { ItemTouchHelper(TouchHelperCallback()) }
 
     private val viewLifecycleScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -123,12 +125,6 @@ class QuestSelectionAdapter(
             // all/many quest orders have been changed - reinit list
             viewLifecycleScope.launch { questTypes = createQuestTypeVisibilityList() }
         }
-    }
-
-    init {
-        val lat = Double.fromBits(prefs.getLong(Prefs.MAP_LATITUDE, 0.0.toBits()))
-        val lng = Double.fromBits(prefs.getLong(Prefs.MAP_LONGITUDE, 0.0.toBits()))
-        currentCountryCodes = countryBoundaries.get().getIds(lng, lat)
     }
 
     override fun onStart(owner: LifecycleOwner) {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/SharedPreferences.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/SharedPreferences.kt
@@ -3,3 +3,11 @@ package de.westnordost.streetcomplete.util.ktx
 import android.content.SharedPreferences
 
 fun SharedPreferences.containsAll(keys: List<String>): Boolean = keys.all { contains(it) }
+
+fun SharedPreferences.Editor.putDouble(key: String, value: Double): SharedPreferences.Editor {
+    return putLong(key, value.toRawBits())
+}
+
+fun SharedPreferences.getDouble(key: String, defValue: Double = 0.0): Double {
+    return Double.fromBits(getLong(key, defValue.toRawBits()))
+}


### PR DESCRIPTION
This PR adds two new extension functions to `SharedPreferences` that make it easier to store `Double` values and updates all usages of this functionality accordingly.