### PR TITLE
Use kotlin.test instead of JUnit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,7 +110,6 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 
     // tests
-    testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.mockito:mockito-inline:$mockitoVersion")
     testImplementation("org.assertj:assertj-core:3.23.1")

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/ApplicationDbTestCase.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/ApplicationDbTestCase.kt
@@ -2,16 +2,16 @@ package de.westnordost.streetcomplete.data
 
 import android.database.sqlite.SQLiteOpenHelper
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.After
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 open class ApplicationDbTestCase {
     protected lateinit var dbHelper: SQLiteOpenHelper
     protected lateinit var database: Database
 
-    @Before fun setUpHelper() {
+    @BeforeTest fun setUpHelper() {
         dbHelper = StreetCompleteSQLiteOpenHelper(
             InstrumentationRegistry.getInstrumentation().targetContext,
             DATABASE_NAME
@@ -20,10 +20,10 @@ open class ApplicationDbTestCase {
     }
 
     @Test fun databaseAvailable() {
-        Assert.assertNotNull(dbHelper.readableDatabase)
+        assertNotNull(dbHelper.readableDatabase)
     }
 
-    @After fun tearDownHelper() {
+    @AfterTest fun tearDownHelper() {
         dbHelper.close()
         InstrumentationRegistry.getInstrumentation().targetContext
             .deleteDatabase(DATABASE_NAME)

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesDaoTest.kt
@@ -3,16 +3,16 @@ package de.westnordost.streetcomplete.data.download.tiles
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DownloadedTilesDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: DownloadedTilesDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = DownloadedTilesDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/meta/CountryInfosTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/meta/CountryInfosTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.meta
 
 import androidx.test.platform.app.InstrumentationRegistry
 import de.westnordost.streetcomplete.osm.opening_hours.model.Weekdays.Companion.getWeekdayIndex
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class CountryInfosTest {
     private val validWeekdays = listOf("Mo", "Tu", "We", "Th", "Fr", "Sa", "Su")

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/created_elements/CreatedElementsDaoTest.kt
@@ -3,15 +3,15 @@ package de.westnordost.streetcomplete.data.osm.created_elements
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class CreatedElementsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: CreatedElementsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = CreatedElementsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
@@ -4,14 +4,14 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class EditElementsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: EditElementsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = EditElementsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
@@ -29,18 +29,18 @@ import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
 import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.Style
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ElementEditsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: ElementEditsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         val list = listOf(1 to TEST_QUEST_TYPE, 2 to TEST_QUEST_TYPE2)
         val list2 = listOf(1 to TestOverlay)
         dao = ElementEditsDao(database, QuestTypeRegistry(list), OverlayRegistry(list2))

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementIdProviderDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementIdProviderDaoTest.kt
@@ -4,16 +4,16 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementIdUpdate
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class ElementIdProviderDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: ElementIdProviderDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = ElementIdProviderDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenChangesetsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenChangesetsDaoTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.osm.edits.upload.changesets
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class OpenChangesetsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: OpenChangesetsDao
@@ -15,7 +15,7 @@ class OpenChangesetsDaoTest : ApplicationDbTestCase() {
     private val P = "Brasliweks"
     private val SOURCE = "test"
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = OpenChangesetsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryDaoTest.kt
@@ -7,18 +7,18 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.NodeDao
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ElementGeometryDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: ElementGeometryDao
     private lateinit var nodeDao: NodeDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         nodeDao = NodeDao(database)
         val relationGeometryDao = RelationGeometryDao(database, PolylinesSerializer())
         val wayGeometryDao = WayGeometryDao(database, PolylinesSerializer())

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/RelationGeometryDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/RelationGeometryDaoTest.kt
@@ -4,18 +4,18 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RelationGeometryDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: RelationGeometryDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = RelationGeometryDao(database, PolylinesSerializer())
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/WayGeometryDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/geometry/WayGeometryDaoTest.kt
@@ -4,18 +4,18 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class WayGeometryDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: WayGeometryDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = WayGeometryDao(database, PolylinesSerializer())
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/NodeDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/NodeDaoTest.kt
@@ -3,18 +3,18 @@ package de.westnordost.streetcomplete.data.osm.mapdata
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NodeDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: NodeDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = NodeDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/RelationDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/RelationDaoTest.kt
@@ -6,18 +6,18 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.RELATION
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.WAY
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RelationDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: RelationDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = RelationDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/WayDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/mapdata/WayDaoTest.kt
@@ -3,18 +3,18 @@ package de.westnordost.streetcomplete.data.osm.mapdata
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class WayDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: WayDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = WayDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
@@ -6,17 +6,17 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class OsmQuestDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: OsmQuestDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = OsmQuestDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
@@ -7,16 +7,16 @@ import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: OsmQuestsHiddenDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = OsmQuestsHiddenDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/NoteDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/NoteDaoTest.kt
@@ -6,18 +6,18 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.user.User
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NoteDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: NoteDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = NoteDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsDaoTest.kt
@@ -4,18 +4,18 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmtracks.Trackpoint
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NoteEditsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: NoteEditsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = NoteEditsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenDaoTest.kt
@@ -5,16 +5,16 @@ import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NoteQuestsHiddenDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: NoteQuestsHiddenDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = NoteQuestsHiddenDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDaoTest.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class UserAchievementsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: UserAchievementsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = UserAchievementsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserLinksDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserLinksDaoTest.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class UserLinksDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: UserLinksDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = UserLinksDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/ActiveDatesDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/ActiveDatesDaoTest.kt
@@ -5,14 +5,14 @@ import de.westnordost.streetcomplete.util.ktx.systemTimeNow
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ActiveDatesDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: ActiveDatesDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = ActiveDatesDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/CountryStatisticsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/CountryStatisticsDaoTest.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.user.statistics
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class CountryStatisticsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: CountryStatisticsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = CountryStatisticsDao(database, CountryStatisticsTables.NAME)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDaoTest.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.user.statistics
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class EditTypeStatisticsDaoTest : ApplicationDbTestCase() {
     private lateinit var daoType: EditTypeStatisticsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         daoType = EditTypeStatisticsDao(database, EditTypeStatisticsTables.NAME)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetsDaoTest.kt
@@ -1,16 +1,16 @@
 package de.westnordost.streetcomplete.data.visiblequests
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class QuestPresetsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: QuestPresetsDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = QuestPresetsDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderDaoTest.kt
@@ -1,15 +1,15 @@
 package de.westnordost.streetcomplete.data.visiblequests
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class QuestTypeOrderDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: QuestTypeOrderDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = QuestTypeOrderDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeDaoTest.kt
@@ -1,16 +1,16 @@
 package de.westnordost.streetcomplete.data.visiblequests
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class VisibleQuestTypeDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: VisibleQuestTypeDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = VisibleQuestTypeDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceLabelTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceLabelTest.kt
@@ -8,10 +8,10 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.util.getNameAndLocationLabel
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.util.Locale
 import java.util.concurrent.FutureTask
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class CheckExistenceLabelTest {
     private var featureDictionaryFuture: FutureTask<FeatureDictionary>

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/TrafficFlowSegmentsApiTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/TrafficFlowSegmentsApiTest.kt
@@ -6,8 +6,8 @@ import de.westnordost.streetcomplete.quests.oneway_suspects.data.ONEWAY_API_URL
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegment
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegmentsApi
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class TrafficFlowSegmentsApiTest {
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/WayTrafficFlowDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/WayTrafficFlowDaoTest.kt
@@ -4,17 +4,17 @@ import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.WayDao
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.WayTrafficFlowDao
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class WayTrafficFlowDaoTest : ApplicationDbTestCase() {
 
     private lateinit var dao: WayTrafficFlowDao
 
-    @Before fun createDao() {
+    @BeforeTest fun createDao() {
         dao = WayTrafficFlowDao(database)
     }
 

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/util/ktx/SQLiteDatabaseKtTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/util/ktx/SQLiteDatabaseKtTest.kt
@@ -1,16 +1,16 @@
 package de.westnordost.streetcomplete.util.ktx
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
-import org.junit.After
-import org.junit.Before
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 
 class SQLiteDatabaseKtTest : ApplicationDbTestCase() {
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         dbHelper.writableDatabase.execSQL("CREATE TABLE t (a int, b int)")
     }
 
-    @After fun tearDown() {
+    @AfterTest fun tearDown() {
         dbHelper.writableDatabase.execSQL("DROP TABLE t")
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/ObjectTypeRegistryTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/ObjectTypeRegistryTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class ObjectTypeRegistryTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesControllerTest.kt
@@ -3,11 +3,12 @@ package de.westnordost.streetcomplete.data.download.tiles
 import de.westnordost.streetcomplete.testutils.eq
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.anyLong
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DownloadedTilesControllerTest {
 
@@ -15,7 +16,7 @@ class DownloadedTilesControllerTest {
     private lateinit var listener: DownloadedTilesSource.Listener
     private lateinit var ctrl: DownloadedTilesController
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         dao = mock()
         listener = mock()
         ctrl = DownloadedTilesController(dao)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/TilesRectTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/download/tiles/TilesRectTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.download.tiles
 
 import de.westnordost.streetcomplete.testutils.bbox
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TilesRectTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/edithistory/EditHistoryControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/edithistory/EditHistoryControllerTest.kt
@@ -17,11 +17,11 @@ import de.westnordost.streetcomplete.testutils.noteEdit
 import de.westnordost.streetcomplete.testutils.noteQuestHidden
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.questHidden
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class EditHistoryControllerTest {
 
@@ -37,7 +37,7 @@ class EditHistoryControllerTest {
     private lateinit var hideNoteQuestsListener: OsmNoteQuestController.HideOsmNoteQuestListener
     private lateinit var hideQuestsListener: OsmQuestController.HideOsmQuestListener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         elementEditsController = mock()
         noteEditsController = mock()
         osmQuestController = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionBuilderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionBuilderTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.elementfilter
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class BooleanExpressionBuilderTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/BooleanExpressionTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.data.elementfilter
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class BooleanExpressionTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpressionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpressionTest.kt
@@ -5,9 +5,9 @@ import de.westnordost.streetcomplete.data.elementfilter.filters.NotHasKey
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ElementFilterExpressionTest {
     private val node = node()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParserAndOverpassQueryCreatorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParserAndOverpassQueryCreatorTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.data.elementfilter
 
 import de.westnordost.streetcomplete.osm.toCheckDateString
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /** Integration test for the filter parser, filter expression and creator, the whole way from
  *  parsing the tag filters expression to returning it as a OQL string. More convenient this way

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParserTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParserTest.kt
@@ -3,10 +3,10 @@ package de.westnordost.streetcomplete.data.elementfilter
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ElementFiltersParserTest {
     @Test fun `fail if no space after or before and or`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/NumberWithUnitParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/NumberWithUnitParserKtTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.data.elementfilter
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class NumberWithUnitParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/StringWithCursorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/StringWithCursorTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.elementfilter
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class StringWithCursorTest {
     @Test fun advance() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/CombineFiltersTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/CombineFiltersTest.kt
@@ -4,9 +4,9 @@ import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CombineFiltersTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementFilterOverpassKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementFilterOverpassKtTest.kt
@@ -3,8 +3,8 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 import de.westnordost.streetcomplete.data.elementfilter.dateDaysAgo
 import de.westnordost.streetcomplete.osm.toCheckDateString
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ElementFilterOverpassKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementNewerThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementNewerThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.dateDaysAgo
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ElementNewerThanTest {
     val c = ElementNewerThan(RelativeDate(-10f))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementOlderThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementOlderThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.dateDaysAgo
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ElementOlderThanTest {
     val c = ElementOlderThan(RelativeDate(-10f))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasDateTagGreaterOrEqualThanTest {
     private val date = LocalDate(2000, 11, 11)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasDateTagGreaterThanTest {
     private val date = LocalDate(2000, 11, 11)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasDateTagLessOrEqualThanTest {
     private val date = LocalDate(2000, 11, 11)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThanTest.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasDateTagLessThanTest {
     private val date = LocalDate(2000, 11, 11)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasKeyLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasKeyLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasKeyLikeTest {
     private val key = HasKeyLike("n.[ms]e")

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasKeyTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasKeyTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasKeyTest {
     private val key = HasKey("name")

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagGreaterOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagGreaterOrEqualThanTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagGreaterOrEqualThanTest {
     private val c = HasTagGreaterOrEqualThan("width", 3.5f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagGreaterThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagGreaterThanTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagGreaterThanTest {
     val c = HasTagGreaterThan("width", 3.5f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLessOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLessOrEqualThanTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagLessOrEqualThanTest {
     val c = HasTagLessOrEqualThan("width", 3.5f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLessThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLessThanTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagLessThanTest {
     val c = HasTagLessThan("width", 3.5f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagLikeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagTest {
     val c = HasTag("highway", "residential")

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagValueLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasTagValueLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HasTagValueLikeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasKeyLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasKeyLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotHasKeyLikeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasKeyTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasKeyTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotHasKeyTest {
     val c = NotHasKey("name")

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotHasTagLikeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotHasTagTest {
     val c = NotHasTag("highway", "residential")

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagValueLikeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/NotHasTagValueLikeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.elementfilter.matches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotHasTagValueLikeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/RegexOrSetTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/RegexOrSetTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class RegexOrSetTest {
     @Test fun pipesMatch() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagNewerThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagNewerThanTest.kt
@@ -3,10 +3,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 import de.westnordost.streetcomplete.data.elementfilter.dateDaysAgo
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import de.westnordost.streetcomplete.osm.toCheckDateString
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TagNewerThanTest {
     private val oldDate = dateDaysAgo(101f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThanTest.kt
@@ -3,10 +3,10 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 import de.westnordost.streetcomplete.data.elementfilter.dateDaysAgo
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import de.westnordost.streetcomplete.osm.toCheckDateString
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TagOlderThanTest {
     private val oldDate = dateDaysAgo(101f)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/meta/AbbreviationsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/meta/AbbreviationsTest.kt
@@ -1,11 +1,11 @@
 package de.westnordost.streetcomplete.data.meta
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class AbbreviationsTest {
     @Test fun `removes abbreviation dot`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
@@ -14,10 +14,10 @@ import de.westnordost.streetcomplete.osm.updateCheckDateForKey
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ResurveyUtilsTest {
     @Test fun toCheckDateString() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsControllerTest.kt
@@ -18,10 +18,10 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class ElementEditsControllerTest {
 
@@ -32,7 +32,7 @@ class ElementEditsControllerTest {
     private lateinit var lastEditTimeStore: LastEditTimeStore
     private lateinit var idProvider: ElementIdProviderDao
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         db = mock()
         on(db.delete(anyLong())).thenReturn(true)
         on(db.markSynced(anyLong())).thenReturn(true)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -31,15 +31,15 @@ import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.math.intersect
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.verifyNoMoreInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class MapDataWithEditsSourceTest {
 
@@ -52,7 +52,7 @@ class MapDataWithEditsSourceTest {
     private lateinit var editsListener: ElementEditsSource.Listener
     private lateinit var mapDataListener: MapDataController.Listener
 
-    @Before
+    @BeforeTest
     fun setUp() {
         editsCtrl = mock()
         mapDataCtrl = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeActionTest.kt
@@ -14,18 +14,18 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 internal class CreateNodeActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before
+    @BeforeTest
     fun setUp() {
         repos = mock()
         provider = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeFromVertexActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/CreateNodeFromVertexActionTest.kt
@@ -14,16 +14,16 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.math.translate
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class CreateNodeFromVertexActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before
+    @BeforeTest
     fun setUp() {
         repos = mock()
         provider = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/create/RevertCreateNodeActionTest.kt
@@ -14,18 +14,18 @@ import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.math.translate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class RevertCreateNodeActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before
+    @BeforeTest
     fun setUp() {
         repos = mock()
         provider = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/DeletePoiNodeActionTest.kt
@@ -9,11 +9,11 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class DeletePoiNodeActionTest {
 
@@ -22,7 +22,7 @@ class DeletePoiNodeActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         repos = mock()
         provider = mock()
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/delete/RevertDeletePoiNodeActionTest.kt
@@ -9,9 +9,9 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.util.ktx.copy
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class RevertDeletePoiNodeActionTest {
@@ -21,7 +21,7 @@ class RevertDeletePoiNodeActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before
+    @BeforeTest
     fun setUp() {
         repos = mock()
         provider = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/move/MoveNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/move/MoveNodeActionTest.kt
@@ -9,17 +9,17 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.util.ktx.copy
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MoveNodeActionTest {
 
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         repos = mock()
         provider = mock()
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/move/RevertMoveNodeActionTest.kt
@@ -9,17 +9,17 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.util.ktx.copy
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class RevertMoveNodeActionTest {
 
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         repos = mock()
         provider = mock()
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
@@ -20,12 +20,12 @@ import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.testutils.waysAsMembers
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.math.createTranslated
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.reset
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class SplitWayActionTest {
 
@@ -63,7 +63,7 @@ class SplitWayActionTest {
         on(repos.getRelationsForWay(0)).thenReturn(listOf())
     }
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         reset(repos)
         updateRepos(way)
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/RevertUpdateElementTagsActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/RevertUpdateElementTagsActionTest.kt
@@ -11,9 +11,9 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class RevertUpdateElementTagsActionTest {
@@ -21,7 +21,7 @@ class RevertUpdateElementTagsActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before
+    @BeforeTest
     fun setUp() {
         repos = mock()
         provider = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/SpatialPartsOfElementKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/SpatialPartsOfElementKtTest.kt
@@ -7,8 +7,8 @@ import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.math.translate
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 internal class SpatialPartsOfElementKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesBuilderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesBuilderTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class StringMapChangesBuilderTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapChangesTest.kt
@@ -2,13 +2,13 @@ package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class StringMapChangesTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryAddTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryAddTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class StringMapEntryAddTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryDeleteTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryDeleteTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class StringMapEntryDeleteTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryModifyTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryModifyTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.osm.edits.update_tags
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class StringMapEntryModifyTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementTagsActionTest.kt
@@ -11,9 +11,9 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class UpdateElementTagsActionTest {
@@ -21,7 +21,7 @@ class UpdateElementTagsActionTest {
     private lateinit var repos: MapDataRepository
     private lateinit var provider: ElementIdProvider
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         repos = mock()
         provider = mock()
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploaderTest.kt
@@ -11,10 +11,10 @@ import de.westnordost.streetcomplete.data.upload.ConflictException
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.doThrow
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class ElementEditUploaderTest {
@@ -24,7 +24,7 @@ class ElementEditUploaderTest {
     private lateinit var mapDataController: MapDataController
     private lateinit var uploader: ElementEditUploader
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         changesetManager = mock()
         mapDataApi = mock()
         mapDataController = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploaderTest.kt
@@ -20,10 +20,10 @@ import de.westnordost.streetcomplete.testutils.on
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class ElementEditsUploaderTest {
 
@@ -37,7 +37,7 @@ class ElementEditsUploaderTest {
     private lateinit var uploader: ElementEditsUploader
     private lateinit var listener: OnUploadedChangeListener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         elementEditsController = mock()
         mapDataController = mock()
         noteEditsController = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/UpdatedElementsHandlerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/UpdatedElementsHandlerTest.kt
@@ -14,9 +14,9 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UpdatedElementsHandlerTest {
     @Test fun `updates element version`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenChangesetsManagerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenChangesetsManagerTest.kt
@@ -8,12 +8,12 @@ import de.westnordost.streetcomplete.data.quest.TestQuestTypeA
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import java.util.Locale
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class OpenChangesetsManagerTest {
 
@@ -24,7 +24,7 @@ class OpenChangesetsManagerTest {
     private lateinit var manager: OpenChangesetsManager
     private lateinit var lastEditTimeStore: LastEditTimeStore
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         questType = TestQuestTypeA()
         mapDataApi = mock()
         openChangesetsDB = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryCreatorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryCreatorTest.kt
@@ -14,10 +14,10 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ElementGeometryCreatorTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/NodeWayMapTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/NodeWayMapTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.osm.geometry
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NodeWayMapTest {
     @Test fun all() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/PolylinesSerializerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/geometry/PolylinesSerializerTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.data.osm.geometry
 
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class PolylinesSerializerTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
@@ -9,11 +9,11 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.anyCollection
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ElementDaoTest {
     private lateinit var nodeDao: NodeDao
@@ -21,7 +21,7 @@ class ElementDaoTest {
     private lateinit var relationDao: RelationDao
     private lateinit var dao: ElementDao
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         nodeDao = mock()
         wayDao = mock()
         relationDao = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCacheTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataCacheTest.kt
@@ -9,11 +9,11 @@ import de.westnordost.streetcomplete.testutils.*
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
 import de.westnordost.streetcomplete.util.math.isCompletelyInside
-import org.junit.Assert.*
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.verifyNoMoreInteractions
+import kotlin.test.*
+import kotlin.test.Test
 
 internal class MapDataCacheTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataControllerTest.kt
@@ -16,14 +16,14 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.verify
 import java.lang.Thread.sleep
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class MapDataControllerTest {
 
@@ -36,7 +36,7 @@ class MapDataControllerTest {
     private lateinit var geometryCreator: ElementGeometryCreator
     private lateinit var createdElementsController: CreatedElementsController
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         nodeDB = mock()
         wayDB = mock()
         relationDB = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometryTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometryTest.kt
@@ -7,9 +7,9 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class MutableMapDataWithGeometryTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
@@ -30,12 +30,12 @@ import de.westnordost.streetcomplete.testutils.osmQuestKey
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.pGeom
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import java.util.concurrent.FutureTask
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OsmQuestControllerTest {
 
@@ -53,7 +53,7 @@ class OsmQuestControllerTest {
     private lateinit var mapDataListener: MapDataWithEditsSource.Listener
     private lateinit var notesListener: NotesWithEditsSource.Listener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         db = mock()
 
         hiddenDB = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/NoteControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/NoteControllerTest.kt
@@ -6,18 +6,18 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.note
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import java.lang.Thread.sleep
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class NoteControllerTest {
     private lateinit var dao: NoteDao
     private lateinit var noteController: NoteController
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         dao = mock()
         noteController = NoteController(dao)
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/NotesDownloaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/NotesDownloaderTest.kt
@@ -7,16 +7,16 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.note
 import de.westnordost.streetcomplete.testutils.on
 import kotlinx.coroutines.runBlocking
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class NotesDownloaderTest {
     private lateinit var noteController: NoteController
     private lateinit var notesApi: NotesApi
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         noteController = mock()
         notesApi = mock()
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsControllerTest.kt
@@ -9,11 +9,11 @@ import de.westnordost.streetcomplete.testutils.note
 import de.westnordost.streetcomplete.testutils.noteEdit
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class NoteEditsControllerTest {
 
@@ -21,7 +21,7 @@ class NoteEditsControllerTest {
     private lateinit var db: NoteEditsDao
     private lateinit var listener: NoteEditsSource.Listener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         db = mock()
         on(db.delete(anyLong())).thenReturn(true)
         on(db.markSynced(anyLong())).thenReturn(true)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploaderTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploaderTest.kt
@@ -16,12 +16,12 @@ import de.westnordost.streetcomplete.testutils.p
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class NoteEditsUploaderTest {
 
@@ -35,7 +35,7 @@ class NoteEditsUploaderTest {
     private lateinit var uploader: NoteEditsUploader
     private lateinit var listener: OnUploadedChangeListener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         notesApi = mock()
         noteController = mock()
         noteEditsController = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSourceTest.kt
@@ -15,12 +15,12 @@ import de.westnordost.streetcomplete.testutils.noteEdit
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NotesWithEditsSourceTest {
 
@@ -31,7 +31,7 @@ class NotesWithEditsSourceTest {
     private lateinit var noteEditsListener: NoteEditsSource.Listener
     private lateinit var userDataSource: UserDataSource
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         noteController = mock()
         noteEditsController = mock()
         userDataSource = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
@@ -14,12 +14,12 @@ import de.westnordost.streetcomplete.testutils.note
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class OsmNoteQuestControllerTest {
 
@@ -36,7 +36,7 @@ class OsmNoteQuestControllerTest {
     private lateinit var noteUpdatesListener: NotesWithEditsSource.Listener
     private lateinit var userLoginListener: UserLoginStatusSource.Listener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         noteSource = mock()
         hiddenDB = mock()
         userDataSource = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/UnsyncedChangesCountSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/UnsyncedChangesCountSourceTest.kt
@@ -11,12 +11,12 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.noteEdit
 import de.westnordost.streetcomplete.testutils.on
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.invocation.InvocationOnMock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class UnsyncedChangesCountSourceTest {
     private lateinit var osmQuestSource: OsmQuestSource
@@ -35,7 +35,7 @@ class UnsyncedChangesCountSourceTest {
 
     private val baseCount = 3 + 4
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         osmQuestSource = mock()
         on(osmQuestSource.addListener(any())).then { invocation: InvocationOnMock ->
             questListener = invocation.arguments[0] as OsmQuestSource.Listener

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSourceTest.kt
@@ -21,12 +21,12 @@ import de.westnordost.streetcomplete.testutils.osmNoteQuest
 import de.westnordost.streetcomplete.testutils.osmQuest
 import de.westnordost.streetcomplete.testutils.osmQuestKey
 import de.westnordost.streetcomplete.testutils.pGeom
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class VisibleQuestsSourceTest {
 
@@ -50,7 +50,7 @@ class VisibleQuestsSourceTest {
     private val questTypes = listOf(TestQuestTypeA(), TestQuestTypeB(), TestQuestTypeC())
     private val questTypeNames = questTypes.map { it.name }
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         osmNoteQuestSource = mock()
         osmQuestSource = mock()
         visibleQuestTypeSource = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/upload/VersionIsBannedCheckerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/upload/VersionIsBannedCheckerTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.upload
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class VersionIsBannedCheckerTest {
     @Test fun `banned version `() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/urlconfig/OrdinalsKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/urlconfig/OrdinalsKtTest.kt
@@ -1,23 +1,23 @@
 package de.westnordost.streetcomplete.data.urlconfig
 
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 
 internal class OrdinalsKtTest {
 
     @Test fun `ordinals to boolean array`() {
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(),
             Ordinals(setOf()).toBooleanArray()
         )
 
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(0, 1),
             Ordinals(setOf(1)).toBooleanArray()
         )
 
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1),
             Ordinals(setOf(0, 1, 4, 10)).toBooleanArray()
         )
@@ -58,17 +58,17 @@ internal class OrdinalsKtTest {
     }
 
     @Test fun `big integer to boolean array`() {
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(),
             0.toBigInteger().toBooleanArray()
         )
 
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(0, 0, 1),
             4.toBigInteger().toBooleanArray()
         )
 
-        assertArrayEquals(
+        assertContentEquals(
             booleanArrayOf(0, 0, 1, 0, 1),
             20.toBigInteger().toBooleanArray()
         )

--- a/app/src/test/java/de/westnordost/streetcomplete/data/urlconfig/UrlConfigKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/urlconfig/UrlConfigKtTest.kt
@@ -8,9 +8,9 @@ import de.westnordost.streetcomplete.data.quest.TestQuestTypeA
 import de.westnordost.streetcomplete.data.quest.TestQuestTypeB
 import de.westnordost.streetcomplete.data.quest.TestQuestTypeC
 import de.westnordost.streetcomplete.data.quest.TestQuestTypeD
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class UrlConfigKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.user.achievements
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AchievementTest {
     @Test fun `getPointThreshold for level 0 is 0`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsControllerTest.kt
@@ -13,11 +13,11 @@ import de.westnordost.streetcomplete.quests.AbstractQuestForm
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AchievementsControllerTest {
 
@@ -32,7 +32,7 @@ class AchievementsControllerTest {
     private lateinit var statisticsListener: StatisticsSource.Listener
     private lateinit var listener: AchievementsSource.Listener
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         userAchievementsDao = mock()
         on(userAchievementsDao.getAll()).thenReturn(mapOf())
         userLinksDao = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsControllerTest.kt
@@ -9,12 +9,12 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.p
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyDouble
 import org.mockito.Mockito.verify
 import java.util.concurrent.FutureTask
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class StatisticsControllerTest {
 
@@ -34,7 +34,7 @@ class StatisticsControllerTest {
     private val questA = "TestQuestTypeA"
     private val questB = "TestQuestTypeB"
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         editTypeStatisticsDao = mock()
         countryStatisticsDao = mock()
         currentWeekEditTypeStatisticsDao = mock()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsParserTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsParserTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.data.user.statistics
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class StatisticsParserTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetControllerTest.kt
@@ -3,10 +3,10 @@ package de.westnordost.streetcomplete.data.visiblequests
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class QuestPresetControllerTest {
 
@@ -17,7 +17,7 @@ class QuestPresetControllerTest {
 
     private val preset = QuestPreset(1, "test")
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         questPresetsDao = mock()
         selectedQuestPresetStore = mock()
         ctrl = QuestPresetsController(questPresetsDao, selectedQuestPresetStore)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderControllerTest.kt
@@ -9,11 +9,12 @@ import de.westnordost.streetcomplete.data.quest.TestQuestTypeD
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 
 class QuestTypeOrderControllerTest {
     private lateinit var questTypeOrderDao: QuestTypeOrderDao
@@ -29,7 +30,7 @@ class QuestTypeOrderControllerTest {
     private val questC = TestQuestTypeC()
     private val questD = TestQuestTypeD()
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         questTypeOrderDao = mock()
         questPresetsSource = mock()
         questTypeRegistry = QuestTypeRegistry(listOf(
@@ -69,7 +70,7 @@ class QuestTypeOrderControllerTest {
         ))
 
         ctrl.sort(list)
-        assertEquals(
+        assertContentEquals(
             listOf(questD, questC, questB, questA),
             list
         )

--- a/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeControllerTest.kt
@@ -8,14 +8,14 @@ import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.eq
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class VisibleQuestTypeControllerTest {
 
@@ -31,7 +31,7 @@ class VisibleQuestTypeControllerTest {
     private val quest1 = TestQuestTypeA()
     private val quest2 = TestQuestTypeB()
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         visibleQuestTypeDao = mock()
         questPresetsSource = mock()
         questTypeRegistry = QuestTypeRegistry(listOf(

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/LocalizedNamesKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/LocalizedNamesKtTest.kt
@@ -5,8 +5,8 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import org.assertj.core.api.Assertions
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 internal class LocalizedNamesKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/MaxspeedKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/MaxspeedKtTest.kt
@@ -6,8 +6,8 @@ import de.westnordost.streetcomplete.data.meta.SpeedMeasurementUnit
 import de.westnordost.streetcomplete.testutils.any
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class MaxspeedKtTest {
     @Test fun `get maxspeed`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/OnewayKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/OnewayKtTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.osm
 
 import de.westnordost.streetcomplete.osm.cycleway.Direction
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class OnewayKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/RoadWidthKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/RoadWidthKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class RoadWidthKtTest {
     @Test fun `roadway width`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/TagsKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/TagsKtTest.kt
@@ -1,7 +1,6 @@
 package de.westnordost.streetcomplete.osm
 
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
 
 class TagsKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberTest.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 class AddressNumberTest {
     @Test fun `applyTo house number`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberValidatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberValidatorKtTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.osm.address
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddressNumberValidatorKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersParserKtTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.osm.address
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class HouseNumbersParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtilKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/HouseNumbersUtilKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.address
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class HouseNumbersUtilKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevardKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevardKtTest.kt
@@ -7,8 +7,8 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.bicycle_boulevard.BicycleBoulevard.*
 import org.assertj.core.api.Assertions
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class BicycleBoulevardKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.osm.cycleway.Cycleway.*
 import de.westnordost.streetcomplete.osm.cycleway.Direction.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class CyclewayCreatorKtTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayKtTest.kt
@@ -2,9 +2,9 @@ package de.westnordost.streetcomplete.osm.cycleway
 
 import de.westnordost.streetcomplete.osm.cycleway.Cycleway.*
 import de.westnordost.streetcomplete.osm.cycleway.Direction.*
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CyclewayKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayParserKtTest.kt
@@ -2,9 +2,9 @@ package de.westnordost.streetcomplete.osm.cycleway
 
 import de.westnordost.streetcomplete.osm.cycleway.Cycleway.*
 import de.westnordost.streetcomplete.osm.cycleway.Direction.*
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class CyclewayParserKtTest {
     /* These are a lot of tests because there are many possible permutations and this test does not

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayCreatorKtTest.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 class SeparateCyclewayCreatorKtTest {
     @Test fun `apply none`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayParserKtTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.osm.cycleway_separate
 
 import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.*
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class SeparateCyclewayParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingCreatorKtTest.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 class LaneNarrowingTrafficCalmingCreatorKtTest {
     @Test fun `set traffic_calming`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingParserKtTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming
 
 import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.*
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class LaneNarrowingTrafficCalmingParserKtTest {
     @Test fun none() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/level/LevelParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/level/LevelParserKtTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.osm.level
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LevelParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.lit.LitStatus.*
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class LitStatusKtTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/CircularSectionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/CircularSectionTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.osm.opening_hours.model
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class CircularSectionTest {
     @Test fun `start and end`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/MonthsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/MonthsTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.osm.opening_hours.model
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class MonthsTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/NumberSystemTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/NumberSystemTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.osm.opening_hours.model
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class NumberSystemTest {
     @Test

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/TimeRangeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/TimeRangeTest.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.osm.opening_hours.model
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TimeRangeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/WeekdaysTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/model/WeekdaysTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.osm.opening_hours.model
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class WeekdaysTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/parser/OpeningHoursParserAndGeneratorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/opening_hours/parser/OpeningHoursParserAndGeneratorTest.kt
@@ -2,9 +2,9 @@ package de.westnordost.streetcomplete.osm.opening_hours.parser
 
 import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningHoursRow
 import de.westnordost.streetcomplete.quests.postbox_collection_times.CollectionTimesRow
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class OpeningHoursParserAndGeneratorTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/shoulders/ShouldersParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/shoulders/ShouldersParserKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.shoulders
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ShouldersParserKtTest {
     @Test fun `shoulders with normal tagging`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class SidewalkCreatorKtTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.sidewalk
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class SidewalkKtTest {
     @Test fun validOrNullValues() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkParserKtTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk.INVALID
 import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk.NO
 import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk.SEPARATE
 import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk.YES
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class SidewalkParserKtTest {
     /* These are a lot of tests because there are many possible permutations and this test does not

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk_surface/SidewalkSurfaceCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk_surface/SidewalkSurfaceCreatorKtTest.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.osm.surface.Surface
 import de.westnordost.streetcomplete.osm.surface.SurfaceAndNote
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 internal class SidewalkSurfaceCreatorKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.*
 import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.*
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class StreetParkingCreatorKtTest {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.street_parking
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class StreetParkingTest {
     @Test fun validOrNullValues() {

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingParserKtTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.osm.street_parking
 
 import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.*
 import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.*
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class StreetParkingParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 class SurfaceCreatorKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.surface
 
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class SurfaceKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceParserKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceParserKtTest.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.osm.surface
 
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class SurfaceParserKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceUtilsKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceUtilsKtTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class SurfaceUtilsKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/overlays/surface/SurfaceColorMappingKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/overlays/surface/SurfaceColorMappingKtTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.osm.surface.Surface
 import de.westnordost.streetcomplete.osm.surface.createSurfaceAndNote
 import de.westnordost.streetcomplete.overlays.Color
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.*
-import org.junit.Test
+import kotlin.test.*
+import kotlin.test.Test
 
 class SurfaceColorMappingKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCardsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCardsTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddAcceptsCardsTest {
     private val questType = AddAcceptsCards()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetTest.kt
@@ -6,9 +6,9 @@ import de.westnordost.streetcomplete.testutils.member
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddAddressStreetTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddHousenumberTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/address/AddHousenumberTest.kt
@@ -17,9 +17,9 @@ import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddHousenumberTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddDetectBarrierIntersectionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddDetectBarrierIntersectionTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddDetectBarrierIntersectionTest {
     private val questType = AddBarrierOnRoad()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/barrier_type/AddStileTypeTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddStileTypeTest {
     private val questType = AddStileType()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/building_entrance/AddEntranceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/building_entrance/AddEntranceTest.kt
@@ -6,8 +6,8 @@ import de.westnordost.streetcomplete.testutils.member
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddBuildingEntranceTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReferenceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReferenceTest.kt
@@ -7,8 +7,8 @@ import de.westnordost.streetcomplete.testutils.member
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddBuildingEntranceReferenceTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddBuildingLevelsTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeTest.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddBuildingTypeTest {
     private val questType = AddBuildingType()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopNameTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopNameTest.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.bus_stop_name
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.osm.LocalizedName
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddBusStopNameTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelterTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelterTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddBusStopShelterTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.AUTOMATED
 import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.SELF_SERVICE
 import de.westnordost.streetcomplete.quests.car_wash_type.CarWashType.SERVICE
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddCarWashTypeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperatorTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperatorTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.clothing_bin_operator
 
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddClothingBinOperatorTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/crossing/AddCrossingTest.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddCrossingTest {
     private val questType = AddCrossing()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIslandTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIslandTest.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.quests.crossing_island
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddCrossingIslandTest {
     private val questType = AddCrossingIsland()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.MARKED
 import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.TRAFFIC_SIGNALS
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddCrossingTypeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayTest.kt
@@ -10,14 +10,14 @@ import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyDouble
 import java.util.concurrent.FutureTask
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class AddCyclewayTest {
 
@@ -25,7 +25,7 @@ class AddCyclewayTest {
     private lateinit var countryInfos: CountryInfos
     private lateinit var questType: AddCycleway
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         val countryBoundaries: CountryBoundaries = mock()
         val futureTask = FutureTask { countryBoundaries }
         futureTask.run()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWaterTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWaterTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.quests.drinking_water
 
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddDrinkingWaterTest {
     private val questType = AddDrinkingWater()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterTypeTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.osm.SURVEY_MARK_KEY
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddDrinkingWaterTypeTest {
     private val questType = AddDrinkingWaterType()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceTest.kt
@@ -10,9 +10,9 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert
-import org.junit.Test
 import java.util.concurrent.FutureTask
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class CheckExistenceTest {
     private val questType = CheckExistence(mockOfFeatureDictionary())

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestriansTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestriansTest.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.NO
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.YES
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddProhibitedForPedestriansTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/kerb_height/KerbUtilTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/kerb_height/KerbUtilTest.kt
@@ -5,10 +5,10 @@ import de.westnordost.streetcomplete.osm.kerb.findAllKerbNodes
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class KerbUtilTest {
     @Test fun `free-floating kerbs do not count`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/lanes/AddLanesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/lanes/AddLanesTest.kt
@@ -5,9 +5,9 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddLanesTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/level/AddLevelTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/level/AddLevelTest.kt
@@ -7,8 +7,8 @@ import de.westnordost.streetcomplete.quests.createMapData
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddLevelTest {
     private val questType = AddLevel()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightTest.kt
@@ -9,9 +9,9 @@ import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddMaxHeightTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedTest.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.quests.max_speed
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddMaxSpeedTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeightTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeightTest.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.max_weight
 
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddMaxWeightTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/oneway/AddOnewayTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/oneway/AddOnewayTest.kt
@@ -3,8 +3,8 @@ package de.westnordost.streetcomplete.quests.oneway
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddOnewayTest {
     private val questType = AddOneway()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
@@ -14,9 +14,9 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import de.westnordost.streetcomplete.util.ktx.toEpochMilli
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddOpeningHoursTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
@@ -7,9 +7,9 @@ import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CheckOpeningHoursSignedTest {
     private val questType = CheckOpeningHoursSigned(mock())

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFeeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFeeTest.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddParkingFeeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceNameTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceNameTest.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.osm.LocalizedName
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.mock
-import org.junit.Test
+import kotlin.test.Test
 
 class AddPlaceNameTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimesTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimesTest.kt
@@ -7,7 +7,7 @@ import ch.poole.openinghoursparser.WeekDayRange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.osm.opening_hours.parser.OpeningHoursRuleList
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddPostboxCollectionTimesTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRefTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRefTest.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.postbox_ref
 
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddPostboxRefTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrierTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/railway_crossing/AddRailwayCrossingBarrierTest.kt
@@ -6,9 +6,9 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddRailwayCrossingBarrierTest {
     private val questType = AddRailwayCrossingBarrier()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeTest.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.quests.recycling
 
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddRecyclingTypeTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterialsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/recycling_material/AddRecyclingContainerMaterialsTest.kt
@@ -15,8 +15,8 @@ import de.westnordost.streetcomplete.quests.recycling_material.RecyclingMaterial
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddRecyclingContainerMaterialsTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/road_name/AddRoadNameTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/road_name/AddRoadNameTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.LocalizedName
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Test
+import kotlin.test.Test
 
 class AddRoadNameTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeTest.kt
@@ -11,19 +11,19 @@ import de.westnordost.streetcomplete.testutils.on
 import de.westnordost.streetcomplete.testutils.pGeom
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import org.mockito.ArgumentMatchers.anyDouble
 import java.util.concurrent.FutureTask
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AddRoofShapeTest {
     private lateinit var countryInfos: CountryInfos
     private lateinit var questType: AddRoofShape
     private lateinit var countryBoundaries: CountryBoundaries
 
-    @Before fun setUp() {
+    @BeforeTest fun setUp() {
         countryBoundaries = mock()
         val futureTask = FutureTask { countryBoundaries }
         futureTask.run()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistenceTest.kt
@@ -5,9 +5,9 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.on
-import org.junit.Assert
-import org.junit.Test
 import java.util.concurrent.FutureTask
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class CheckShopExistenceTest {
     private val questType = CheckShopExistence(mockOfFeatureDictionary())

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopTypeTest.kt
@@ -6,9 +6,9 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CheckShopTypeTest {
     private val questType = CheckShopType()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopTypeTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.shop_type
 
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SpecifyShopTypeTest {
     private val questType = SpecifyShopType()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkTest.kt
@@ -5,9 +5,9 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.p
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.math.translate
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AddSidewalkTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoking/AddSmokingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoking/AddSmokingTest.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.quests.smoking
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddSmokingTest {
     private val questType = AddSmoking()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothnessTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.quests.smoothness
 
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class AddRoadSmoothnessTest {
     private val questType = AddRoadSmoothness()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswerKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswerKtTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import kotlin.test.Test
 
 class SmoothnessAnswerKtTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/sport/AddSportTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/sport/AddSportTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.quests.sport.Sport.HANDBALL
 import de.westnordost.streetcomplete.quests.sport.Sport.ICE_SKATING
 import de.westnordost.streetcomplete.quests.sport.Sport.SOCCER
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddSportTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampTest.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.quests.verifyAnswer
-import org.junit.Test
+import kotlin.test.Test
 
 class AddStepsRampTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurfaceTest.kt
@@ -10,10 +10,10 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddCyclewayPartSurfaceTest {
     private val questType = AddCyclewayPartSurface()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurfaceTest.kt
@@ -10,10 +10,10 @@ import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.way
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddFootwayPartSurfaceTest {
     private val questType = AddFootwayPartSurface()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurfaceTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddPitchSurfaceTest {
     private val questType = AddPitchSurface()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurfaceTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.surface
 
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddRoadSurfaceTest {
     private val questType = AddRoadSurface()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurfaceTest.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.quests.surface
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddSidewalkSurfaceTest {
     private val questType = AddSidewalkSurface()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalkTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalkTest.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.quests.tactile_paving
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AddTactilePavingCrosswalkTest {
     private val questType = AddTactilePavingCrosswalk()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingStepsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingStepsTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.quests.tactile_paving
 
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddTactilePavingStepsTest {
     private val questType = AddTactilePavingSteps()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSoundTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSoundTest.kt
@@ -3,8 +3,8 @@ package de.westnordost.streetcomplete.quests.traffic_signals_sound
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddTrafficSignalsSoundTest {
     private val questType = AddTrafficSignalsSound()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibrationTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibrationTest.kt
@@ -3,8 +3,8 @@ package de.westnordost.streetcomplete.quests.traffic_signals_vibrate
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class AddTrafficSignalsVibrationTest {
     private val questType = AddTrafficSignalsVibration()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPartTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPartTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 
 import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
-import org.junit.Assert
-import org.junit.Test
+import kotlin.test.Assert
+import kotlin.test.Test
 
 class AddWheelchairAccessToiletsPartTest {
     private val questType = AddWheelchairAccessToiletsPart()

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/width/AddRoadWidthTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/width/AddRoadWidthTest.kt
@@ -7,9 +7,9 @@ import de.westnordost.streetcomplete.osm.LengthInMeters
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AddRoadWidthTest {
     private val quest = AddRoadWidth(mock())

--- a/app/src/test/java/de/westnordost/streetcomplete/screens/main/map/tangram/TangramExtensionsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/screens/main/map/tangram/TangramExtensionsTest.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.screens.main.map.tangram
 
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class TangramExtensionsTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/LastPickedValuesStoreTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/LastPickedValuesStoreTest.kt
@@ -3,67 +3,68 @@ package de.westnordost.streetcomplete.util
 import de.westnordost.streetcomplete.util.Letter.A
 import de.westnordost.streetcomplete.util.Letter.B
 import de.westnordost.streetcomplete.util.Letter.C
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class LastPickedValuesStoreTest {
 
-    @Test fun `mostCommonWithin basic functionality`() {
+    @Test
+    fun `mostCommonWithin basic functionality`() {
         assertEquals(
-            "Returns the most common items",
             listOf(A, C),
             sequenceOf(A, A, B, C, C).mostCommonWithin(2, 99, 1).toList(),
+            "Returns the most common items",
         )
         assertEquals(
-            "Sorted in the original order",
             listOf(A, C, B),
             sequenceOf(A, C, B, B, C).mostCommonWithin(4, 99, 1).toList(),
+            "Sorted in the original order",
         )
         assertEquals(
-            "Doesn't return nulls",
             listOf(A),
-            sequenceOf(A, null).mostCommonWithin(2, 99, 1).toList()
+            sequenceOf(A, null).mostCommonWithin(2, 99, 1).toList(),
+            "Doesn't return nulls",
         )
     }
 
     @Test fun `mostCommonWithin first item(s) special case`() {
         assertEquals(
-            "Included even if it is not the most common",
             listOf(A, B),
             sequenceOf(A, B, B, C, C).mostCommonWithin(2, 99, 1).toList(),
+            "Included even if it is not the most common",
         )
         assertEquals(
-            "Not included if null",
             listOf(B, C),
             sequenceOf(null, B, C).mostCommonWithin(2, 99, 1).toList(),
+            "Not included if null",
         )
         assertEquals(
-            "Not duplicated if it was already among the most common",
             listOf(A, B),
             sequenceOf(A, B, A, B).mostCommonWithin(4, 99, 1).toList(),
+            "Not duplicated if it was already among the most common",
         )
     }
 
     @Test fun `mostCommonWithin counts the right number of items`() {
         assertEquals(
-            "Always counts the minimum",
             listOf(A, C),
             sequenceOf(A, B, C, C).mostCommonWithin(2, 4, 1).toList(),
+            "Always counts the minimum",
         )
         assertEquals(
-            "Counts more to find the target",
             listOf(A, B, C),
             sequenceOf(A, B, C, C).mostCommonWithin(3, 1, 1).toList(),
+            "Counts more to find the target",
         )
         assertEquals(
-            "Counts nulls towards the minimum",
             listOf(A, B),
             sequenceOf(A, null, B, null, C, C).mostCommonWithin(2, 3, 1).toList(),
+            "Counts nulls towards the minimum",
         )
         assertEquals(
-            "Doesn't count null toward the target",
             listOf(A, B, C),
             sequenceOf(A, null, B, null, C, C).mostCommonWithin(3, 2, 1).toList(),
+            "Doesn't count null toward the target",
         )
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/SpatialCacheTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/SpatialCacheTest.kt
@@ -16,12 +16,12 @@ import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
 import de.westnordost.streetcomplete.util.math.intersect
 import de.westnordost.streetcomplete.util.math.isCompletelyInside
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import org.mockito.Mockito.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class SpatialCacheTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
@@ -2,11 +2,11 @@ package de.westnordost.streetcomplete.util.ktx
 
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CollectionsTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/ktx/DateTimeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/ktx/DateTimeTest.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.util.ktx
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class DateTimeTest {
     @Test fun `check parsing of ISO timestamp with offset`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/util/ktx/ElementTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/ktx/ElementTest.kt
@@ -2,9 +2,9 @@ package de.westnordost.streetcomplete.util.ktx
 
 import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ElementTest {
     @Test fun `relation with no tags is no area`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/util/ktx/LatLonTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/ktx/LatLonTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.util.ktx
 
 import de.westnordost.streetcomplete.testutils.p
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class LatLonTest {
     @Test fun `different LatLon is different`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/util/math/FlatEarthMathTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/math/FlatEarthMathTest.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.util.math
 
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class FlatEarthMathTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/util/math/SphericalEarthMathTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/util/math/SphericalEarthMathTest.kt
@@ -4,15 +4,15 @@ import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.testutils.bbox
 import de.westnordost.streetcomplete.util.ktx.equalsInOsm
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SphericalEarthMathTest {
 


### PR DESCRIPTION
Almost everything works, but there is one new test failure in `androidTest` `NoteQuestsHiddenDaoTest.getNewerThan` on a Pixel 4 emulator that I don't know what it's caused by:

```
java.lang.NoSuchMethodError: No static method boxLong(J)Ljava/lang/Long; in class Lkotlin/coroutines/jvm/internal/Boxing; or its super classes (declaration of 'kotlin.coroutines.jvm.internal.Boxing' appears in /data/app/~~Cmbt4P5atgm8GMNc69RGiA==/de.westnordost.streetcomplete.debug-n9y365mjtzOc6KdZczYHAg==/base.apk)
at de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenDaoTest$getNewerThan$1.invokeSuspend(NoteQuestsHiddenDaoTest.kt:49)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:254)
at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:166)
at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:474)
at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:508)
at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:497)
at kotlinx.coroutines.CancellableContinuationImpl.resumeUndispatched(CancellableContinuationImpl.kt:595)
at kotlinx.coroutines.EventLoopImplBase$DelayedResumeTask.run(EventLoop.common.kt:493)
at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:280)
at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1)
at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1)
at de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenDaoTest.getNewerThan(NoteQuestsHiddenDaoTest.kt:43)
```

The error occurs in line 49 `assertEquals(2L, result.noteId)`.

https://github.com/streetcomplete/StreetComplete/blob/7063485528c4cbb2a56c9cc1381cc18db341f3f9/app/src/androidTest/java/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenDaoTest.kt#L43-L50

And another question regarding code style of imports and consistency.
Some files use star import à la `import org.junit.Assert.*`. Should this be kept, all files changed to star import or all files changed to explicit imports?