### PR TITLE
Removing assertj dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,13 +114,11 @@ dependencies {
     // tests
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.mockito:mockito-inline:$mockitoVersion")
-    testImplementation("org.assertj:assertj-core:3.23.1")
     testImplementation(kotlin("test"))
 
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("org.mockito:mockito-android:$mockitoVersion")
-    androidTestImplementation("org.assertj:assertj-core:3.23.1")
     androidTestImplementation(kotlin("test"))
 
     // dependency injection

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/TrafficFlowSegmentsApiTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/oneway_suspects/TrafficFlowSegmentsApiTest.kt
@@ -5,8 +5,9 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.ONEWAY_API_URL
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegment
 import de.westnordost.streetcomplete.quests.oneway_suspects.data.TrafficFlowSegmentsApi
-import org.assertj.core.api.Assertions.assertThat
 import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TrafficFlowSegmentsApiTest {
@@ -27,7 +28,7 @@ class TrafficFlowSegmentsApiTest {
             1L to listOf(TrafficFlowSegment(LatLon(2.0, 1.0), LatLon(6.0, 5.0))),
             2L to listOf(TrafficFlowSegment(LatLon(4.0, 3.0), LatLon(8.0, 7.0)))
         )
-        assertThat(result).containsAllEntriesOf(expected)
+        assertMapsAreEqual(expected, result)
     }
 
     @Test fun parseTwoOfSameWay() {
@@ -41,11 +42,19 @@ class TrafficFlowSegmentsApiTest {
             TrafficFlowSegment(LatLon(2.0, 1.0), LatLon(6.0, 5.0)),
             TrafficFlowSegment(LatLon(4.0, 3.0), LatLon(8.0, 7.0))
         ))
-        assertThat(result).containsAllEntriesOf(expected)
+        assertMapsAreEqual(expected, result)
     }
 
     @Test fun withSomeRealData() {
         // should just not crash...
         TrafficFlowSegmentsApi(ONEWAY_API_URL).get(BoundingBox(-34.0, 18.0, -33.0, 19.0))
+    }
+
+    private fun <K,V> assertMapsAreEqual(expected: Map<K,V>, actual: Map<K, V>) {
+        assertEquals(expected.size, actual.size)
+        val expectedEntries = expected.entries
+        val actualEntries = actual.entries
+        expectedEntries.forEach{ assertContains(actualEntries, it) }
+        actualEntries.forEach{ assertContains(expectedEntries, it) }
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/LocalizedNamesKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/LocalizedNamesKtTest.kt
@@ -4,7 +4,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -133,6 +133,5 @@ internal class LocalizedNamesKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: List<LocalizedName>, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/address/AddressNumberTest.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.osm.address
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 class AddressNumberTest {
@@ -49,6 +49,5 @@ class AddressNumberTest {
 private fun verifyAnswer(answer: AddressNumber, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(emptyMap())
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevardKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevardKtTest.kt
@@ -5,10 +5,11 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
-import de.westnordost.streetcomplete.osm.bicycle_boulevard.BicycleBoulevard.*
-import org.assertj.core.api.Assertions
-import kotlin.test.*
+import de.westnordost.streetcomplete.osm.bicycle_boulevard.BicycleBoulevard.NO
+import de.westnordost.streetcomplete.osm.bicycle_boulevard.BicycleBoulevard.YES
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class BicycleBoulevardKtTest {
 
@@ -83,6 +84,5 @@ private fun verifyAnswer(
 ) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb, countryCode)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreatorKtTest.kt
@@ -5,10 +5,23 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
-import de.westnordost.streetcomplete.osm.cycleway.Cycleway.*
-import de.westnordost.streetcomplete.osm.cycleway.Direction.*
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.ADVISORY_LANE
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.BUSWAY
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.EXCLUSIVE_LANE
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.INVALID
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.NONE
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.NONE_NO_ONEWAY
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.PICTOGRAMS
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.SEPARATE
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.SIDEWALK_EXPLICIT
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.SUGGESTION_LANE
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.TRACK
+import de.westnordost.streetcomplete.osm.cycleway.Cycleway.UNSPECIFIED_LANE
+import de.westnordost.streetcomplete.osm.cycleway.Direction.BACKWARD
+import de.westnordost.streetcomplete.osm.cycleway.Direction.BOTH
+import de.westnordost.streetcomplete.osm.cycleway.Direction.FORWARD
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -785,8 +798,7 @@ class CyclewayCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LeftAndRightCycleway, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb, false)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }
 
 private fun cycleway(left: Pair<Cycleway, Direction>?, right: Pair<Cycleway, Direction>?) =

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/cycleway_separate/SeparateCyclewayCreatorKtTest.kt
@@ -5,9 +5,16 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
-import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.*
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.ALLOWED_ON_FOOTWAY
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.EXCLUSIVE
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.EXCLUSIVE_WITH_SIDEWALK
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.NON_DESIGNATED
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.NON_SEGREGATED
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.NOT_ALLOWED
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.PATH
+import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway.SEGREGATED
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 class SeparateCyclewayCreatorKtTest {
@@ -703,6 +710,5 @@ class SeparateCyclewayCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: SeparateCycleway, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingCreatorKtTest.kt
@@ -5,9 +5,12 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
-import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.*
+import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.CHICANE
+import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.CHOKED_ISLAND
+import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.CHOKER
+import de.westnordost.streetcomplete.osm.lane_narrowing_traffic_calming.LaneNarrowingTrafficCalming.ISLAND
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 class LaneNarrowingTrafficCalmingCreatorKtTest {
@@ -244,6 +247,5 @@ class LaneNarrowingTrafficCalmingCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LaneNarrowingTrafficCalming?, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/lit/LitStatusKtTest.kt
@@ -4,9 +4,13 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
-import de.westnordost.streetcomplete.osm.lit.LitStatus.*
+import de.westnordost.streetcomplete.osm.lit.LitStatus.AUTOMATIC
+import de.westnordost.streetcomplete.osm.lit.LitStatus.NIGHT_AND_DAY
+import de.westnordost.streetcomplete.osm.lit.LitStatus.NO
+import de.westnordost.streetcomplete.osm.lit.LitStatus.UNSUPPORTED
+import de.westnordost.streetcomplete.osm.lit.LitStatus.YES
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -93,6 +97,5 @@ class LitStatusKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LitStatus, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreatorKtTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -267,6 +267,5 @@ class SidewalkCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LeftAndRightSidewalk, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk_surface/SidewalkSurfaceCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/sidewalk_surface/SidewalkSurfaceCreatorKtTest.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.osm.surface.Surface
 import de.westnordost.streetcomplete.osm.surface.SurfaceAndNote
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 internal class SidewalkSurfaceCreatorKtTest {
@@ -128,6 +128,5 @@ internal class SidewalkSurfaceCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LeftAndRightSidewalkSurface, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/street_parking/StreetParkingCreatorKtTest.kt
@@ -6,9 +6,17 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.*
-import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.*
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.DIAGONAL
+import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.PARALLEL
+import de.westnordost.streetcomplete.osm.street_parking.ParkingOrientation.PERPENDICULAR
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.HALF_ON_STREET
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.OFF_STREET
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.ON_STREET
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.PAINTED_AREA_ONLY
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.STAGGERED_HALF_ON_STREET
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.STAGGERED_ON_STREET
+import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition.STREET_SIDE
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -585,6 +593,5 @@ class StreetParkingCreatorKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: LeftAndRightStreetParking, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 class SurfaceCreatorKtTest {
@@ -154,6 +154,5 @@ class SurfaceCreatorKtTest {
 private fun verify(tags: Map<String, String>, value: SurfaceAndNote, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     value.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/OsmElementQuestType.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/OsmElementQuestType.kt
@@ -5,13 +5,12 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
-import org.assertj.core.api.Assertions.assertThat
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 
 fun <T> OsmElementQuestType<T>.verifyAnswer(tags: Map<String, String>, answer: T, vararg expectedChanges: StringMapEntryChange) {
     val cb = StringMapChangesBuilder(tags)
     this.applyAnswerTo(answer, cb, ElementPointGeometry(LatLon(0.0, 0.0)), 0)
-    val changes = cb.create().changes
-    assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }
 
 fun <T> OsmElementQuestType<T>.verifyAnswer(answer: T, vararg expectedChanges: StringMapEntryChange) {

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswerKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoothness/SmoothnessAnswerKtTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
-import org.assertj.core.api.Assertions
+import de.westnordost.streetcomplete.testutils.assertSetsAreEqual
 import kotlin.test.Test
 
 class SmoothnessAnswerKtTest {
@@ -80,6 +80,5 @@ class SmoothnessAnswerKtTest {
 private fun verifyAnswer(tags: Map<String, String>, answer: SmoothnessAnswer, expectedChanges: Array<StringMapEntryChange>) {
     val cb = StringMapChangesBuilder(tags)
     answer.applyTo(cb)
-    val changes = cb.create().changes
-    Assertions.assertThat(changes).containsExactlyInAnyOrder(*expectedChanges)
+    assertSetsAreEqual(expectedChanges.toSet(), cb.create().changes)
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/SetAssertions.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/SetAssertions.kt
@@ -1,0 +1,10 @@
+package de.westnordost.streetcomplete.testutils
+
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+fun <T> assertSetsAreEqual(expected: Set<T>, actual: Set<T>) {
+    assertEquals(expected.size, actual.size)
+    expected.forEach{ assertContains(actual, it)}
+    actual.forEach{ assertContains(expected, it)}
+}

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/SetAssertionsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/SetAssertionsTest.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.testutils
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class SetAssertionsTest {
+    @Test fun `assertSetsAreEqual`() {
+        // No assertion failures
+        assertSetsAreEqual(setOf("A"), setOf("A"))
+        assertSetsAreEqual(emptySet<Int>(), emptySet<Int>())
+        assertSetsAreEqual("clint eastwood".toSet(), "old west action".toSet())
+
+        // Failures
+        assertFailsWith<AssertionError> { assertSetsAreEqual(setOf("A"), setOf()) }
+        assertFailsWith<AssertionError> { assertSetsAreEqual(setOf("A"), setOf("B")) }
+        assertFailsWith<AssertionError> { assertSetsAreEqual(setOf("A", "B"), setOf("C", "A")) }
+        assertFailsWith<AssertionError> { assertSetsAreEqual(setOf("A", "C"), setOf("B", "A")) }
+    }
+}


### PR DESCRIPTION
**What**: Removing `assertj` dependency in tests.

**Why**: In order to make a tiny step towards #1892

**Testing performed**
- [x] just a `./gradlew test`

I suggest a careful review as a bug in tests might cause us miss some issues in the future.