### PR TITLE
Upgrading minor dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,17 +175,17 @@ dependencies {
     implementation("org.jbox2d:jbox2d-library:2.2.1.1")
 
     // sharing presets/settings via QR Code
-    implementation("com.google.zxing:core:3.5.0")
+    implementation("com.google.zxing:core:3.5.2")
 
     // serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
-    implementation("com.charleskorn.kaml:kaml:0.48.0")
+    implementation("com.charleskorn.kaml:kaml:0.55.0")
 
     // map and location
     implementation("com.mapzen.tangram:tangram:0.17.1")
 
     // opening hours parser
-    implementation("ch.poole:OpeningHoursParser:0.27.0")
+    implementation("ch.poole:OpeningHoursParser:0.27.1")
 
     // image view that allows zoom and pan
     implementation("com.github.chrisbanes:PhotoView:2.3.0")


### PR DESCRIPTION
**What**: Upgrading 3 minor dependencies: zxing, kaml and OpeningHoursParser to their latest available versions.

**Why**: For no specific reason other than staying up-to-date