### PR TITLE
Allow searching in debug "Show quest forms" view

### DIFF
--- a/app/src/main/res/menu/menu_debug_quest_forms.xml
+++ b/app/src/main/res/menu/menu_debug_quest_forms.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/action_search"
+        android:title="@string/action_search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        android:icon="@drawable/ic_search_24dp"
+        app:showAsAction="ifRoom"/>
+
+</menu>


### PR DESCRIPTION
The more quests we add, the harder it gets to find the quest in the debug "Show quest forms" list. This PR adds a simple search filter, just like we have in the quest selection view. It also uses basically the same implementation as in the quest selection view.

Fixes #3229.