### PR TITLE
Move map lifecycle callbacks to onStart / onStop

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -163,15 +163,11 @@ open class MapFragment :
             delay(50)
             sceneMapComponent?.loadScene()
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
         binding.map.onResume()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         binding.map.onPause()
         saveMapState()
     }


### PR DESCRIPTION
This PR changes the lifecycle callbacks so that the tangram map is resumed in `onStart` and paused in `onStop` instead of in `onResume` and `onPause`. This causes the callbacks to be executed a little earlier or later, respectively.

This prevents the map from being completely black during the back gesture animation (when enabled) on Android 14 (see the screenshots below). This is also the recommended behavior on devices supporting multi-window but not multi-resume (see [here](https://developer.android.com/guide/topics/large-screens/multi-window-support#lifecycle)), where an activity could be visible to the user in its paused state.

| Old | New |
| --- | --- |
| <img src="https://github.com/streetcomplete/StreetComplete/assets/6892794/0f7b1b0c-7caf-421b-9bba-db36fea1a1bf" width="250"> | <img src="https://github.com/streetcomplete/StreetComplete/assets/6892794/62bd1550-5534-43e1-a70b-fd7f0ea1c334" width="250"> |

I have been using the app with these changes for some time now and have not experienced any related issues.

