### PR TITLE
Enable searching by English quest titles

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
@@ -137,7 +137,7 @@ class QuestSelectionAdapter(
         }
 
         override fun onQuestTypeOrdersChanged() {
-            // all/many quest orders have been changed - reinit list
+            // all/many quest orders have been changed - re-init list
             viewLifecycleScope.launch { questTypes = createQuestTypeVisibilityList() }
         }
     }
@@ -319,7 +319,7 @@ class QuestSelectionAdapter(
                 AlertDialog.Builder(compoundButton.context)
                     .setTitle(R.string.enable_quest_confirmation_title)
                     .setMessage(item.questType.defaultDisabledMessage)
-                    .setPositiveButton(android.R.string.ok) { _, _ -> applyChecked(b) }
+                    .setPositiveButton(android.R.string.ok) { _, _ -> applyChecked(true) }
                     .setNegativeButton(android.R.string.cancel) { _, _ -> compoundButton.isChecked = false }
                     .setOnCancelListener { compoundButton.isChecked = false }
                     .show()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
@@ -313,7 +313,7 @@ class QuestSelectionAdapter(
                 AlertDialog.Builder(compoundButton.context)
                     .setTitle(R.string.enable_quest_confirmation_title)
                     .setMessage(item.questType.defaultDisabledMessage)
-                    .setPositiveButton(android.R.string.ok) { _, _ -> applyChecked(true) }
+                    .setPositiveButton(android.R.string.ok) { _, _ -> applyChecked(b) }
                     .setNegativeButton(android.R.string.cancel) { _, _ -> compoundButton.isChecked = false }
                     .setOnCancelListener { compoundButton.isChecked = false }
                     .show()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionAdapter.kt
@@ -89,15 +89,9 @@ class QuestSelectionAdapter(
             }
         }
 
-    private fun questTypeMatchesSearchWords(questType: QuestType, words: List<String>): Boolean {
-        val question = genericQuestTitle(context.resources, questType).lowercase()
-        if (question.containsAll(words)) {
-            return true
-        }
-
-        val englishQuestion = genericQuestTitle(englishResources, questType).lowercase()
-        return englishQuestion.containsAll(words)
-    }
+    private fun questTypeMatchesSearchWords(questType: QuestType, words: List<String>) =
+        genericQuestTitle(context.resources, questType).lowercase().containsAll(words)
+        || genericQuestTitle(englishResources, questType).lowercase().containsAll(words)
 
     private fun filterQuestTypes(f: String) {
         if (f.isEmpty()) {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/String.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/String.kt
@@ -2,3 +2,5 @@ package de.westnordost.streetcomplete.util.ktx
 
 fun String.truncate(length: Int): String =
     if (this.length > length) substring(0, length - 1) + "…" else this
+
+fun String.containsAll(words: List<String>) = words.all { this.contains(it) }


### PR DESCRIPTION
This might make it easier to find quests where you don't know the exact translation. E.g. the [quest list in the OSM Wiki](https://wiki.openstreetmap.org/wiki/StreetComplete/Quests) is only in English.