### PR TITLE
set and enforce a maximum tilt

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/CameraManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/CameraManager.kt
@@ -21,6 +21,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import de.westnordost.streetcomplete.util.ktx.runImmediate
 import kotlin.math.PI
+import kotlin.math.min
 
 /**
  *  Controls the camera of a Tangram MapController. Use in place of the
@@ -67,6 +68,8 @@ class CameraManager(private val c: MapController, private val contentResolver: C
         }
 
     val isAnimating: Boolean get() = lastAnimator != null
+
+    var maximumTilt: Float = PI.toFloat() / 8f // 45°
 
     interface AnimationsListener {
         @UiThread fun onAnimationsStarted()
@@ -115,7 +118,7 @@ class CameraManager(private val c: MapController, private val contentResolver: C
             _tangramCamera.longitude = it.longitude
         }
         update.rotation?.let { _tangramCamera.rotation = it }
-        update.tilt?.let { _tangramCamera.tilt = it }
+        update.tilt?.let { _tangramCamera.tilt = min(it, maximumTilt) }
         update.zoom?.let { _tangramCamera.zoom = it }
         pushCameraPositionToController()
     }
@@ -133,7 +136,8 @@ class CameraManager(private val c: MapController, private val contentResolver: C
             assignAnimation("rotation", animator)
         }
         update.tilt?.let {
-            propValues.add(PropertyValuesHolder.ofFloat(TangramTiltProperty, it))
+            val tilt = min(it, maximumTilt)
+            propValues.add(PropertyValuesHolder.ofFloat(TangramTiltProperty, tilt))
             assignAnimation("tilt", animator)
         }
         update.zoom?.let {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/CameraManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/tangram/CameraManager.kt
@@ -69,7 +69,7 @@ class CameraManager(private val c: MapController, private val contentResolver: C
 
     val isAnimating: Boolean get() = lastAnimator != null
 
-    var maximumTilt: Float = PI.toFloat() / 8f // 45°
+    var maximumTilt: Float = PI.toFloat() / 6f // 60°
 
     interface AnimationsListener {
         @UiThread fun onAnimationsStarted()


### PR DESCRIPTION
fixes #5177

Set maximum tilt to 60° (PI/6) and enforce it also during the shove gesture.

@Helium314 tested that Tangram is not able to find a position at 60.47° tilt and above. So if the crash persists on other devices, we could just set the max tilt to 45° or something.