### PR TITLE
test: use assertFailsWith instead of expected

### DIFF
--- a/app/src/test/java/de/westnordost/streetcomplete/data/ObjectTypeRegistryTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/ObjectTypeRegistryTest.kt
@@ -2,17 +2,22 @@ package de.westnordost.streetcomplete.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 internal class ObjectTypeRegistryTest {
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `throws when one class is added twice`() {
-        ObjectTypeRegistry<Any>(listOf(1 to A, 2 to A))
+        assertFailsWith<IllegalArgumentException> {
+            ObjectTypeRegistry<Any>(listOf(1 to A, 2 to A))
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `throws when one ordinal is added twice`() {
-        ObjectTypeRegistry(listOf(1 to A, 1 to B))
+        assertFailsWith<IllegalArgumentException> {
+            ObjectTypeRegistry(listOf(1 to A, 1 to B))
+        }
     }
 
     @Test

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionBuilderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionBuilderTest.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.data.elementfilter
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class BooleanExpressionBuilderTest {
     @Test fun leaf() { check("a") }
@@ -55,23 +56,47 @@ class BooleanExpressionBuilderTest {
     @Test fun flatten1() { check("((a*b)*c)*d*(e*f)", "a*b*c*d*e*f") }
     @Test fun flatten2() { check("(a+b*(c+d)+e)*f", "(a+b*(c+d)+e)*f") }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too many brackets 1`() { TestBooleanExpressionParser.parse("a+b)") }
+    @Test
+    fun `closed too many brackets 1`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("a+b)")
+        }
+    }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too many brackets 2`() { TestBooleanExpressionParser.parse("(a+b))") }
+    @Test
+    fun `closed too many brackets 2`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("(a+b))")
+        }
+    }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too many brackets 3`() { TestBooleanExpressionParser.parse("((b+c)*a)+d)") }
+    @Test
+    fun `closed too many brackets 3`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("((b+c)*a)+d)")
+        }
+    }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too few brackets 1`() { TestBooleanExpressionParser.parse("(a+b") }
+    @Test
+    fun `closed too few brackets 1`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("(a+b")
+        }
+    }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too few brackets 2`() { TestBooleanExpressionParser.parse("((a+b)") }
+    @Test
+    fun `closed too few brackets 2`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("((a+b)")
+        }
+    }
 
-    @Test(expected = IllegalStateException::class)
-    fun `closed too few brackets 3`() { TestBooleanExpressionParser.parse("((a*(b+c))") }
+    @Test
+    fun `closed too few brackets 3`() {
+        assertFailsWith<IllegalStateException> {
+            TestBooleanExpressionParser.parse("((a*(b+c))")
+        }
+    }
 
     private fun check(input: String, expected: String = input) {
         val tree = TestBooleanExpressionParser.parse(input)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 internal class CreateNodeActionTest {
     private lateinit var repos: MapDataRepository
@@ -78,7 +79,7 @@ internal class CreateNodeActionTest {
         assertEquals(listOf<Long>(1, -123, 2), updatedWay.nodeIds)
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if way the node should be inserted into does not exist`() {
         val way = way(id = 1, nodes = listOf(1, 2))
         val pos1 = LatLon(0.0, 1.0)
@@ -91,10 +92,12 @@ internal class CreateNodeActionTest {
         val position = LatLon(0.0, 1.5)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos2)))
 
-        action.createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            action.createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if node 2 is not successive to node 1`() {
         val way = way(id = 1, nodes = listOf(1, 2, 3))
         val pos1 = LatLon(0.0, 1.0)
@@ -111,7 +114,9 @@ internal class CreateNodeActionTest {
         val position = LatLon(0.0, 1.5)
         val action = CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, pos3)))
 
-        action.createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            action.createUpdates(repos, provider)
+        }
     }
 
     @Test
@@ -135,7 +140,7 @@ internal class CreateNodeActionTest {
         action.createUpdates(repos, provider)
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if node 1 has been moved`() {
         val way = way(id = 1, nodes = listOf(1, 2))
         val oldPos1 = LatLon(0.0, 0.0)
@@ -152,10 +157,12 @@ internal class CreateNodeActionTest {
         val action =
             CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, oldPos1, pos2)))
 
-        action.createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            action.createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if node 2 has been moved`() {
         val way = way(id = 1, nodes = listOf(1, 2))
         val oldPos2 = LatLon(0.0, 0.0)
@@ -172,7 +179,9 @@ internal class CreateNodeActionTest {
         val action =
             CreateNodeAction(position, tags, listOf(InsertIntoWayAt(way.id, pos1, oldPos2)))
 
-        action.createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            action.createUpdates(repos, provider)
+        }
     }
 
     @Test

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeFromVertexActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeFromVertexActionTest.kt
@@ -17,6 +17,7 @@ import de.westnordost.streetcomplete.util.math.translate
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 internal class CreateNodeFromVertexActionTest {
     private lateinit var repos: MapDataRepository
@@ -28,25 +29,29 @@ internal class CreateNodeFromVertexActionTest {
         provider = mock()
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node position changed`() {
         val n = node()
         val n2 = n.copy(position = n.position.translate(1.0, 0.0)) // moved by 1 meter
         on(repos.getNode(n.id)).thenReturn(n2)
         on(repos.getWaysForNode(n.id)).thenReturn(listOf())
 
-        CreateNodeFromVertexAction(n, StringMapChanges(listOf()), listOf())
-            .createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            CreateNodeFromVertexAction(n, StringMapChanges(listOf()), listOf())
+                .createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node is not part of exactly the same ways as before`() {
         val n = node()
         on(repos.getNode(n.id)).thenReturn(n)
         on(repos.getWaysForNode(n.id)).thenReturn(listOf(way(1), way(2)))
 
-        CreateNodeFromVertexAction(n, StringMapChanges(listOf()), listOf(1L))
-            .createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            CreateNodeFromVertexAction(n, StringMapChanges(listOf()), listOf(1L))
+                .createUpdates(repos, provider)
+        }
     }
 
     @Test

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class RevertCreateNodeActionTest {
     private lateinit var repos: MapDataRepository
@@ -43,13 +44,16 @@ class RevertCreateNodeActionTest {
         assertEquals(node, deletedNode)
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node already deleted`() {
         on(repos.getNode(1)).thenReturn(null)
-        RevertCreateNodeAction(node(1), listOf()).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            RevertCreateNodeAction(node(1), listOf()).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node is now member of a relation`() {
         val node = node(1)
 
@@ -57,10 +61,12 @@ class RevertCreateNodeActionTest {
         on(repos.getWaysForNode(1)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1)).thenReturn(listOf(rel()))
 
-        RevertCreateNodeAction(node, listOf()).createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            RevertCreateNodeAction(node, listOf()).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node is part of more ways than initially`() {
         val node = node(1)
 
@@ -68,10 +74,12 @@ class RevertCreateNodeActionTest {
         on(repos.getWaysForNode(1)).thenReturn(listOf(way(1), way(2), way(3)))
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        RevertCreateNodeAction(node, listOf(1, 2)).createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            RevertCreateNodeAction(node, listOf(1, 2)).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when node was moved at all`() {
         val node = node(1)
         val movedNode = node.copy(position = node.position.translate(10.0, 0.0))
@@ -80,10 +88,12 @@ class RevertCreateNodeActionTest {
         on(repos.getWaysForNode(1)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        RevertCreateNodeAction(node).createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            RevertCreateNodeAction(node).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict when tags changed on node at all`() {
         val node = node(1)
 
@@ -91,7 +101,9 @@ class RevertCreateNodeActionTest {
         on(repos.getWaysForNode(1)).thenReturn(emptyList())
         on(repos.getRelationsForNode(1)).thenReturn(emptyList())
 
-        RevertCreateNodeAction(node).createUpdates(repos, provider)
+        assertFailsWith<ConflictException> {
+            RevertCreateNodeAction(node).createUpdates(repos, provider)
+        }
     }
 
     @Test

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class DeletePoiNodeActionTest {
 
@@ -46,10 +47,13 @@ class DeletePoiNodeActionTest {
         assertTrue(data.modifications.single().tags.isEmpty())
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `moved element creates conflict`() {
         on(repos.getNode(e.id)).thenReturn(e.copy(position = p(1.0, 1.0)))
-        DeletePoiNodeAction(e).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            DeletePoiNodeAction(e).createUpdates(repos, provider)
+        }
     }
 
     @Test fun idsUpdatesApplied() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
@@ -12,6 +12,7 @@ import de.westnordost.streetcomplete.util.ktx.copy
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class RevertDeletePoiNodeActionTest {
 
@@ -51,11 +52,14 @@ class RevertDeletePoiNodeActionTest {
         )
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if there is already a newer version`() {
         on(repos.getNode(1)).thenReturn(e.copy(version = 4))
-        // version 3 would be the deletion
-        RevertDeletePoiNodeAction(e).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            // version 3 would be the deletion
+            RevertDeletePoiNodeAction(e).createUpdates(repos, provider)
+        }
     }
 
     @Test fun idsUpdatesApplied() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.reset
+import kotlin.test.assertFailsWith
 
 class SplitWayActionTest {
 
@@ -67,60 +68,84 @@ class SplitWayActionTest {
         updateRepos(way)
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if less than two split positions on closed way`() {
         way = way(0, mutableListOf(0, 1, 2, 0))
-        doSplit(SplitAtPoint(p[1]))
+
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtPoint(p[1]))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if way was deleted`() {
         on(repos.getWayComplete(0)).thenReturn(null)
-        doSplit(SplitAtPoint(p[1]))
+
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtPoint(p[1]))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if updated way was cut at the start`() {
         way = way(0, mutableListOf(1, 2, 3))
         val originalWay = way(0, mutableListOf(0, 1, 2, 3))
-        doSplit(split, originalWay = originalWay)
+
+        assertFailsWith<ConflictException> {
+            doSplit(split, originalWay = originalWay)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if updated way was cut at the end`() {
         way = way(0, mutableListOf(0, 1, 2))
         val originalWay = way(0, mutableListOf(0, 1, 2, 3))
-        doSplit(split, originalWay = originalWay)
+
+        assertFailsWith<ConflictException> {
+            doSplit(split, originalWay = originalWay)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if way has split position at its very start`() {
-        doSplit(SplitAtPoint(p[0]))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtPoint(p[0]))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if way has split position at its very end`() {
-        doSplit(SplitAtPoint(p[3]))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtPoint(p[3]))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if first split point of line split is not in the way`() {
-        doSplit(SplitAtLinePosition(outsidePoints[0], p[1], 0.5))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtLinePosition(outsidePoints[0], p[1], 0.5))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if second split point of line split is not in the way`() {
-        doSplit(SplitAtLinePosition(p[1], outsidePoints[0], 0.5))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtLinePosition(p[1], outsidePoints[0], 0.5))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if split point of point split is not in the way`() {
-        doSplit(SplitAtPoint(outsidePoints[0]))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtPoint(outsidePoints[0]))
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `raise conflict if the second node is not directly after the first one in the updated way`() {
-        doSplit(SplitAtLinePosition(p[0], p[2], 0.3))
+        assertFailsWith<ConflictException> {
+            doSplit(SplitAtLinePosition(p[0], p[2], 0.3))
+        }
     }
 
     @Test fun `find node to split at from several alternatives`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/RevertUpdateElementTagsActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/RevertUpdateElementTagsActionTest.kt
@@ -14,6 +14,7 @@ import de.westnordost.streetcomplete.testutils.way
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class RevertUpdateElementTagsActionTest {
 
@@ -26,23 +27,29 @@ class RevertUpdateElementTagsActionTest {
         provider = mock()
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if node moved too much`() {
         on(repos.get(ElementType.NODE, 1)).thenReturn(node(1, p(1.0, 0.0)))
-        RevertUpdateElementTagsAction(
-            node(1, p(0.0, 0.0)),
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            RevertUpdateElementTagsAction(
+                node(1, p(0.0, 0.0)),
+                StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+            ).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if changes are not applicable`() {
         val w = way(1, listOf(1, 2, 3), mutableMapOf("highway" to "residential"))
         on(repos.get(ElementType.WAY, 1)).thenReturn(w)
-        RevertUpdateElementTagsAction(
-            w,
-            StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
-        ).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            RevertUpdateElementTagsAction(
+                w,
+                StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
+            ).createUpdates(repos, provider)
+        }
     }
 
     @Test fun `apply changes`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.verify
+import kotlin.test.assertFailsWith
 
 class StringMapChangesTest {
 
@@ -59,7 +60,7 @@ class StringMapChangesTest {
         verify(change2, atLeastOnce()).conflictsWith(someMap)
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test
     fun `applying with conflict fails`() {
         val someMap = mutableMapOf<String, String>()
 
@@ -68,7 +69,9 @@ class StringMapChangesTest {
 
         val changes = StringMapChanges(listOf(conflict))
 
-        changes.applyTo(someMap)
+        assertFailsWith<IllegalStateException> {
+            changes.applyTo(someMap)
+        }
     }
 
     @Test fun getConflicts() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
@@ -14,6 +14,7 @@ import de.westnordost.streetcomplete.testutils.way
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class UpdateElementTagsActionTest {
 
@@ -25,23 +26,29 @@ class UpdateElementTagsActionTest {
         provider = mock()
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if node moved too much`() {
         on(repos.get(NODE, 1)).thenReturn(node(1, p(1.0, 0.0)))
-        UpdateElementTagsAction(
-            node(1, p(0.0, 0.0)),
-            StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
-        ).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            UpdateElementTagsAction(
+                node(1, p(0.0, 0.0)),
+                StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+            ).createUpdates(repos, provider)
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `conflict if changes are not applicable`() {
         val w = way(1, listOf(1, 2, 3), mutableMapOf("highway" to "residential"))
         on(repos.get(WAY, 1)).thenReturn(w)
-        UpdateElementTagsAction(
-            w,
-            StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
-        ).createUpdates(repos, provider)
+
+        assertFailsWith<ConflictException> {
+            UpdateElementTagsAction(
+                w,
+                StringMapChanges(listOf(StringMapEntryAdd("highway", "living_street")))
+            ).createUpdates(repos, provider)
+        }
     }
 
     @Test fun `apply changes`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
@@ -15,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.doThrow
+import kotlin.test.assertFailsWith
 
 class ElementEditUploaderTest {
 
@@ -31,17 +32,20 @@ class ElementEditUploaderTest {
         uploader = ElementEditUploader(changesetManager, mapDataApi, mapDataController)
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `passes on conflict exception`() {
         val edit: ElementEdit = mock()
         val action: ElementEditAction = mock()
         on(edit.action).thenReturn(action)
         on(action.createUpdates(any(), any())).thenReturn(MapDataChanges())
         on(mapDataApi.uploadChanges(anyLong(), any(), any())).thenThrow(ConflictException())
-        uploader.upload(edit, { mock() })
+
+        assertFailsWith<ConflictException> {
+            uploader.upload(edit, { mock() })
+        }
     }
 
-    @Test(expected = ConflictException::class)
+    @Test
     fun `passes on element conflict exception`() {
         val edit: ElementEdit = mock()
         val action: ElementEditAction = mock()
@@ -52,9 +56,10 @@ class ElementEditUploaderTest {
         on(changesetManager.createChangeset(any(), any())).thenReturn(1)
         on(mapDataApi.uploadChanges(anyLong(), any(), any()))
             .thenThrow(ConflictException())
-            .thenThrow(ConflictException())
 
-        uploader.upload(edit, { mock() })
+        assertFailsWith<ConflictException> {
+            uploader.upload(edit, { mock() })
+        }
     }
 
     @Test fun `handles changeset conflict exception`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.osm.cycleway.Direction.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class CyclewayCreatorKtTest {
 
@@ -766,14 +767,18 @@ class CyclewayCreatorKtTest {
         )
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying invalid left throws exception`() {
-        cycleway(INVALID, null).applyTo(StringMapChangesBuilder(mapOf()), false)
+        assertFailsWith<IllegalArgumentException> {
+            cycleway(INVALID, null).applyTo(StringMapChangesBuilder(mapOf()), false)
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying invalid right throws exception`() {
-        cycleway(null, INVALID).applyTo(StringMapChangesBuilder(mapOf()), false)
+        assertFailsWith<IllegalArgumentException> {
+            cycleway(null, INVALID).applyTo(StringMapChangesBuilder(mapOf()), false)
+        }
     }
 }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.osm.lit.LitStatus.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class LitStatusKtTest {
 
@@ -19,9 +20,11 @@ class LitStatusKtTest {
         verifyAnswer(mapOf(), NIGHT_AND_DAY, arrayOf(StringMapEntryAdd("lit", "24/7")))
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying invalid throws exception`() {
-        UNSUPPORTED.applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            UNSUPPORTED.applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 
     @Test fun `apply updates check date`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/NumberSystemTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/NumberSystemTest.kt
@@ -3,10 +3,14 @@ package de.westnordost.streetcomplete.osm.opening_hours.model
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class NumberSystemTest {
-    @Test(expected = IllegalArgumentException::class) fun `illegal arguments`() {
-        NumberSystem(10, 3)
+    @Test
+    fun `illegal arguments`() {
+        assertFailsWith<IllegalArgumentException> {
+            NumberSystem(10, 3)
+        }
     }
 
     @Test fun getSize() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class SidewalkCreatorKtTest {
     @Test fun `apply nothing applies nothing`() {
@@ -248,14 +249,18 @@ class SidewalkCreatorKtTest {
         )
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying invalid left throws exception`() {
-        LeftAndRightSidewalk(Sidewalk.INVALID, null).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightSidewalk(Sidewalk.INVALID, null).applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying invalid right throws exception`() {
-        LeftAndRightSidewalk(null, Sidewalk.INVALID).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightSidewalk(null, Sidewalk.INVALID).applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.*
 import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.*
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class StreetParkingCreatorKtTest {
 
@@ -547,24 +548,37 @@ class StreetParkingCreatorKtTest {
         )
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying incomplete left throws exception`() {
-        LeftAndRightStreetParking(IncompleteStreetParking, null).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightStreetParking(IncompleteStreetParking,null)
+                .applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying incomplete right throws exception`() {
-        LeftAndRightStreetParking(null, IncompleteStreetParking).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightStreetParking(null, IncompleteStreetParking)
+                .applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying unknown left throws exception`() {
-        LeftAndRightStreetParking(UnknownStreetParking, null).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightStreetParking(UnknownStreetParking, null)
+                .applyTo(StringMapChangesBuilder(mapOf())
+            )
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `applying unknown right throws exception`() {
-        LeftAndRightStreetParking(null, UnknownStreetParking).applyTo(StringMapChangesBuilder(mapOf()))
+        assertFailsWith<IllegalArgumentException> {
+            LeftAndRightStreetParking(null, UnknownStreetParking)
+                .applyTo(StringMapChangesBuilder(mapOf()))
+        }
     }
 }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class CollectionsTest {
 
@@ -21,14 +22,18 @@ class CollectionsTest {
         assertNull(listOf<Int>().findNext(0) { true })
     }
 
-    @Test(expected = IndexOutOfBoundsException::class)
+    @Test
     fun `findNext throws if out of bounds index`() {
-        assertNull(listOf(1, 2, 3).findNext(4) { true })
+        assertFailsWith<IndexOutOfBoundsException> {
+            listOf(1, 2, 3).findNext(4) { true }
+        }
     }
 
-    @Test(expected = IndexOutOfBoundsException::class)
+    @Test
     fun `findNext throws if negative index`() {
-        assertNull(listOf(1, 2, 3).findNext(-1) { true })
+        assertFailsWith<IndexOutOfBoundsException> {
+            listOf(1, 2, 3).findNext(-1) { true }
+        }
     }
 
     @Test fun `findPrevious starts at index exclusive`() {
@@ -43,14 +48,18 @@ class CollectionsTest {
         assertNull(listOf<Int>().findPrevious(0) { true })
     }
 
-    @Test(expected = IndexOutOfBoundsException::class)
+    @Test
     fun `findPrevious throws if out of bounds index`() {
-        assertNull(listOf(1, 2, 3).findPrevious(4) { true })
+        assertFailsWith<IndexOutOfBoundsException> {
+            listOf(1, 2, 3).findPrevious(4) { true }
+        }
     }
 
-    @Test(expected = IndexOutOfBoundsException::class)
+    @Test
     fun `findPrevious throws if negative index`() {
-        assertNull(listOf(1, 2, 3).findPrevious(-1) { true })
+        assertFailsWith<IndexOutOfBoundsException> {
+            listOf(1, 2, 3).findPrevious(-1) { true }
+        }
     }
 
     @Test fun `asSequenceOfPairs with empty list`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/util/math/SphericalEarthMathTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/math/SphericalEarthMathTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+import kotlin.test.assertFailsWith
 
 class SphericalEarthMathTest {
 
@@ -327,9 +328,11 @@ class SphericalEarthMathTest {
         assertTrue(bbox.crosses180thMeridian)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `enclosingbbox fails for empty line`() {
-        listOf<LatLon>().enclosingBoundingBox()
+        assertFailsWith<IllegalArgumentException> {
+            listOf<LatLon>().enclosingBoundingBox()
+        }
     }
 
     @Test fun `enclosingbbox for points`() {
@@ -369,9 +372,11 @@ class SphericalEarthMathTest {
 
     //region centerLineOfPolyline
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `centerLineOfPolyline for point fails`() {
-        listOf(p(0.0, 0.0)).centerLineOfPolyline()
+        assertFailsWith<IllegalArgumentException> {
+            listOf(p(0.0, 0.0)).centerLineOfPolyline()
+        }
     }
 
     @Test fun `centerLineOfPolyline for a line with zero length`() {
@@ -407,9 +412,11 @@ class SphericalEarthMathTest {
 
     //region centerPointOfPolyline
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `centerPointOfPolyline fails for empty list`() {
-        listOf<LatLon>().centerPointOfPolyline()
+        assertFailsWith<IllegalArgumentException> {
+            listOf<LatLon>().centerPointOfPolyline()
+        }
     }
 
     @Test fun `centerPointOfPolyline for line with zero length`() {
@@ -483,9 +490,11 @@ class SphericalEarthMathTest {
 
     //region isRingDefinedClockwise
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `isRingDefinedClockwise for empty list fails`() {
-        emptyList<LatLon>().isRingDefinedClockwise()
+        assertFailsWith<IllegalArgumentException> {
+            emptyList<LatLon>().isRingDefinedClockwise()
+        }
     }
 
     @Test fun isRingDefinedClockwise() {
@@ -504,14 +513,18 @@ class SphericalEarthMathTest {
 
     //region intersectsWith
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `intersectsWith requires line`() {
-        listOf(p(0.0, 0.0)).intersectsWith(listOf(p(1.0, 0.0), p(0.0, 1.0)))
+        assertFailsWith<IllegalArgumentException> {
+            listOf(p(0.0, 0.0)).intersectsWith(listOf(p(1.0, 0.0), p(0.0, 1.0)))
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `intersectsWith requires line for the parameter too`() {
-        listOf(p(1.0, 0.0), p(0.0, 1.0)).intersectsWith(listOf(p(0.0, 0.0)))
+        assertFailsWith<IllegalArgumentException> {
+            listOf(p(1.0, 0.0), p(0.0, 1.0)).intersectsWith(listOf(p(0.0, 0.0)))
+        }
     }
 
     @Test fun `intersectsWith finds intersection`() {
@@ -640,9 +653,11 @@ class SphericalEarthMathTest {
 
     //region centerPointOfPolygon
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `centerPointOfPolygon for empty polygon fails`() {
-        listOf<LatLon>().centerPointOfPolygon()
+        assertFailsWith<IllegalArgumentException> {
+            listOf<LatLon>().centerPointOfPolygon()
+        }
     }
 
     @Test fun `centerPointOfPolygon with no area simply returns first point`() {


### PR DESCRIPTION
As promised in https://github.com/streetcomplete/StreetComplete/pull/5193#issuecomment-1678464000
> > > Other than that, some classes use `@Test(expected = <ExceptionClass>::class)`. Should this also be replaced?
> > 
> > 
> > Oh yeah, I'd like that! Not required for this PR to be merged, though. Never liked that API. I think they also corrected that awkward API in JUnit 5. (But if we migrate, we rather migrate fully to `kotlin.test` rather than Junit 5).
> > If you do that, consider whether it makes sense to group such test functions into one test function (i.e. they were only really in separate functions because of that API before).
> 
> I will do this in another PR.


