### PR TITLE
Change enabled quests in New Zealand

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -22,11 +22,12 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
         "CA",
         "IE",
         "JE",
-        "AU", // see https://github.com/streetcomplete/StreetComplete/issues/4487
-        "TR", // see https://github.com/streetcomplete/StreetComplete/issues/4489
+        "AU", // https://github.com/streetcomplete/StreetComplete/issues/4487
+        "TR", // https://github.com/streetcomplete/StreetComplete/issues/4489
         "US",
-        "IL", // see https://github.com/streetcomplete/StreetComplete/issues/5119
+        "IL", // https://github.com/streetcomplete/StreetComplete/issues/5119
         "CO", // https://github.com/streetcomplete/StreetComplete/issues/5124
+        "NZ", // https://wiki.openstreetmap.org/w/index.php?title=Talk:StreetComplete/Quests&oldid=2599288#Quests_in_New_Zealand
     )
     override val changesetComment = "Determine bus/tram stop refs"
     override val wikiLink = "Tag:public_transport=platform"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -19,10 +19,11 @@ class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
     override val isDeleteElementEnabled = true
     override val achievements = listOf(POSTMAN)
     override val enabledInCountries = NoCountriesExcept(
-        // United Kingdom and some former nations of the British Empire, members of the Commonwealth of Nations and British overseas territories etc
-        "GB", "GI", "CY", "HK", "MT", "NZ", "LK",
+        // United Kingdom and some former nations of the British Empire, members of the Commonwealth of Nations and British overseas territories etc.
+        "GB", "GI", "CY", "HK", "MT", "LK",
         // territories with agency postal services provided by the British Post Office
         "KW", "BH", "MA"
+        // Not New Zealand: https://wiki.openstreetmap.org/w/index.php?title=Talk:StreetComplete/Quests&oldid=2599288#Quests_in_New_Zealand
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_postboxRoyalCypher_title


### PR DESCRIPTION
* disable `AddPostboxRoyalCypher`
* enable `AddBusStopRef`

See https://wiki.openstreetmap.org/wiki/Talk:StreetComplete/Quests#Quests_in_New_Zealand for more context. Note that I put a permalink to that page version in the code comments.