### PR TITLE
Ask AddCrossing for sidewalk and crossing ways

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AListQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AListQuestForm.kt
@@ -40,7 +40,7 @@ abstract class AListQuestForm<T> : AbstractOsmQuestForm<T>() {
     }
 
     override fun onClickOk() {
-        applyAnswer(radioButtonIds.getValue(binding.radioButtonGroup.checkedRadioButtonId).value)
+        applyAnswer(checkedItem!!.value)
     }
 
     override fun isFormComplete() = binding.radioButtonGroup.checkedRadioButtonId != -1

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AListQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AListQuestForm.kt
@@ -19,6 +19,8 @@ abstract class AListQuestForm<T> : AbstractOsmQuestForm<T>() {
 
     private val radioButtonIds = HashMap<Int, TextItem<T>>()
 
+    val checkedItem get() = radioButtonIds[binding.radioButtonGroup.checkedRadioButtonId]
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         for (item in items) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -25,15 +25,9 @@ class AddCrossing : OsmElementQuestType<CrossingAnswer> {
     private val footwaysFilter by lazy { """
         ways with
           (highway ~ footway|steps or highway ~ path|cycleway and foot ~ designated|yes)
-          and footway !~ sidewalk|crossing
           and area != yes
           and access !~ private|no
     """.toElementFilterExpression() }
-
-    /* It is neither asked for sidewalks nor crossings (=separately mapped sidewalk infrastructure)
-    *  because a "no" answer would require to also delete/adapt the crossing ways, rather than just
-    *  tagging crossing=no on the vertex.
-    *  See https://github.com/streetcomplete/StreetComplete/pull/2999#discussion_r681516203 */
 
     override val changesetComment = "Specify whether there are crossings at intersections of paths and roads"
     override val wikiLink = "Tag:highway=crossing"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.quests.crossing
 
+import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.quests.AListQuestForm
@@ -10,17 +11,31 @@ import org.koin.android.ext.android.inject
 class AddCrossingForm : AListQuestForm<CrossingAnswer>() {
     private val mapDataSource: MapDataWithEditsSource by inject()
 
-    override val items get() = listOfNotNull(
+    override val items get() = listOf(
         TextItem(YES, R.string.quest_crossing_yes),
         TextItem(NO, R.string.quest_crossing_no),
-        if (isOnSidewalkOrCrossing()) null else TextItem(PROHIBITED, R.string.quest_crossing_prohibited)
+        TextItem(PROHIBITED, R.string.quest_crossing_prohibited)
     )
 
-    /* PROHIBITED is neither available for sidewalks nor crossings (=separately mapped sidewalk infrastructure)
+    /* PROHIBITED is neither possible for sidewalks nor crossings (=separately mapped sidewalk infrastructure)
     *  because a "no" answer would require to also delete/adapt the crossing ways, rather than just
     *  tagging crossing=no on the vertex.
+    *  This situation needs to be solved in a different editor, so we ask the user to leave a note.
     *  See https://github.com/streetcomplete/StreetComplete/pull/2999#discussion_r681516203
     *  and https://github.com/streetcomplete/StreetComplete/issues/5160 */
+    override fun isFormComplete(): Boolean {
+        if (checkedItem?.value == PROHIBITED && isOnSidewalkOrCrossing()) {
+            AlertDialog.Builder(requireContext())
+                .setMessage(R.string.quest_crossing_prohibited_but_on_sidewalk_or_crossing)
+                .setPositiveButton(R.string.quest_leave_new_note_yes) { _, _ -> composeNote() }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+            return false
+        }
+        return super.isFormComplete()
+    }
+
+    override fun isRejectingClose() = super.isFormComplete()
 
     private fun isOnSidewalkOrCrossing(): Boolean {
         val ways = mapDataSource.getWaysForNode(element.id)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
@@ -1,15 +1,32 @@
 package de.westnordost.streetcomplete.quests.crossing
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.crossing.CrossingAnswer.*
+import org.koin.android.ext.android.inject
 
 class AddCrossingForm : AListQuestForm<CrossingAnswer>() {
+    private val mapDataSource: MapDataWithEditsSource by inject()
 
-    override val items = listOf(
+    override val items get() = listOfNotNull(
         TextItem(YES, R.string.quest_crossing_yes),
         TextItem(NO, R.string.quest_crossing_no),
-        TextItem(PROHIBITED, R.string.quest_crossing_prohibited),
+        if (isOnSidewalkOrCrossing()) null else TextItem(PROHIBITED, R.string.quest_crossing_prohibited)
     )
+
+    /* PROHIBITED is neither available for sidewalks nor crossings (=separately mapped sidewalk infrastructure)
+    *  because a "no" answer would require to also delete/adapt the crossing ways, rather than just
+    *  tagging crossing=no on the vertex.
+    *  See https://github.com/streetcomplete/StreetComplete/pull/2999#discussion_r681516203
+    *  and https://github.com/streetcomplete/StreetComplete/issues/5160 */
+
+    private fun isOnSidewalkOrCrossing(): Boolean {
+        val ways = mapDataSource.getWaysForNode(element.id)
+        return ways.any {
+            val footway = it.tags["footway"]
+            footway == "sidewalk" || footway == "crossing"
+        }
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingForm.kt
@@ -31,7 +31,7 @@ class AddCrossingForm : AListQuestForm<CrossingAnswer>() {
     override fun onClickOk() {
         if (checkedItem?.value == PROHIBITED && isOnSidewalkOrCrossing()) {
             AlertDialog.Builder(requireContext())
-                .setMessage(R.string.quest_crossing_prohibited_but_on_sidewalk_or_crossing)
+                .setMessage(R.string.quest_leave_new_note_as_answer)
                 .setPositiveButton(R.string.quest_leave_new_note_yes) { _, _ -> composeNote() }
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -931,6 +931,7 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
     <string name="quest_crossing_yes">Yes (e.g. the curb is lowered here or there are markings)</string>
     <string name="quest_crossing_no">No, but crossing is possible</string>
     <string name="quest_crossing_prohibited">No, crossing is prohibited or impossible</string>
+    <string name="quest_crossing_prohibited_but_on_sidewalk_or_crossing">This position is on a sidewalk or crossing. Please leave a note to explain the situation.</string>
 
     <string name="quest_crossing_type_title">What kind of crossing is this?</string>
     <string name="quest_crossing_type_signals_controlled">Controlled by traffic lights</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="quest_leave_new_note_description">"You can leave a public note for other mappers to resolve at this location, or hide this quest for yourself only"</string>
     <string name="quest_leave_new_note_yes">"Leave note"</string>
     <string name="quest_leave_new_note_no">"Hide"</string>
+    <string name="quest_leave_new_note_as_answer">In this case, you need to leave a note in which you explain the situation.</string>
+
 
     <string name="quest_generic_otherAnswers">"Other answers…"</string>
     <!-- aka "not applicable", "not answerable" -->
@@ -931,7 +933,6 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
     <string name="quest_crossing_yes">Yes (e.g. the curb is lowered here or there are markings)</string>
     <string name="quest_crossing_no">No, but crossing is possible</string>
     <string name="quest_crossing_prohibited">No, crossing is prohibited or impossible</string>
-    <string name="quest_crossing_prohibited_but_on_sidewalk_or_crossing">This position is on a sidewalk or crossing. Please leave a note to explain the situation.</string>
 
     <string name="quest_crossing_type_title">What kind of crossing is this?</string>
     <string name="quest_crossing_type_signals_controlled">Controlled by traffic lights</string>


### PR DESCRIPTION
fixes #5160

Hides the prohibited answer for `footway=sidewalk` and `footway=crossing`, so the user has to leave a note in that case.