### PR TITLE
Get rid of CopyOnWriteArrayList

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/UnsyncedChangesCountSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/UnsyncedChangesCountSource.kt
@@ -4,9 +4,9 @@ import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditsSource
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEdit
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsSource
+import de.westnordost.streetcomplete.util.Listeners
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** Access and listen to how many unsynced (=uploadable) changes there are */
 class UnsyncedChangesCountSource(
@@ -18,7 +18,7 @@ class UnsyncedChangesCountSource(
         fun onDecreased()
     }
 
-    private val listeners = CopyOnWriteArrayList<Listener>()
+    private val listeners = Listeners<Listener>()
 
     suspend fun getCount(): Int = withContext(Dispatchers.IO) {
         elementEditsSource.getUnsyncedCount() + noteEditsSource.getUnsyncedCount()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/DownloadProgressRelay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/DownloadProgressRelay.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.data.download
 
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class DownloadProgressRelay : DownloadProgressListener {
 
-    private val listeners = CopyOnWriteArrayList<DownloadProgressListener>()
+    private val listeners = Listeners<DownloadProgressListener>()
 
     override fun onStarted() { listeners.forEach { it.onStarted() } }
     override fun onError(e: Exception) { listeners.forEach { it.onError(e) } }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/download/tiles/DownloadedTilesController.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.download.tiles
 
 import de.westnordost.streetcomplete.ApplicationConstants
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 class DownloadedTilesController(
     private val dao: DownloadedTilesDao
 ) : DownloadedTilesSource {
 
-    private val listeners = CopyOnWriteArrayList<DownloadedTilesSource.Listener>()
+    private val listeners = Listeners<DownloadedTilesSource.Listener>()
 
     override fun contains(tilesRect: TilesRect, ignoreOlderThan: Long): Boolean =
         dao.contains(tilesRect, ignoreOlderThan)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
@@ -12,8 +12,8 @@ import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsController
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsSource
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestController
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestHidden
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** All edits done by the user in one place: Edits made on notes, on map data, hidings of quests */
 class EditHistoryController(
@@ -22,7 +22,7 @@ class EditHistoryController(
     private val noteQuestController: OsmNoteQuestController,
     private val osmQuestController: OsmQuestController
 ) : EditHistorySource {
-    private val listeners: MutableList<EditHistorySource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<EditHistorySource.Listener>()
 
     private val osmElementEditsListener = object : ElementEditsSource.Listener {
         override fun onAddedEdit(edit: ElementEdit) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/messages/MessagesSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/messages/MessagesSource.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.user.UserDataController
 import de.westnordost.streetcomplete.data.user.UserDataSource
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
 import de.westnordost.streetcomplete.data.user.achievements.AchievementsSource
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** This class is to access user messages, which are basically dialogs that pop up when
  *  clicking on the mail icon, such as "you have a new OSM message in your inbox" etc. */
@@ -24,7 +24,7 @@ class MessagesSource(
     interface UpdateListener {
         fun onNumberOfMessagesUpdated(numberOfMessages: Int)
     }
-    private val listeners: MutableList<UpdateListener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<UpdateListener>()
 
     /** Achievement levels unlocked since application start. I.e. when restarting the app, the
      *  messages about new achievements unlocked are lost, this is deliberate */
@@ -110,8 +110,6 @@ class MessagesSource(
     }
 
     private fun onNumberOfMessagesUpdated() {
-        for (listener in listeners) {
-            listener.onNumberOfMessagesUpdated(getNumberOfMessages())
-        }
+        listeners.forEach { it.onNumberOfMessagesUpdated(getNumberOfMessages()) }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/messages/QuestSelectionHintController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/messages/QuestSelectionHintController.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.messages.QuestSelectionHintState.SHOUL
 import de.westnordost.streetcomplete.data.quest.Quest
 import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.data.quest.VisibleQuestsSource
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class QuestSelectionHintController(
     private val visibleQuestsSource: VisibleQuestsSource,
@@ -19,7 +19,7 @@ class QuestSelectionHintController(
     interface Listener {
         fun onQuestSelectionHintStateChanged()
     }
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     var state: QuestSelectionHintState
         set(value) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -4,8 +4,8 @@ import de.westnordost.streetcomplete.data.osm.edits.upload.LastEditTimeStore
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 class ElementEditsController(
     private val editsDB: ElementEditsDao,
@@ -16,7 +16,7 @@ class ElementEditsController(
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */
 
-    private val listeners: MutableList<ElementEditsSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<ElementEditsSource.Listener>()
 
     /* ----------------------- Unsynced edits and syncing them -------------------------------- */
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -26,9 +26,9 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Relation
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.key
 import de.westnordost.streetcomplete.data.upload.ConflictException
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.math.contains
 import de.westnordost.streetcomplete.util.math.intersect
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** Source for map data. It combines the original data downloaded with the edits made.
  *
@@ -52,7 +52,7 @@ class MapDataWithEditsSource internal constructor(
         /** Called when all map data has been cleared */
         fun onCleared()
     }
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     /* For thread-safety, all access to these three fields is synchronized. Since there is no hell
      * of parallelism, simply any method that somehow accesses these fields (~just about any method

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataController.kt
@@ -6,9 +6,9 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryDao
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryEntry
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.format
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** Controller to access element data and its geometry and handle updates to it (from OSM API) */
 class MapDataController internal constructor(
@@ -36,7 +36,7 @@ class MapDataController internal constructor(
         /** Called when all elements have been cleared */
         fun onCleared()
     }
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     private val cache = MapDataCache(
         SPATIAL_CACHE_TILE_ZOOM,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
@@ -22,6 +22,7 @@ import de.westnordost.streetcomplete.quests.existence.CheckExistence
 import de.westnordost.streetcomplete.quests.oneway_suspects.AddSuspectedOneway
 import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
 import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.format
 import de.westnordost.streetcomplete.util.ktx.intersects
 import de.westnordost.streetcomplete.util.ktx.isInAny
@@ -38,7 +39,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.FutureTask
 
 /** Controller for managing OsmQuests. Takes care of persisting OsmQuest objects and notifying
@@ -60,9 +60,9 @@ class OsmQuestController internal constructor(
         fun onUnhid(edit: OsmQuestHidden)
         fun onUnhidAll()
     }
-    private val hideListeners: MutableList<HideOsmQuestListener> = CopyOnWriteArrayList()
+    private val hideListeners = Listeners<HideOsmQuestListener>()
 
-    private val listeners: MutableList<OsmQuestSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<OsmQuestSource.Listener>()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/NoteController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/NoteController.kt
@@ -3,9 +3,9 @@ package de.westnordost.streetcomplete.data.osmnotes
 import android.util.Log
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.format
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** Manages access to the notes storage */
 class NoteController(
@@ -21,7 +21,7 @@ class NoteController(
         /** called when all notes have been cleared */
         fun onCleared()
     }
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     /** Replace all notes in the given bounding box with the given notes */
     fun putAllForBBox(bbox: BoundingBox, notes: Collection<Note>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
@@ -5,8 +5,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementIdUpdate
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmnotes.Note
 import de.westnordost.streetcomplete.data.osmtracks.Trackpoint
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import java.util.concurrent.CopyOnWriteArrayList
 
 class NoteEditsController(
     private val editsDB: NoteEditsDao
@@ -14,7 +14,7 @@ class NoteEditsController(
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */
 
-    private val listeners: MutableList<NoteEditsSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<NoteEditsSource.Listener>()
 
     fun add(
         noteId: Long,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditAction.COMMENT
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditAction.CREATE
 import de.westnordost.streetcomplete.data.user.User
 import de.westnordost.streetcomplete.data.user.UserDataSource
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class NotesWithEditsSource(
     private val noteController: NoteController,
@@ -22,7 +22,7 @@ class NotesWithEditsSource(
 
         fun onCleared()
     }
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     private val noteControllerListener = object : NoteController.Listener {
         override fun onUpdated(added: Collection<Note>, updated: Collection<Note>, deleted: Collection<Long>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osmnotes.NoteComment
 import de.westnordost.streetcomplete.data.osmnotes.edits.NotesWithEditsSource
 import de.westnordost.streetcomplete.data.user.UserDataSource
 import de.westnordost.streetcomplete.data.user.UserLoginStatusSource
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Used to get visible osm note quests */
 class OsmNoteQuestController(
@@ -25,9 +25,9 @@ class OsmNoteQuestController(
         fun onUnhid(edit: OsmNoteQuestHidden)
         fun onUnhidAll()
     }
-    private val hideListeners: MutableList<HideOsmNoteQuestListener> = CopyOnWriteArrayList()
+    private val hideListeners = Listeners<HideOsmNoteQuestListener>()
 
-    private val listeners: MutableList<OsmNoteQuestSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<OsmNoteQuestSource.Listener>()
 
     private val showOnlyNotesPhrasedAsQuestions: Boolean get() =
         notesPreferences.showOnlyNotesPhrasedAsQuestions

--- a/app/src/main/java/de/westnordost/streetcomplete/data/overlays/SelectedOverlayController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/overlays/SelectedOverlayController.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.data.overlays
 
 import de.westnordost.streetcomplete.overlays.Overlay
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class SelectedOverlayController(
     private val selectedOverlayStore: SelectedOverlayStore,
     private val overlayRegistry: OverlayRegistry
 ) : SelectedOverlaySource {
 
-    private val listeners = CopyOnWriteArrayList<SelectedOverlaySource.Listener>()
+    private val listeners = Listeners<SelectedOverlaySource.Listener>()
 
     override var selectedOverlay: Overlay?
     set(value) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSource.kt
@@ -8,8 +8,8 @@ import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestSource
 import de.westnordost.streetcomplete.data.overlays.SelectedOverlaySource
 import de.westnordost.streetcomplete.data.visiblequests.TeamModeQuestFilter
 import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeSource
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.SpatialCache
-import java.util.concurrent.CopyOnWriteArrayList
 
 /** Access and listen to quests visible on the map */
 class VisibleQuestsSource(
@@ -27,7 +27,7 @@ class VisibleQuestsSource(
         fun onVisibleQuestsInvalidated()
     }
 
-    private val listeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<Listener>()
 
     private val osmQuestSourceListener = object : OsmQuestSource.Listener {
         override fun onUpdated(addedQuests: Collection<OsmQuest>, deletedQuestKeys: Collection<OsmQuestKey>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/upload/UploadProgressRelay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/upload/UploadProgressRelay.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.upload
 
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class UploadProgressRelay : UploadProgressListener {
-    private val listeners = CopyOnWriteArrayList<UploadProgressListener>()
+    private val listeners = Listeners<UploadProgressListener>()
 
     override fun onStarted() {
         listeners.forEach { it.onStarted() }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserDataController.kt
@@ -4,7 +4,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import de.westnordost.osmapi.user.UserDetails
 import de.westnordost.streetcomplete.Prefs
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Controller that handles user login, logout, auth and updated data */
 class UserDataController(
@@ -19,7 +19,7 @@ class UserDataController(
         }
     }
 
-    private val listeners: MutableList<UserDataSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<UserDataSource.Listener>()
 
     override val userId: Long get() = prefs.getLong(Prefs.OSM_USER_ID, -1)
     override val userName: String? get() = prefs.getString(Prefs.OSM_USER_NAME, null)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserLoginStatusController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserLoginStatusController.kt
@@ -4,8 +4,8 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import de.westnordost.osmapi.OsmConnection
 import de.westnordost.streetcomplete.Prefs
+import de.westnordost.streetcomplete.util.Listeners
 import oauth.signpost.OAuthConsumer
-import java.util.concurrent.CopyOnWriteArrayList
 
 class UserLoginStatusController(
     private val oAuthStore: OAuthStore,
@@ -13,7 +13,7 @@ class UserLoginStatusController(
     private val prefs: SharedPreferences,
 ) : UserLoginStatusSource {
 
-    private val listeners: MutableList<UserLoginStatusSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<UserLoginStatusSource.Listener>()
 
     override val isLoggedIn: Boolean get() = oAuthStore.isAuthorized
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserUpdater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserUpdater.kt
@@ -5,11 +5,11 @@ import de.westnordost.osmapi.user.UserApi
 import de.westnordost.streetcomplete.data.osmnotes.AvatarsDownloader
 import de.westnordost.streetcomplete.data.user.statistics.StatisticsController
 import de.westnordost.streetcomplete.data.user.statistics.StatisticsDownloader
+import de.westnordost.streetcomplete.util.Listeners
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.util.concurrent.CopyOnWriteArrayList
 
 class UserUpdater(
     private val userApi: UserApi,
@@ -23,7 +23,7 @@ class UserUpdater(
     interface Listener {
         fun onUserAvatarUpdated()
     }
-    private val userAvatarListeners: MutableList<Listener> = CopyOnWriteArrayList()
+    private val userAvatarListeners = Listeners<Listener>()
 
     fun update() = coroutineScope.launch(Dispatchers.IO) {
         try {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsController.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.data.user.achievements
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.user.statistics.StatisticsSource
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Manages the data associated with achievements: Unlocked achievements, unlocked links and info
  *  about newly unlocked achievements (the user shall be notified about) */
@@ -17,7 +17,7 @@ class AchievementsController(
     allLinks: List<Link>
 ) : AchievementsSource {
 
-    private val listeners: MutableList<AchievementsSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<AchievementsSource.Listener>()
 
     private val achievementsById = allAchievements.associateBy { it.id }
     private val linksById = allLinks.associateBy { it.id }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsController.kt
@@ -7,13 +7,13 @@ import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.user.UserLoginStatusSource
+import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.getIds
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import de.westnordost.streetcomplete.util.ktx.systemTimeNow
 import de.westnordost.streetcomplete.util.ktx.toLocalDate
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.FutureTask
 
 /** Manages edit statistics - by element edit type and by country */
@@ -28,7 +28,7 @@ class StatisticsController(
     userLoginStatusSource: UserLoginStatusSource
 ) : StatisticsSource {
 
-    private val listeners: MutableList<StatisticsSource.Listener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<StatisticsSource.Listener>()
 
     private val userLoginStatusListener = object : UserLoginStatusSource.Listener {
         override fun onLoggedIn() {}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetsController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/QuestPresetsController.kt
@@ -1,13 +1,13 @@
 package de.westnordost.streetcomplete.data.visiblequests
 
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class QuestPresetsController(
     private val questPresetsDao: QuestPresetsDao,
     private val selectedQuestPresetStore: SelectedQuestPresetStore
 ) : QuestPresetsSource {
 
-    private val listeners = CopyOnWriteArrayList<QuestPresetsSource.Listener>()
+    private val listeners = Listeners<QuestPresetsSource.Listener>()
 
     override var selectedId: Long
         get() = selectedQuestPresetStore.get()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/QuestTypeOrderController.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.data.visiblequests
 
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class QuestTypeOrderController(
     private val questTypeOrderDao: QuestTypeOrderDao,
@@ -10,7 +10,7 @@ class QuestTypeOrderController(
     private val questTypeRegistry: QuestTypeRegistry
 ) : QuestTypeOrderSource {
 
-    private val listeners = CopyOnWriteArrayList<QuestTypeOrderSource.Listener>()
+    private val listeners = Listeners<QuestTypeOrderSource.Listener>()
 
     private val selectedPresetId: Long get() = questPresetsSource.selectedId
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/TeamModeQuestFilter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/TeamModeQuestFilter.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.created_elements.CreatedElementsSo
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuest
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuest
 import de.westnordost.streetcomplete.data.quest.Quest
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Controller for filtering all quests that are hidden because they are shown to other users in
  *  team mode. Takes care of persisting team mode settings and notifying listeners about changes */
@@ -26,7 +26,7 @@ class TeamModeQuestFilter internal constructor(
     interface TeamModeChangeListener {
         fun onTeamModeChanged(enabled: Boolean)
     }
-    private val listeners: MutableList<TeamModeChangeListener> = CopyOnWriteArrayList()
+    private val listeners = Listeners<TeamModeChangeListener>()
 
     fun isVisible(quest: Quest): Boolean =
         !isEnabled

--- a/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeController.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.data.visiblequests
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestType
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Controller to set/get quest types as enabled or disabled. This controls only the visibility
  *  of quest types per user preference and does not take anything else into account that may
@@ -14,7 +14,7 @@ class VisibleQuestTypeController(
     private val questTypeRegistry: QuestTypeRegistry
 ) : VisibleQuestTypeSource {
 
-    private val listeners = CopyOnWriteArrayList<VisibleQuestTypeSource.Listener>()
+    private val listeners = Listeners<VisibleQuestTypeSource.Listener>()
 
     init {
         questPresetsSource.addListener(object : QuestPresetsSource.Listener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/teammode/TeamModeIndexSelectAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/teammode/TeamModeIndexSelectAdapter.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.databinding.CellTeamModeColorCircleSelectBinding
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 class TeamModeIndexSelectAdapter : RecyclerView.Adapter<TeamModeIndexSelectAdapter.ViewHolder>() {
     var count: Int = 0
@@ -21,12 +21,10 @@ class TeamModeIndexSelectAdapter : RecyclerView.Adapter<TeamModeIndexSelectAdapt
 
             oldIndex?.let { notifyItemChanged(it) }
             index?.let { notifyItemChanged(it) }
-            for (listener in listeners) {
-                listener.onSelectedIndexChanged(index)
-            }
+            listeners.forEach { it.onSelectedIndexChanged(index) }
         }
 
-    val listeners: MutableList<OnSelectedIndexChangedListener> = CopyOnWriteArrayList()
+    val listeners = Listeners<OnSelectedIndexChangedListener>()
 
     interface OnSelectedIndexChangedListener {
         fun onSelectedIndexChanged(index: Int?)

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
@@ -1,0 +1,24 @@
+package de.westnordost.streetcomplete.util
+
+/** Lightweight wrapper around `HashSet` for storing listeners in a thread-safe way */
+class Listeners<T> {
+    private val listeners = HashSet<T>()
+
+    fun add(element: T): Boolean {
+        synchronized(this) {
+            return listeners.add(element)
+        }
+    }
+
+    fun remove(element: T): Boolean {
+        synchronized(this) {
+            return listeners.remove(element)
+        }
+    }
+
+    fun forEach(action: (T) -> Unit) {
+        synchronized(this) {
+            listeners.forEach(action)
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.R
-import java.util.concurrent.CopyOnWriteArrayList
+import de.westnordost.streetcomplete.util.Listeners
 
 /** Select a number of items from a list of items  */
 class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
@@ -21,7 +21,7 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
 
     var cellLayoutId = R.layout.cell_labeled_image_select
 
-    val listeners: MutableList<OnItemSelectionListener> = CopyOnWriteArrayList()
+    val listeners = Listeners<OnItemSelectionListener>()
 
     val selectedItems get() = _selectedIndices.map { i -> items[i] }
 
@@ -59,9 +59,7 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
         if (!_selectedIndices.add(index)) return
 
         notifyItemChanged(index)
-        for (listener in listeners) {
-            listener.onIndexSelected(index)
-        }
+        listeners.forEach { it.onIndexSelected(index) }
     }
 
     fun deselect(index: Int) {
@@ -69,9 +67,7 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
         if (!_selectedIndices.remove(index)) return
 
         notifyItemChanged(index)
-        for (listener in listeners) {
-            listener.onIndexDeselected(index)
-        }
+        listeners.forEach { it.onIndexDeselected(index) }
     }
 
     fun toggle(index: Int) {


### PR DESCRIPTION
Replaces `java.util.concurrent.CopyOnWriteArrayList` with a lightweight wrapper around `HashSet` for storing listeners in a thread-safe way. (See https://github.com/streetcomplete/StreetComplete/issues/1892#issuecomment-1671074967)