### PR TITLE
RFC: opening_hours: prefer "open" to deceptive "24/7"

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -167,7 +167,7 @@ class AddOpeningHours(
         } else {
             val openingHoursString = when (answer) {
                 is RegularOpeningHours  -> answer.hours.toString()
-                is AlwaysOpen           -> "24/7"
+                is AlwaysOpen           -> "open"
                 is DescribeOpeningHours -> "\"" + answer.text.replace("\"", "") + "\""
                 NoOpeningHoursSign      -> throw IllegalStateException()
             }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
@@ -75,7 +75,7 @@ class AddOpeningHoursTest {
     @Test fun `apply always open answer`() {
         questType.verifyAnswer(
             AlwaysOpen,
-            StringMapEntryAdd("opening_hours", "24/7")
+            StringMapEntryAdd("opening_hours", "open")
         )
     }
 
@@ -83,7 +83,7 @@ class AddOpeningHoursTest {
         questType.verifyAnswer(
             mapOf("opening_hours" to "34/3"),
             AlwaysOpen,
-            StringMapEntryModify("opening_hours", "34/3", "24/7")
+            StringMapEntryModify("opening_hours", "34/3", "open")
         )
     }
 
@@ -91,7 +91,7 @@ class AddOpeningHoursTest {
         questType.verifyAnswer(
             mapOf("opening_hours" to "24/7"),
             AlwaysOpen,
-            StringMapEntryModify("opening_hours", "24/7", "24/7"),
+            StringMapEntryModify("opening_hours", "24/7", "open"),
             StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString())
         )
     }
@@ -100,7 +100,7 @@ class AddOpeningHoursTest {
         questType.verifyAnswer(
             mapOf("opening_hours:signed" to "yes"),
             AlwaysOpen,
-            StringMapEntryAdd("opening_hours", "24/7")
+            StringMapEntryAdd("opening_hours", "open")
         )
     }
 
@@ -111,7 +111,7 @@ class AddOpeningHoursTest {
                 "opening_hours:signed" to "yes"
             ),
             AlwaysOpen,
-            StringMapEntryModify("opening_hours", "24/7", "24/7"),
+            StringMapEntryModify("opening_hours", "24/7", "open"),
             StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString())
         )
     }
@@ -123,7 +123,7 @@ class AddOpeningHoursTest {
                 "opening_hours:signed" to "yes"
             ),
             AlwaysOpen,
-            StringMapEntryModify("opening_hours", "34/3", "24/7")
+            StringMapEntryModify("opening_hours", "34/3", "open")
         )
     }
 


### PR DESCRIPTION
both imply the same meaning, but they are not the same. So prefer the unambiguous "open".

opening_hours.js warns that 24/7 is actually 24/5:

>   WARN: 24/7 is handled as a synonym for 00:00-24:00, so Mo-Fr 24/7 (though
>   not really correct, because of that you should avoid it or replace it
>   with "open".

I didn't test it, but it does address all uses of `AlwaysOpen`, while leaving 24/7 parsing and logic intact.