### PR TITLE
Fix crash #5241

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/DownloadedAreaMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/DownloadedAreaMapComponent.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
 class DownloadedAreaMapComponent(private val ctrl: KtMapController) {
     private var layer: MapData? = null
 
-    fun set(tiles: Collection<TilePos>) {
+    fun set(tiles: Collection<TilePos>) = synchronized(this) {
         // tangram does not clear a layer properly on re-setting features on it, so let's remove
         // and re-add the whole layer
         layer?.remove()


### PR DESCRIPTION
Doing `DownloadedAreaMapComponent.set` synchronized avoids the situation described in https://github.com/streetcomplete/StreetComplete/issues/5241#issuecomment-1722423742.
With this change the crash is not reproducible any more, while without it is reproducible: https://github.com/streetcomplete/StreetComplete/issues/5241#issuecomment-1722410706

I can't guarantee all occurrences of this crash will be fixed by this change, but it fixes the crashes on startup I sometimes had.