### PR TITLE
Exclude own package from map app installed check

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.PointF
 import android.graphics.Rect
@@ -809,7 +810,9 @@ class MainFragment :
         val uri = buildGeoUri(pos.latitude, pos.longitude, zoom)
 
         val intent = Intent(Intent.ACTION_VIEW, uri)
-        if (intent.resolveActivity(ctx.packageManager) != null) {
+        val otherMapAppInstalled = ctx.packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            .any { !it.activityInfo.packageName.equals(ctx.packageName) }
+        if (otherMapAppInstalled) {
             startActivity(intent)
         } else {
             ctx.toast(R.string.map_application_missing, Toast.LENGTH_LONG)


### PR DESCRIPTION
As StreetComplete itself can also open geo URIs, the "No other map application installed" toast was not displayed before even if no other map app was actually installed. This PR fixes the behavior by excluding the SC package name from the resolve check. I have tested on an emulator to confirm that the new implementation now works as expected both when another map app is installed and when not.