### PR TITLE
Remove unnecessary dontnotes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,11 +3,6 @@
 -dontwarn org.xmlpull.**
 -dontnote org.xmlpull.**
 
-# https://issuetracker.google.com/issues/37070898
--dontnote android.net.http.*
--dontnote org.apache.commons.codec.**
--dontnote org.apache.http.**
-
 # tangram start ------------------------------------------------------------------------------------
 
 # let's just keep everything


### PR DESCRIPTION
The linked issue has been marked as fixed in 2018. I also do not see any related notes printed to the console when building without specifying these three proguard dontnotes.