### PR TITLE
Pass `getCountryInfoByLocation` and `getCountryCodeByLocation` to quests/modules

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/OverlaysModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/OverlaysModule.kt
@@ -3,7 +3,10 @@ package de.westnordost.streetcomplete.overlays
 import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.osmfeatures.Feature
 import de.westnordost.osmfeatures.FeatureDictionary
+import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.meta.CountryInfos
+import de.westnordost.streetcomplete.data.meta.getByLocation
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
 import de.westnordost.streetcomplete.overlays.address.AddressOverlay
 import de.westnordost.streetcomplete.overlays.cycleway.CyclewayOverlay
@@ -13,6 +16,7 @@ import de.westnordost.streetcomplete.overlays.street_parking.StreetParkingOverla
 import de.westnordost.streetcomplete.overlays.surface.SurfaceOverlay
 import de.westnordost.streetcomplete.overlays.way_lit.WayLitOverlay
 import de.westnordost.streetcomplete.util.ktx.getFeature
+import de.westnordost.streetcomplete.util.ktx.getIds
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.util.concurrent.FutureTask
@@ -22,8 +26,15 @@ import java.util.concurrent.FutureTask
 val overlaysModule = module {
     single {
         overlaysRegistry(
-            get(),
-            { get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get() },
+            { location ->
+                val countryInfos = get<CountryInfos>()
+                val countryBoundaries = get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get()
+                countryInfos.getByLocation(countryBoundaries, location.longitude, location.latitude)
+            },
+            { location ->
+                val countryBoundaries = get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get()
+                countryBoundaries.getIds(location).firstOrNull()
+            },
             { tags ->
                 get<FutureTask<FeatureDictionary>>(named("FeatureDictionaryFuture"))
                 .get().getFeature(tags)
@@ -33,16 +44,16 @@ val overlaysModule = module {
 }
 
 fun overlaysRegistry(
-    countryInfos: CountryInfos,
-    getCountryBoundaries: () -> CountryBoundaries,
+    getCountryInfoByLocation: (location: LatLon) -> CountryInfo,
+    getCountryCodeByLocation: (location: LatLon) -> String?,
     getFeature: (tags: Map<String, String>) -> Feature?,
 ) = OverlayRegistry(listOf(
 
     0 to WayLitOverlay(),
     6 to SurfaceOverlay(),
     1 to SidewalkOverlay(),
-    5 to CyclewayOverlay(countryInfos, getCountryBoundaries),
+    5 to CyclewayOverlay(getCountryInfoByLocation),
     2 to StreetParkingOverlay(),
-    3 to AddressOverlay(getCountryBoundaries),
+    3 to AddressOverlay(getCountryCodeByLocation),
     4 to ShopsOverlay(getFeature),
 ))

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/OverlaysModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/OverlaysModule.kt
@@ -23,7 +23,7 @@ val overlaysModule = module {
     single {
         overlaysRegistry(
             get(),
-            get(named("CountryBoundariesFuture")),
+            { get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get() },
             { tags ->
                 get<FutureTask<FeatureDictionary>>(named("FeatureDictionaryFuture"))
                 .get().getFeature(tags)
@@ -34,15 +34,15 @@ val overlaysModule = module {
 
 fun overlaysRegistry(
     countryInfos: CountryInfos,
-    countryBoundariesFuture: FutureTask<CountryBoundaries>,
+    getCountryBoundaries: () -> CountryBoundaries,
     getFeature: (tags: Map<String, String>) -> Feature?,
 ) = OverlayRegistry(listOf(
 
     0 to WayLitOverlay(),
     6 to SurfaceOverlay(),
     1 to SidewalkOverlay(),
-    5 to CyclewayOverlay(countryInfos, countryBoundariesFuture),
+    5 to CyclewayOverlay(countryInfos, getCountryBoundaries),
     2 to StreetParkingOverlay(),
-    3 to AddressOverlay(countryBoundariesFuture),
+    3 to AddressOverlay(getCountryBoundaries),
     4 to ShopsOverlay(getFeature),
 ))

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlay.kt
@@ -13,10 +13,9 @@ import de.westnordost.streetcomplete.overlays.PolygonStyle
 import de.westnordost.streetcomplete.quests.address.AddHousenumber
 import de.westnordost.streetcomplete.util.getShortHouseNumber
 import de.westnordost.streetcomplete.util.ktx.getIds
-import java.util.concurrent.FutureTask
 
 class AddressOverlay(
-    private val countryBoundaries: FutureTask<CountryBoundaries>
+    private val getCountryBoundaries: () -> CountryBoundaries
 ) : Overlay {
 
     override val title = R.string.overlay_addresses
@@ -49,7 +48,7 @@ class AddressOverlay(
             .filter("ways, relations with building")
             .filter {
                 val center = mapData.getGeometry(it.type, it.id)?.center ?: return@filter false
-                val country = countryBoundaries.get().getIds(center).firstOrNull()
+                val country = getCountryBoundaries().getIds(center).firstOrNull()
                 country !in noAddressesOnBuildings
             }
             .map { it to PolygonStyle(Color.INVISIBLE, label = getShortHouseNumber(it.tags)) }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/address/AddressOverlay.kt
@@ -1,8 +1,8 @@
 package de.westnordost.streetcomplete.overlays.address
 
-import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.POSTMAN
@@ -12,10 +12,9 @@ import de.westnordost.streetcomplete.overlays.PointStyle
 import de.westnordost.streetcomplete.overlays.PolygonStyle
 import de.westnordost.streetcomplete.quests.address.AddHousenumber
 import de.westnordost.streetcomplete.util.getShortHouseNumber
-import de.westnordost.streetcomplete.util.ktx.getIds
 
 class AddressOverlay(
-    private val getCountryBoundaries: () -> CountryBoundaries
+    private val getCountryCodeByLocation: (location: LatLon) -> String?
 ) : Overlay {
 
     override val title = R.string.overlay_addresses
@@ -48,7 +47,7 @@ class AddressOverlay(
             .filter("ways, relations with building")
             .filter {
                 val center = mapData.getGeometry(it.type, it.id)?.center ?: return@filter false
-                val country = getCountryBoundaries().getIds(center).firstOrNull()
+                val country = getCountryCodeByLocation(center)
                 country !in noAddressesOnBuildings
             }
             .map { it to PolygonStyle(Color.INVISIBLE, label = getShortHouseNumber(it.tags)) }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
@@ -27,11 +27,10 @@ import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.PolylineStyle
 import de.westnordost.streetcomplete.overlays.StrokeStyle
 import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
-import java.util.concurrent.FutureTask
 
 class CyclewayOverlay(
     private val countryInfos: CountryInfos,
-    private val countryBoundaries: FutureTask<CountryBoundaries>
+    private val getCountryBoundaries: () -> CountryBoundaries
 ) : Overlay {
 
     override val title = R.string.overlay_cycleway
@@ -50,7 +49,7 @@ class CyclewayOverlay(
         """).mapNotNull {
             val pos = mapData.getWayGeometry(it.id)?.center ?: return@mapNotNull null
             val countryInfo = countryInfos.getByLocation(
-                countryBoundaries.get(),
+                getCountryBoundaries(),
                 pos.longitude,
                 pos.latitude
             )

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
@@ -1,12 +1,10 @@
 package de.westnordost.streetcomplete.overlays.cycleway
 
-import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfo
-import de.westnordost.streetcomplete.data.meta.CountryInfos
-import de.westnordost.streetcomplete.data.meta.getByLocation
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
@@ -29,8 +27,7 @@ import de.westnordost.streetcomplete.overlays.StrokeStyle
 import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
 
 class CyclewayOverlay(
-    private val countryInfos: CountryInfos,
-    private val getCountryBoundaries: () -> CountryBoundaries
+    private val getCountryInfoByLocation: (location: LatLon) -> CountryInfo,
 ) : Overlay {
 
     override val title = R.string.overlay_cycleway
@@ -48,11 +45,7 @@ class CyclewayOverlay(
               and area != yes
         """).mapNotNull {
             val pos = mapData.getWayGeometry(it.id)?.center ?: return@mapNotNull null
-            val countryInfo = countryInfos.getByLocation(
-                getCountryBoundaries(),
-                pos.longitude,
-                pos.latitude
-            )
+            val countryInfo = getCountryInfoByLocation(pos)
             it to getStreetCyclewayStyle(it, countryInfo)
         } +
         // separately mapped ways

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -3,7 +3,10 @@ package de.westnordost.streetcomplete.quests
 import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.osmfeatures.Feature
 import de.westnordost.osmfeatures.FeatureDictionary
+import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.meta.CountryInfos
+import de.westnordost.streetcomplete.data.meta.getByLocation
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.quests.accepts_cards.AddAcceptsCards
@@ -182,8 +185,11 @@ val questsModule = module {
             get(),
             get(),
             get(),
-            get(),
-            { get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get() },
+            { location ->
+                val countryInfos = get<CountryInfos>()
+                val countryBoundaries = get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get()
+                countryInfos.getByLocation(countryBoundaries, location.longitude, location.latitude)
+            },
             { tags ->
                 get<FutureTask<FeatureDictionary>>(named("FeatureDictionaryFuture"))
                     .get().getFeature(tags)
@@ -195,9 +201,8 @@ val questsModule = module {
 fun questTypeRegistry(
     trafficFlowSegmentsApi: TrafficFlowSegmentsApi,
     trafficFlowDao: WayTrafficFlowDao,
-    countryInfos: CountryInfos,
     arSupportChecker: ArSupportChecker,
-    getCountryBoundaries: () -> CountryBoundaries,
+    getCountryInfoByLocation: (location: LatLon) -> CountryInfo,
     getFeature: (tags: Map<String, String>) -> Feature?,
 ) = QuestTypeRegistry(listOf(
 
@@ -474,7 +479,7 @@ fun questTypeRegistry(
     134 to AddSidewalk(), // for any pedestrian routers, needs minimal thinking
     135 to AddRoadSurface(), // used by BRouter, OsmAnd, OSRM, graphhopper, HOT map style... - sometimes requires way to be split
     136 to AddTracktype(), // widely used in map rendering - OSM Carto, OsmAnd...
-    137 to AddCycleway(countryInfos, getCountryBoundaries), // for any cyclist routers (and cyclist maps)
+    137 to AddCycleway(getCountryInfoByLocation), // for any cyclist routers (and cyclist maps)
     138 to AddLanes(), // abstreet, certainly most routing engines - often requires way to be split
 
     // disabled completely because definition is too fuzzy/broad to be useful and easy to answer,
@@ -500,7 +505,7 @@ fun questTypeRegistry(
     // buildings
     150 to AddBuildingType(),
     151 to AddBuildingLevels(),
-    152 to AddRoofShape(countryInfos, getCountryBoundaries),
+    152 to AddRoofShape(getCountryInfoByLocation),
 
     153 to AddStepCount(), // can only be gathered when walking along this way, also needs the most effort and least useful
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -182,8 +182,8 @@ val questsModule = module {
             get(),
             get(),
             get(),
-            get(named("CountryBoundariesFuture")),
             get(),
+            { get<FutureTask<CountryBoundaries>>(named("CountryBoundariesFuture")).get() },
             { tags ->
                 get<FutureTask<FeatureDictionary>>(named("FeatureDictionaryFuture"))
                     .get().getFeature(tags)
@@ -196,8 +196,8 @@ fun questTypeRegistry(
     trafficFlowSegmentsApi: TrafficFlowSegmentsApi,
     trafficFlowDao: WayTrafficFlowDao,
     countryInfos: CountryInfos,
-    countryBoundariesFuture: FutureTask<CountryBoundaries>,
     arSupportChecker: ArSupportChecker,
+    getCountryBoundaries: () -> CountryBoundaries,
     getFeature: (tags: Map<String, String>) -> Feature?,
 ) = QuestTypeRegistry(listOf(
 
@@ -474,7 +474,7 @@ fun questTypeRegistry(
     134 to AddSidewalk(), // for any pedestrian routers, needs minimal thinking
     135 to AddRoadSurface(), // used by BRouter, OsmAnd, OSRM, graphhopper, HOT map style... - sometimes requires way to be split
     136 to AddTracktype(), // widely used in map rendering - OSM Carto, OsmAnd...
-    137 to AddCycleway(countryInfos, countryBoundariesFuture), // for any cyclist routers (and cyclist maps)
+    137 to AddCycleway(countryInfos, getCountryBoundaries), // for any cyclist routers (and cyclist maps)
     138 to AddLanes(), // abstreet, certainly most routing engines - often requires way to be split
 
     // disabled completely because definition is too fuzzy/broad to be useful and easy to answer,
@@ -500,7 +500,7 @@ fun questTypeRegistry(
     // buildings
     150 to AddBuildingType(),
     151 to AddBuildingLevels(),
-    152 to AddRoofShape(countryInfos, countryBoundariesFuture),
+    152 to AddRoofShape(countryInfos, getCountryBoundaries),
 
     153 to AddStepCount(), // can only be gathered when walking along this way, also needs the most effort and least useful
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -25,11 +25,10 @@ import de.westnordost.streetcomplete.osm.cycleway.applyTo
 import de.westnordost.streetcomplete.osm.cycleway.createCyclewaySides
 import de.westnordost.streetcomplete.osm.cycleway.isAmbiguous
 import de.westnordost.streetcomplete.osm.surface.ANYTHING_UNPAVED
-import java.util.concurrent.FutureTask
 
 class AddCycleway(
     private val countryInfos: CountryInfos,
-    private val countryBoundariesFuture: FutureTask<CountryBoundaries>,
+    private val getCountryBoundaries: () -> CountryBoundaries,
 ) : OsmElementQuestType<LeftAndRightCycleway> {
 
     override val changesetComment = "Specify whether there are cycleways"
@@ -87,7 +86,7 @@ class AddCycleway(
         val oldRoadsWithKnownCycleways = eligibleRoads.filter { way ->
             val countryInfo = mapData.getWayGeometry(way.id)?.center?.let { p ->
                 countryInfos.getByLocation(
-                    countryBoundariesFuture.get(),
+                    getCountryBoundaries(),
                     p.longitude,
                     p.latitude,
                 )
@@ -108,7 +107,7 @@ class AddCycleway(
 
     override fun applyAnswerTo(answer: LeftAndRightCycleway, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         val countryInfo = countryInfos.getByLocation(
-            countryBoundariesFuture.get(),
+            getCountryBoundaries(),
             geometry.center.longitude,
             geometry.center.latitude
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -1,15 +1,13 @@
 package de.westnordost.streetcomplete.quests.cycleway
 
-import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.filters.RelativeDate
 import de.westnordost.streetcomplete.data.elementfilter.filters.TagOlderThan
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfo
-import de.westnordost.streetcomplete.data.meta.CountryInfos
-import de.westnordost.streetcomplete.data.meta.getByLocation
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
@@ -27,8 +25,7 @@ import de.westnordost.streetcomplete.osm.cycleway.isAmbiguous
 import de.westnordost.streetcomplete.osm.surface.ANYTHING_UNPAVED
 
 class AddCycleway(
-    private val countryInfos: CountryInfos,
-    private val getCountryBoundaries: () -> CountryBoundaries,
+    private val getCountryInfoByLocation: (location: LatLon) -> CountryInfo,
 ) : OsmElementQuestType<LeftAndRightCycleway> {
 
     override val changesetComment = "Specify whether there are cycleways"
@@ -84,12 +81,8 @@ class AddCycleway(
         val eligibleRoads = mapData.ways.filter { roadsFilter.matches(it) }
         val roadsWithMissingCycleway = eligibleRoads.filter { untaggedRoadsFilter.matches(it) }
         val oldRoadsWithKnownCycleways = eligibleRoads.filter { way ->
-            val countryInfo = mapData.getWayGeometry(way.id)?.center?.let { p ->
-                countryInfos.getByLocation(
-                    getCountryBoundaries(),
-                    p.longitude,
-                    p.latitude,
-                )
+            val countryInfo = mapData.getWayGeometry(way.id)?.center?.let {
+                getCountryInfoByLocation(it)
             }
             way.hasOldInvalidOrAmbiguousCyclewayTags(countryInfo) == true
         }
@@ -106,11 +99,7 @@ class AddCycleway(
     override fun createForm() = AddCyclewayForm()
 
     override fun applyAnswerTo(answer: LeftAndRightCycleway, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        val countryInfo = countryInfos.getByLocation(
-            getCountryBoundaries(),
-            geometry.center.longitude,
-            geometry.center.latitude
-        )
+        val countryInfo = getCountryInfoByLocation(geometry.center)
         answer.applyTo(tags, countryInfo.isLeftHandTraffic)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -1,12 +1,11 @@
 package de.westnordost.streetcomplete.quests.roof_shape
 
-import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
-import de.westnordost.streetcomplete.data.meta.CountryInfos
-import de.westnordost.streetcomplete.data.meta.getByLocation
+import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BUILDING
@@ -14,8 +13,7 @@ import de.westnordost.streetcomplete.osm.BUILDINGS_WITH_LEVELS
 import de.westnordost.streetcomplete.osm.Tags
 
 class AddRoofShape(
-    private val countryInfos: CountryInfos,
-    private val getCountryBoundaries: () -> CountryBoundaries,
+    private val getCountryInfoByLocation: (location: LatLon) -> CountryInfo,
 ) : OsmElementQuestType<RoofShape> {
 
     private val filter by lazy { """
@@ -57,11 +55,7 @@ class AddRoofShape(
 
     private fun roofsAreUsuallyFlatAt(element: Element, mapData: MapDataWithGeometry): Boolean? {
         val center = mapData.getGeometry(element.type, element.id)?.center ?: return null
-        return countryInfos.getByLocation(
-            getCountryBoundaries(),
-            center.longitude,
-            center.latitude,
-        ).roofsAreUsuallyFlat
+        return getCountryInfoByLocation(center).roofsAreUsuallyFlat
     }
 
     override fun applyAnswerTo(answer: RoofShape, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -12,11 +12,10 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BUILDING
 import de.westnordost.streetcomplete.osm.BUILDINGS_WITH_LEVELS
 import de.westnordost.streetcomplete.osm.Tags
-import java.util.concurrent.FutureTask
 
 class AddRoofShape(
     private val countryInfos: CountryInfos,
-    private val countryBoundariesFuture: FutureTask<CountryBoundaries>,
+    private val getCountryBoundaries: () -> CountryBoundaries,
 ) : OsmElementQuestType<RoofShape> {
 
     private val filter by lazy { """
@@ -59,7 +58,7 @@ class AddRoofShape(
     private fun roofsAreUsuallyFlatAt(element: Element, mapData: MapDataWithGeometry): Boolean? {
         val center = mapData.getGeometry(element.type, element.id)?.center ?: return null
         return countryInfos.getByLocation(
-            countryBoundariesFuture.get(),
+            getCountryBoundaries(),
             center.longitude,
             center.latitude,
         ).roofsAreUsuallyFlat


### PR DESCRIPTION
Follow-up to #5273. This PR implements similar changes for `CountryBoundariesFuture`. Thus, more implementation detail is abstracted from the quests/overlays and the Java dependency is reduced a bit.