### PR TITLE
Improve floating point issues with tile/lat conversion

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/TilesRect.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/TilesRect.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.Serializable
 import kotlin.math.PI
 import kotlin.math.asinh
 import kotlin.math.atan
+import kotlin.math.nextDown
+import kotlin.math.nextUp
 import kotlin.math.sinh
 import kotlin.math.tan
 
@@ -114,12 +116,12 @@ private fun tile2lon(x: Int, zoom: Int): Double =
     360.0 * x / numTiles(zoom).toDouble() - 180.0
 
 private fun tile2lat(y: Int, zoom: Int): Double =
-    180.0 * atan(sinh(PI * (1.0 - 2.0 * y / numTiles(zoom)))) / PI
+    (180.0 / PI * atan(sinh(PI * (1.0 - 2.0 * y / numTiles(zoom))))).nextDown()
 
 private fun lon2tile(lon: Double, zoom: Int): Int =
     (numTiles(zoom) * (lon + 180.0) / 360.0).toInt()
 
 private fun lat2tile(lat: Double, zoom: Int): Int =
-    (numTiles(zoom) * (1.0 - asinh(tan(PI * lat / 180.0)) / PI) / 2.0).toInt()
+    (numTiles(zoom) * (1.0 - asinh(tan(PI * lat / 180.0)) / PI) / 2.0).nextUp().toInt()
 
 private fun numTiles(zoom: Int): Int = 1 shl zoom


### PR DESCRIPTION
This greatly reduces the number of `LatLon`s where https://github.com/streetcomplete/StreetComplete/blob/5cc6506dbecaad6b6b510bd1b3881281037c4043/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/TilesRectTest.kt#L13 fails

It's a draft because the change to `tile2lat` causes the test for `p(0.0, 0.0)` to fail. This is some sort of "special" point that's used in many other tests, and thus I think it really needs to work.
So far the only way I found it to work for `p(0.0, 0.0)` is treating `y == numTiles(zoom) / 2` as a special case in `tile2lat`, though this looks a bit ugly.

Slightly modified `convert bbox to tiles rect and back results in same bbox` using 1 million random coordinates (with lat limited to range from -85 to 85) fail count:
* master: ca 80k
* with `lat2tile` `nextUp`: ca 53k
* with `tile2lat` `nextDown`: ca 9200
* with `tile2lat` `nextDown` and moving `/ PI`: ca 6700
* with all improvements (this PR): ca 2900