### PR TITLE
Don't show ok button in AddBuildingType if category value is null

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestForm.kt
@@ -134,5 +134,5 @@ abstract class AGroupedImageListQuestForm<I, T> : AbstractOsmQuestForm<T>() {
 
     abstract fun onClickOk(value: I)
 
-    override fun isFormComplete() = selectedItem != null
+    override fun isFormComplete() = selectedItem?.value != null
 }


### PR DESCRIPTION
Currently when selecting e.g. "for cars" category in `AddBuildingType`, the ok button is shown, but when clicking ok the user is asked to select a more specific value.
With this change, the ok button is not shown any more when selecting such a category. This should avoid unnecessary attempts on selecting some categories, while at the same time providing a subtle hint that categories can actually be used for answering the quest too.