### PR TITLE
Improve quest preset UX

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsAdapter.kt
@@ -141,6 +141,7 @@ class QuestPresetsAdapter(
             val dialog = EditTextDialog(ctx,
                 title = ctx.getString(R.string.quest_presets_rename),
                 text = preset.name,
+                hint = ctx.getString(R.string.quest_presets_preset_name),
                 callback = { name -> renameQuestPreset(preset.id, name) }
             )
             dialog.editText.filters = arrayOf(InputFilter.LengthFilter(60))
@@ -157,6 +158,7 @@ class QuestPresetsAdapter(
             val dialog = EditTextDialog(ctx,
                 title = ctx.getString(R.string.quest_presets_duplicate),
                 text = preset.name,
+                hint = ctx.getString(R.string.quest_presets_preset_name),
                 callback = { name -> duplicateQuestPreset(preset.id, name) }
             )
             dialog.editText.filters = arrayOf(InputFilter.LengthFilter(60))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsAdapter.kt
@@ -170,6 +170,7 @@ class QuestPresetsAdapter(
                 val newPresetId = questPresetsController.add(name)
                 questTypeOrderController.copyOrders(presetId, newPresetId)
                 visibleQuestTypeController.copyVisibilities(presetId, newPresetId)
+                questPresetsController.selectedId = newPresetId
             }
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsFragment.kt
@@ -43,9 +43,9 @@ class QuestPresetsFragment : TwoPaneDetailFragment(R.layout.fragment_quest_prese
         val ctx = context ?: return
         val dialog = EditTextDialog(ctx,
             title = ctx.getString(R.string.quest_presets_preset_add),
+            hint = ctx.getString(R.string.quest_presets_preset_name),
             callback = { name -> addQuestPreset(name) }
         )
-        dialog.editText.hint = ctx.getString(R.string.quest_presets_preset_name)
         dialog.editText.filters = arrayOf(InputFilter.LengthFilter(60))
         dialog.show()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestPresetsFragment.kt
@@ -52,7 +52,8 @@ class QuestPresetsFragment : TwoPaneDetailFragment(R.layout.fragment_quest_prese
 
     private fun addQuestPreset(name: String) {
         viewLifecycleScope.launch(Dispatchers.IO) {
-            questPresetsController.add(name)
+            val newPresetId = questPresetsController.add(name)
+            questPresetsController.selectedId = newPresetId
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/EditTextDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/EditTextDialog.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.util.ktx.nonBlankTextOrNull
+import de.westnordost.streetcomplete.util.ktx.showKeyboard
 
 /** A dialog in which you input a text */
 class EditTextDialog(
@@ -46,6 +47,13 @@ class EditTextDialog(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         updateEditButtonEnablement()
+    }
+
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        if (hasWindowFocus) {
+            editText.requestFocus()
+            editText.showKeyboard()
+        }
     }
 
     private fun updateEditButtonEnablement() {

--- a/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/EditTextDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/dialogs/EditTextDialog.kt
@@ -15,6 +15,7 @@ class EditTextDialog(
     context: Context,
     title: CharSequence? = null,
     text: String? = null,
+    hint: String? = null,
     @LayoutRes layoutResId: Int = R.layout.dialog_edit_text,
     private val callback: (value: String) -> Unit
 ) : AlertDialog(context) {
@@ -28,6 +29,7 @@ class EditTextDialog(
 
         editText = view.findViewById(R.id.editText)
         editText.setText(text)
+        editText.hint = hint
         editText.doAfterTextChanged {
             updateEditButtonEnablement()
         }


### PR DESCRIPTION
* Add hint to preset name input field when renaming or duplicating preset
* Auto-focus preset name input field when opening the dialog
* Automatically select newly added/duplicated preset