### PR TITLE
Fix element highlighting in amenity_coverage

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -246,7 +246,7 @@ fun questTypeRegistry(
     9 to AddCarWashType(),
 
     10 to AddBenchBackrest(),
-    11 to AddAmenityCover(),
+    11 to AddAmenityCover(featureDictionaryFuture),
 
     12 to AddBridgeStructure(),
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_cover/AddAmenityCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_cover/AddAmenityCover.kt
@@ -1,26 +1,30 @@
 package de.westnordost.streetcomplete.quests.amenity_cover
 
+import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
-import de.westnordost.streetcomplete.data.osm.mapdata.filter
-import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
+import java.util.concurrent.FutureTask
 
-class AddAmenityCover : OsmFilterQuestType<Boolean>() {
+class AddAmenityCover (
+    private val featureDictionaryFuture: FutureTask<FeatureDictionary>
+) : OsmElementQuestType<Boolean> {
 
-    override val elementFilter = """
+    private val nodesFilter by lazy { """
         nodes with
           (leisure = picnic_table
            or amenity = bbq)
           and access !~ private|no
           and !covered
           and (!seasonal or seasonal = no)
-    """
+    """.toElementFilterExpression() }
     override val changesetComment = "Specify whether various amenities are covered"
     override val wikiLink = "Key:covered"
     override val icon = R.drawable.ic_quest_picnic_table_cover
@@ -28,9 +32,26 @@ class AddAmenityCover : OsmFilterQuestType<Boolean>() {
     override val achievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_amenityCover_title
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
+        mapData.filter { isApplicableTo(it) }
 
-    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().filter("nodes with leisure = picnic_table")
+    override fun isApplicableTo(element: Element) =
+        nodesFilter.matches(element) && hasAnyName(element.tags)
+
+    private fun hasAnyName(tags: Map<String, String>): Boolean =
+        featureDictionaryFuture.get().byTags(tags).isSuggestion(false).find().isNotEmpty()
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry): Sequence<Element> {
+        /* put markers for objects that are exactly the same as for which this quest is asking for
+           e.g. it's a ticket validator? -> display other ticket validators. Etc. */
+        val feature = featureDictionaryFuture.get()
+            .byTags(element.tags)
+            .isSuggestion(false) // not brands
+            .find()
+            .firstOrNull() ?: return emptySequence()
+
+        return getMapData().filter { it.tags.containsAll(feature.tags) }.asSequence()
+    }
 
     override fun createForm() = YesNoQuestForm()
 
@@ -38,3 +59,5 @@ class AddAmenityCover : OsmFilterQuestType<Boolean>() {
         tags["covered"] = answer.toYesNo()
     }
 }
+
+private fun <X, Y> Map<X, Y>.containsAll(other: Map<X, Y>) = other.all { this[it.key] == it.value }


### PR DESCRIPTION
In the AddAmenityCover-Task,

it is asked for coverage of various amenitys (picnic_table,bbq, maybe more in the future), but the getHighlightedElements(..) was still hardcoded to highlight picnic_tables, but should highlight elements of the same type than surveyed to avoid misunderstandings, which element should be checked.

This was mostly copy&paste from the logik used in the CheckExistence-quest.