### PR TITLE
Exclude motor_vehicle=no from oneway quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -27,7 +27,7 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
         ways with highway ~ living_street|residential|service|tertiary|unclassified
          and width <= 4 and (!lanes or lanes <= 1)
          and !oneway and area != yes and junction != roundabout
-         and (access !~ private|no or (foot and foot !~ private|no))
+         and (access !~ private|no or (foot and foot !~ private|no) or motor_vehicle != no)
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether narrow roads are one-ways"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway_suspects/AddSuspectedOneway.kt
@@ -30,6 +30,7 @@ class AddSuspectedOneway(
           and (
             access !~ private|no
             or (foot and foot !~ private|no)
+            or motor_vehicle != no
           )
     """.toElementFilterExpression() }
 


### PR DESCRIPTION
I found a note that showed that the oneway quest triggered for a road tagged as `motor_vehicle=no`, and no other access tags. It also had bollards mapped on it. This seems like a valid way to map such a road, and clearly oneway does not apply in such cases, so the quest should not be asked.

I haven't tested this yet, apologies.