### PR TITLE
Extend General fee with Sanitary Dump Stations

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -23,7 +23,11 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
     override val icon = R.drawable.ic_quest_fee
     override val achievements = listOf(CITIZEN)
 
-    override fun getTitle(tags: Map<String, String>) = R.string.quest_generalFee_title2
+    override fun getTitle(tags: Map<String, String>) =
+     if (tags["amenity"] == "sanitary_dump_station")
+         R.string.quest_generalFee_title
+     else
+         R.string.quest_generalFee_title2
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -12,7 +12,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-         (tourism = museum or leisure = beach_resort or tourism = gallery or tourism = caravan_site)
+         (tourism = museum or leisure = beach_resort or tourism = gallery or tourism = caravan_site or amenity = sanitary_dump_station)
          and access !~ private|no
          and !fee
     """

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -12,7 +12,9 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-         (tourism = museum or leisure = beach_resort or tourism = gallery or tourism = caravan_site or amenity = sanitary_dump_station)
+         tourism ~ museum|gallery|caravan_site
+         or leisure = beach_resort
+         or amenity = sanitary_dump_station
          and access !~ private|no
          and !fee
     """

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -12,9 +12,11 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-         tourism ~ museum|gallery|caravan_site
-         or leisure = beach_resort
-         or amenity = sanitary_dump_station
+         (
+           tourism ~ museum|gallery|caravan_site
+           or leisure = beach_resort
+           or amenity = sanitary_dump_station
+         )
          and access !~ private|no
          and !fee
     """

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1038,6 +1038,7 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
     <!-- "Self-service" refers to a situation where patrons can pump gas for themselves -->
     <string name="quest_fuelSelfService_title">Does this gas station allow self-service?</string>
 
+    <string name="quest_generalFee_title">Do you need to pay to use this?</string>
     <string name="quest_generalFee_title2">Do you need to pay to enter here?</string>
     <string name="quest_genericRef_title">What’s the identification number here?</string>
 


### PR DESCRIPTION
This quest applies to ~50% of all sanitary dump stations on OSM. I extended the General Fee Quest, and added Sanitary Dump Stations.