### PR TITLE
Add santiary dump station fee quest (Needs Icon)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sanitary_dump_station_fee/AddSanitaryDumpStationFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sanitary_dump_station_fee/AddSanitaryDumpStationFee.kt
@@ -1,0 +1,37 @@
+package de.westnordost.streetcomplete.quests.sanitary_dump_station_fee
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.YesNoQuestForm
+import de.westnordost.streetcomplete.util.ktx.toYesNo
+
+class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
+
+    override val elementFilter = """
+        nodes, ways with
+         amenity = sanitary_dump_station
+         and !fee
+    """
+    override val changesetComment = "Specify if sanitary dump station requires a fee"
+    override val wikiLink = "Tag:amenity=sanitary_dump_station"
+    override val icon = R.drawable.ic_quest_fuel_self_service
+    override val isDeleteElementEnabled = true
+    override val achievements = listOf(OUTDOORS)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_sanitary_dump_station_fee_title
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("nodes, ways with amenity = sanitary_dump_station")
+
+    override fun createForm() = YesNoQuestForm()
+
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags["fee"] = answer.toYesNo()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1367,6 +1367,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_seating_outdoor_only">Outdoor seating only</string>
     <string name="quest_seating_indoor_and_outdoor">Both indoor and outdoor seating</string>
 
+    <string name="quest_sanitary_dump_station_fee_title">Does this Sanitary Dump Station require a fee?</string>
+
     <string name="quest_segregated_title">How are the footpath and bicycle path laid out here?</string>
     <string name="quest_segregated_separated">Segregated from one another</string>
     <string name="quest_segregated_mixed">Cyclists and pedestrians share the same space</string>


### PR DESCRIPTION
This quest applies to ~50% of all sanitary dump stations on OSM. This quest will ask "Does this Sanitary Dump Station require a fee?"

This PR needs a icon.