### PR TITLE
AddIsAmenityIndoor: Don't ask for amenities under building=roof

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
@@ -31,8 +31,11 @@ class AddIsAmenityIndoor(private val getFeature: (tags: Map<String, String>) -> 
     """.toElementFilterExpression() }
 
     /* We only want survey nodes within building outlines. */
+    // exclude building=roof, see https://github.com/streetcomplete/StreetComplete/issues/5333
     private val buildingFilter by lazy { """
-        ways, relations with building
+        ways, relations with 
+            building
+            and building != roof 
     """.toElementFilterExpression() }
 
     override val changesetComment = "Determine whether amenities are inside buildings"


### PR DESCRIPTION
See #5333
This excludes building=roof from the element selection, so nodes within roof outline will not longer be surveyed as potentially indoor.