### PR TITLE
Update Java to v17 in GitHub Actions

### DIFF
--- a/.github/workflows/generate-quest-list.yml
+++ b/.github/workflows/generate-quest-list.yml
@@ -10,12 +10,12 @@ jobs:
     name: Generate quest list
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: set up JDK 11
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
needed for Android Gradle plugin v8. Follow-up to #5267.