### PR TITLE
Enable platform quests on relations

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddBusStopLit : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.osm.applyTo
 class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.quests.bus_stop_shelter.BusStopShelterAnswe
 class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with
+        nodes, ways, relations with
         (
           public_transport = platform
           or (highway = bus_stop and public_transport != stop_position)


### PR DESCRIPTION
This commit also considers `public_transport=platform`s that are relations (e.g. multipolygons). See #5182 for more details.