### PR TITLE
Use Android's built-in XmlPull implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ configurations {
     all {
         // it's already included in Android
         exclude(group = "net.sf.kxml", module = "kxml2")
+        exclude(group = "xmlpull", module = "xmlpull")
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,8 +1,5 @@
 -dontobfuscate
 
--dontwarn org.xmlpull.**
--dontnote org.xmlpull.**
-
 # https://issuetracker.google.com/issues/37070898
 -dontnote android.net.http.*
 -dontnote org.apache.commons.codec.**


### PR DESCRIPTION
This PR fixes a build error with AGP version 8 or greater, where the previously ignored proguard / R8 warning for including a program (i.e., built-in Android) class in a library is now considered to be an error. For details, see [here](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes) and [here](https://issuetracker.google.com/issues/247066506).

The app still works fine with these changes on my device. All XML classes used by the [osmapi library](https://github.com/westnordost/osmapi) are part of Android since API level 1.