### PR TITLE
use UTC for statistics calendar

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/DatesActiveDrawable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/DatesActiveDrawable.kt
@@ -61,7 +61,7 @@ class DatesActiveDrawable(
 
         // grid + months
         for (i in 0..datesActiveRange) {
-            val date = time.toLocalDate()
+            val date = time.toLocalDateTime(TimeZone.UTC).date
 
             val y = (height - 1) - (i + dayOffset) % height
             val x = (width - 1) - floor(((i + dayOffset) / height).toDouble()).toInt()


### PR DESCRIPTION
Together with https://github.com/streetcomplete/sc-statistics-service/pull/26, fixes https://github.com/streetcomplete/StreetComplete/issues/4951

It used UTC for some things, and local time zone for others. Those PRs make it use UTC always. 
Tested in this [debug build](https://github.com/mnalis/StreetComplete/actions/runs/6140514585) :




![small_Screenshot_20230911_235020_de westnordost streetcomplete mn debug](https://github.com/streetcomplete/StreetComplete/assets/156656/db20bb84-0b49-4d9c-a2ba-cf6d03b787c8) ![small_Screenshot_20230912_014649_de westnordost streetcomplete mn debug](https://github.com/streetcomplete/StreetComplete/assets/156656/63d59e35-6bf3-4aae-b0b2-d4c854f35c05)

 ![small_Screenshot_20230912_015617_de westnordost streetcomplete mn debug](https://github.com/streetcomplete/StreetComplete/assets/156656/3881fdfc-5dab-46ae-b02a-615392b5f1ae) ![small_Screenshot_20230912_022038_de westnordost streetcomplete mn debug](https://github.com/streetcomplete/StreetComplete/assets/156656/48056d73-4b4b-4768-8a5b-0e968ac17d58)