### PR TITLE
make bboxes created from TilesRect snap to a certain precision

### DIFF
--- a/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/TilesRectTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/TilesRectTest.kt
@@ -16,7 +16,7 @@ class TilesRectTest {
             p(0.0, 0.0),
             p(48.179, 16.414),
             p(0.236, 47.235),
-            // p(85.049, -179.989), // fails
+            p(85.049, -179.989),
         )
         for (p in points) {
             val tile = p.enclosingTilePos(15)


### PR DESCRIPTION
Supersedes #5091

cc @Helium314 : How does this look to you? You obviously have been testing with a larger set of test data. Would you test this out with your data? Does it make sense to add this as unit tests?