### PR TITLE
Improve profile layout on wide screens & with large fonts

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,411 +1,294 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:scrollbarStyle="outsideOverlay"
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="400dp">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        <LinearLayout
+            android:layout_width="0dp"
+            app:layout_constraintWidth_max="400dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:layout_marginBottom="@dimen/activity_vertical_margin"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+            android:divider="@drawable/space_24dp"
+            android:paddingBottom="16dp"
+            android:showDividers="middle">
 
-            <LinearLayout
+            <RelativeLayout
+                android:id="@+id/profileContainer"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_marginTop="@dimen/activity_vertical_margin"
-                android:layout_marginBottom="@dimen/activity_vertical_margin"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:divider="@drawable/space_24dp"
-                android:paddingBottom="64dp"
-                android:showDividers="middle">
+                android:layout_height="wrap_content">
 
-                <RelativeLayout
-                    android:id="@+id/profileContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                <ImageView
+                    android:layout_marginEnd="16dp"
+                    android:id="@+id/userAvatarImageView"
+                    android:layout_width="100dp"
+                    android:layout_height="100dp"
+                    android:scaleType="fitCenter"
+                    tools:src="@drawable/ic_osm_anon_avatar" />
 
-                    <RelativeLayout
-                        android:id="@+id/avatarAndButtonContainer"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="16dp">
-
-                        <ImageView
-                            android:id="@+id/userAvatarImageView"
-                            android:layout_width="100dp"
-                            android:layout_height="100dp"
-                            android:scaleType="fitCenter"
-                            tools:src="@drawable/ic_osm_anon_avatar"
-                            android:layout_centerHorizontal="true"/>
-
-                    </RelativeLayout>
-
-                    <TextView
-                        android:id="@+id/userNameTextView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:maxLines="1"
-                        android:gravity="center_vertical"
-                        android:textAppearance="@style/TextAppearance.Title"
-                        android:textSize="32dp"
-                        app:autoSizeMaxTextSize="32dp"
-                        app:autoSizeMinTextSize="22dp"
-                        app:autoSizeTextType="uniform"
-                        android:layout_toEndOf="@id/avatarAndButtonContainer"
-                        tools:text="westnordost" />
-
-                    <LinearLayout
-                        android:id="@+id/solvedQuestsContainer"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@id/userNameTextView"
-                        android:layout_marginTop="8dp"
-                        android:layout_toEndOf="@id/avatarAndButtonContainer"
-                        android:divider="@drawable/space_4dp"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:showDividers="middle">
-
-                        <ImageView
-                            android:layout_width="32dp"
-                            android:layout_height="32dp"
-                            android:src="@drawable/ic_star_48dp" />
-
-                        <TextView
-                            android:id="@+id/editCountText"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:maxLines="1"
-                            android:textAlignment="gravity"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:textSize="24dp"
-                            tools:text="1021" />
-
-                    </LinearLayout>
-
-                    <TextView
-                        android:id="@+id/unpublishedEditCountText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@id/solvedQuestsContainer"
-                        android:layout_marginTop="8dp"
-                        android:layout_toEndOf="@id/avatarAndButtonContainer"
-                        tools:text="@string/unsynced_quests_description" />
-
-                </RelativeLayout>
-
-                <RelativeLayout
-                    android:id="@+id/buttonsContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <Button
-                        android:id="@+id/profileButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_alignParentStart="true"
-                        app:icon="@drawable/ic_open_in_browser_24dp"
-                        android:layout_centerHorizontal="true"
-                        android:text="@string/osm_profile" />
-
-                    <Button
-                        android:id="@+id/logoutButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_alignParentEnd="true"
-                        android:text="@string/user_logout"
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"/>
-
-                </RelativeLayout>
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/divider"/>
-
-                <com.google.android.flexbox.FlexboxLayout
-                    android:id="@+id/badgesContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:flexWrap="wrap"
-                    app:showDivider="middle"
-                    app:dividerDrawableHorizontal="@drawable/space_16dp"
-                    app:dividerDrawableVertical="@drawable/space_8dp"
-                    app:showDividerVertical="middle"
-                    app:showDividerHorizontal="middle"
-                    app:alignContent="stretch">
-
-                    <RelativeLayout
-                        android:id="@+id/localRankContainer"
-                        android:layout_width="84dp"
-                        android:layout_height="wrap_content">
-
-                        <TextView
-                            android:id="@+id/localRankText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="#1"/>
-
-                        <TextView
-                            android:id="@+id/localRankLabel"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@id/localRankText"
-                            android:layout_below="@+id/localRankText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_local_rank"
-                            tools:text="Rank in\nUnited States of America"/>
-
-                    </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/globalRankContainer"
-                        android:layout_width="84dp"
-                        android:layout_height="wrap_content">
-
-                        <TextView
-                            android:id="@+id/globalRankText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="#123456"/>
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@id/globalRankText"
-                            android:layout_below="@id/globalRankText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_global_rank"/>
-
-                    </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/daysActiveContainer"
-                        android:layout_width="84dp"
-                        android:layout_height="wrap_content">
-
-                        <TextView
-                            android:id="@+id/daysActiveText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="82"/>
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@id/daysActiveText"
-                            android:layout_below="@id/daysActiveText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_days_active"/>
-
-                    </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/achievementLevelsContainer"
-                        android:layout_width="84dp"
-                        android:layout_height="wrap_content">
-
-                        <TextView
-                            android:id="@+id/achievementLevelsText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="123"/>
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@+id/achievementLevelsText"
-                            android:layout_below="@id/achievementLevelsText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_achievement_levels"/>
-
-                    </RelativeLayout>
-
-                </com.google.android.flexbox.FlexboxLayout>
-
-                <LinearLayout
-                    android:id="@+id/currentWeekSolvedQuestsContainer"
+                <TextView
+                    android:id="@+id/userNameTextView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:gravity="center_vertical"
+                    android:textAppearance="@style/TextAppearance.Title"
+                    android:textSize="32sp"
+                    app:autoSizeMaxTextSize="32sp"
+                    app:autoSizeMinTextSize="22sp"
+                    app:autoSizeTextType="uniform"
+                    android:layout_toEndOf="@id/userAvatarImageView"
+                    tools:text="westnordost" />
+
+                <LinearLayout
+                    android:id="@+id/solvedQuestsContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/userNameTextView"
+                    android:layout_marginTop="8dp"
+                    android:layout_toEndOf="@id/userAvatarImageView"
                     android:divider="@drawable/space_4dp"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
                     android:showDividers="middle">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:textAlignment="gravity"
-                        android:textAppearance="@style/TextAppearance.Title"
-                        android:text="@string/user_profile_current_week_title" />
-
                     <ImageView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
                         android:src="@drawable/ic_star_48dp" />
 
                     <TextView
-                        android:id="@+id/currentWeekEditCountText"
+                        android:id="@+id/editCountText"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:gravity="center_vertical"
                         android:maxLines="1"
                         android:textAlignment="gravity"
                         android:textAppearance="@style/TextAppearance.Title"
+                        android:textSize="24sp"
                         tools:text="1021" />
 
                 </LinearLayout>
 
-                <com.google.android.flexbox.FlexboxLayout
-                    android:id="@+id/currentWeekBadgesContainer"
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/unpublishedEditCountText"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:flexWrap="wrap"
-                    app:showDivider="middle"
-                    app:dividerDrawableHorizontal="@drawable/space_16dp"
-                    app:dividerDrawableVertical="@drawable/space_8dp"
-                    app:showDividerVertical="middle"
-                    app:showDividerHorizontal="middle"
-                    app:alignContent="stretch">
+                    android:layout_below="@id/solvedQuestsContainer"
+                    android:layout_marginTop="8dp"
+                    android:layout_toEndOf="@id/userAvatarImageView"
+                    tools:text="@string/unsynced_quests_description" />
 
-                    <RelativeLayout
-                        android:id="@+id/currentWeekLocalRankContainer"
+            </RelativeLayout>
+
+            <com.google.android.flexbox.FlexboxLayout
+                android:id="@+id/buttonsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:flexWrap="wrap"
+                app:dividerDrawableHorizontal="@drawable/space_8dp"
+                app:dividerDrawableVertical="@drawable/space_16dp"
+                app:showDividerVertical="middle"
+                app:showDividerHorizontal="middle"
+                app:justifyContent="space_between"
+                app:alignContent="stretch">
+
+                <Button
+                    android:id="@+id/profileButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:icon="@drawable/ic_open_in_browser_24dp"
+                    android:layout_centerHorizontal="true"
+                    android:text="@string/osm_profile" />
+
+                <Button
+                    android:id="@+id/logoutButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/user_logout"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+            </com.google.android.flexbox.FlexboxLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/divider" />
+
+            <com.google.android.flexbox.FlexboxLayout
+                android:id="@+id/badgesContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:flexWrap="wrap"
+                app:dividerDrawableHorizontal="@drawable/space_16dp"
+                app:dividerDrawableVertical="@drawable/space_8dp"
+                app:showDividerVertical="middle"
+                app:showDividerHorizontal="middle"
+                app:alignContent="stretch">
+
+                <RelativeLayout
+                    android:id="@+id/localRankContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/localRankText"
                         android:layout_width="84dp"
-                        android:layout_height="wrap_content">
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="#1" />
 
-                        <TextView
-                            android:id="@+id/currentWeekLocalRankText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="#1"/>
+                    <TextView
+                        android:id="@+id/localRankLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@id/localRankText"
+                        android:layout_below="@+id/localRankText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_local_rank"
+                        tools:text="Rank in\nUnited States of America" />
 
-                        <TextView
-                            android:id="@+id/currentWeekLocalRankLabel"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@id/currentWeekLocalRankText"
-                            android:layout_below="@+id/currentWeekLocalRankText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_local_rank"
-                            tools:text="Rank in\nUnited States of America"/>
+                </RelativeLayout>
 
-                    </RelativeLayout>
+                <RelativeLayout
+                    android:id="@+id/globalRankContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
 
-                    <RelativeLayout
-                        android:id="@+id/currentWeekGlobalRankContainer"
+                    <TextView
+                        android:id="@+id/globalRankText"
                         android:layout_width="84dp"
-                        android:layout_height="wrap_content">
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="#123456789" />
 
-                        <TextView
-                            android:id="@+id/currentWeekGlobalRankText"
-                            android:layout_width="84dp"
-                            android:layout_height="84dp"
-                            android:background="@drawable/background_inverted_text_circle"
-                            android:gravity="center"
-                            android:padding="8dp"
-                            android:maxLines="1"
-                            android:textAppearance="@style/TextAppearance.Title"
-                            android:layout_centerHorizontal="true"
-                            app:autoSizeTextType="uniform"
-                            app:autoSizeMaxTextSize="22dp"
-                            app:autoSizeMinTextSize="12dp"
-                            android:textColor="@color/background"
-                            tools:text="#123456"/>
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@id/globalRankText"
+                        android:layout_below="@id/globalRankText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_global_rank" />
 
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_centerHorizontal="true"
-                            android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:labelFor="@id/currentWeekGlobalRankText"
-                            android:layout_below="@id/currentWeekGlobalRankText"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/user_profile_global_rank"/>
+                </RelativeLayout>
 
-                    </RelativeLayout>
+                <RelativeLayout
+                    android:id="@+id/daysActiveContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
 
-                </com.google.android.flexbox.FlexboxLayout>
+                    <TextView
+                        android:id="@+id/daysActiveText"
+                        android:layout_width="84dp"
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="82" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@id/daysActiveText"
+                        android:layout_below="@id/daysActiveText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_days_active" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/achievementLevelsContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/achievementLevelsText"
+                        android:layout_width="84dp"
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="123" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@+id/achievementLevelsText"
+                        android:layout_below="@id/achievementLevelsText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_achievement_levels" />
+
+                </RelativeLayout>
+
+            </com.google.android.flexbox.FlexboxLayout>
+
+            <LinearLayout
+                android:id="@+id/currentWeekSolvedQuestsContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:divider="@drawable/space_4dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:showDividers="middle">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -413,17 +296,125 @@
                     android:gravity="center_vertical"
                     android:textAlignment="gravity"
                     android:textAppearance="@style/TextAppearance.Title"
-                    android:text="@string/user_profile_dates_mapped" />
+                    android:text="@string/user_profile_current_week_title" />
 
                 <ImageView
-                    android:id="@+id/datesActiveView"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_star_48dp" />
+
+                <TextView
+                    android:id="@+id/currentWeekEditCountText"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:maxLines="1"
+                    android:textAlignment="gravity"
+                    android:textAppearance="@style/TextAppearance.Title"
+                    tools:text="1021" />
 
             </LinearLayout>
 
-        </ScrollView>
+            <com.google.android.flexbox.FlexboxLayout
+                android:id="@+id/currentWeekBadgesContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:flexWrap="wrap"
+                app:showDivider="middle"
+                app:dividerDrawableHorizontal="@drawable/space_16dp"
+                app:dividerDrawableVertical="@drawable/space_8dp"
+                app:showDividerVertical="middle"
+                app:showDividerHorizontal="middle"
+                app:alignContent="stretch">
+
+                <RelativeLayout
+                    android:id="@+id/currentWeekLocalRankContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/currentWeekLocalRankText"
+                        android:layout_width="84dp"
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="#1" />
+
+                    <TextView
+                        android:id="@+id/currentWeekLocalRankLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@id/currentWeekLocalRankText"
+                        android:layout_below="@+id/currentWeekLocalRankText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_local_rank"
+                        tools:text="Rank in\nUnited States of America" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/currentWeekGlobalRankContainer"
+                    android:layout_width="84dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/currentWeekGlobalRankText"
+                        android:layout_width="84dp"
+                        android:layout_height="84dp"
+                        android:background="@drawable/background_inverted_text_circle"
+                        android:gravity="center"
+                        android:padding="8dp"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Title"
+                        android:layout_centerHorizontal="true"
+                        app:autoSizeTextType="uniform"
+                        app:autoSizeMaxTextSize="22dp"
+                        app:autoSizeMinTextSize="12dp"
+                        android:textColor="@color/background"
+                        tools:text="#123456" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:gravity="center"
+                        android:textAppearance="@style/TextAppearance.Body"
+                        android:labelFor="@id/currentWeekGlobalRankText"
+                        android:layout_below="@id/currentWeekGlobalRankText"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/user_profile_global_rank" />
+
+                </RelativeLayout>
+
+            </com.google.android.flexbox.FlexboxLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:textAlignment="gravity"
+                android:textAppearance="@style/TextAppearance.Title"
+                android:text="@string/user_profile_dates_mapped" />
+
+            <ImageView
+                android:id="@+id/datesActiveView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
This PR improves the profile screen by:

1. Fixing the "osm profile" and "logout" buttons from overlapping with large fonts on small screens by then displaying them in two lines.
2. Allowing scrolling using the entire screen width when the screen is wider than 400 dp (see the scrollbar in the screenshots below).
3. Scaling the top two text views with the user-selected font size (sp instead of dp)
4. Removing unnecessary inner layouts. Most of the highlighted lines in the diff are due to the resulting change in indentation.

Before:
<img src="https://github.com/streetcomplete/StreetComplete/assets/6892794/7ad8f61c-7078-4a27-b7f6-faa6333b2e81" width="400">

After:
<img src="https://github.com/streetcomplete/StreetComplete/assets/6892794/b30f6ba0-ec44-4b6d-8b61-86ca86774af6" width="400">
