### PR TITLE
Add GPX import functionality

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
             android:windowSoftInputMode="adjustResize"
             android:name="de.westnordost.streetcomplete.screens.MainActivity"
             android:configChanges="orientation|screenSize"
-            android:exported="true">
+            android:exported="true"
+            android:documentLaunchMode="never">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -64,6 +65,30 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="streetcomplete" />
+            </intent-filter>
+            <!-- Open GXP from file manager -->
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/gpx+xml" />
+                <data android:mimeType="application/xml+gpx" />
+            </intent-filter>
+            <!-- Receive shared GXP if sent as intent.data -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/gpx+xml" android:scheme="content" />
+                <data android:mimeType="application/xml+gpx"  android:scheme="content" />
+                <data android:mimeType="*/*" android:pathPattern=".*\\.gpx"/>
+                <data android:mimeType="*/*" android:pathPattern="/.*\\..*\\.gpx"/>
+                <data android:mimeType="*/*" android:pathPattern="/.*\\..*\\..*\\.gpx"/>
+            </intent-filter>
+            <!-- Receive shared GXP if sent as intent.clipData -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/gpx+xml" />
+                <data android:mimeType="application/xml+gpx" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -5,6 +5,7 @@ global:
     track_color: '#44536dfe'
     track_color_record: '#44fe1616'
     old_track_color: '#22536dfe'
+    imported_track_color: '#44147d14'
 
 textures:
     pins:
@@ -259,6 +260,15 @@ layers:
                     collide: false
                     join: round
                     order: 900
+    streetcomplete_imported_track:
+        data: { source: streetcomplete_imported_track }
+        draw:
+            track-lines:
+                color: global.imported_track_color
+                width: [[14, 6px],[18, 12px]]
+                collide: false
+                join: round
+                order: 900
     # styled map data shown in overlays
     streetcomplete_map_data:
         data: { source: streetcomplete_map_data }

--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -16,6 +16,7 @@ import de.westnordost.streetcomplete.data.download.downloadModule
 import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
 import de.westnordost.streetcomplete.data.edithistory.EditHistoryController
 import de.westnordost.streetcomplete.data.edithistory.editHistoryModule
+import de.westnordost.streetcomplete.data.import.importModule
 import de.westnordost.streetcomplete.data.maptiles.maptilesModule
 import de.westnordost.streetcomplete.data.messages.messagesModule
 import de.westnordost.streetcomplete.data.meta.metadataModule
@@ -93,6 +94,7 @@ class StreetCompleteApplication : Application() {
                 editHistoryModule,
                 elementEditsModule,
                 elementGeometryModule,
+                importModule,
                 mapDataModule,
                 mapModule,
                 mainModule,

--- a/app/src/main/java/de/westnordost/streetcomplete/data/import/GpxImporter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/import/GpxImporter.kt
@@ -1,0 +1,225 @@
+package de.westnordost.streetcomplete.data.import
+
+import android.util.Log
+import de.westnordost.streetcomplete.ApplicationConstants
+import de.westnordost.streetcomplete.data.download.tiles.TilePos
+import de.westnordost.streetcomplete.data.download.tiles.enclosingTilesRect
+import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.toPolygon
+import de.westnordost.streetcomplete.util.math.area
+import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+
+/**
+ * Read GPX tracks and provide the data needed to
+ * - display the track on the map
+ * - download map data along the track for offline-use
+ */
+class GpxImporter {
+
+    data class GpxImportData(
+        val downloadAlongTrack: Boolean,
+        val trackpoints: List<LatLon>,
+        val downloadBBoxes: List<BoundingBox>,
+        val areaToDownloadInSqkm: Double,
+    )
+
+    /**
+     * @param[inputStream] GPX track to parse
+     * @param[minDownloadDistance] in meters; points within minDownloadDistance along the track should be downloaded
+     * @param[findDownloadBBoxes]: if true, compute bounding boxes which need to be downloaded to cover the track
+     * @param[progressCallback]: a callback to set progress between 0 .. 100
+     */
+    suspend fun processGpxFile(
+        inputStream: InputStream,
+        minDownloadDistance: Double,
+        findDownloadBBoxes: Boolean,
+        progressCallback: suspend (progress: Int) -> Unit,
+    ): Result<GpxImportData> {
+        progressCallback(0)
+        val trackSampler = parseTrack(inputStream, minDownloadDistance, findDownloadBBoxes)
+            .getOrElse { return Result.failure(it) }
+        progressCallback(10)
+
+        if (!findDownloadBBoxes || trackSampler.getCoveringBoundingBoxes().isEmpty()) {
+            progressCallback(100)
+            return Result.success(
+                GpxImportData(false, trackSampler.getOriginalPoints(), ArrayList(), 0.0)
+            )
+        }
+
+        val bBoxesToDownload = determineBBoxesToDownload(trackSampler.getCoveringBoundingBoxes())
+        // about 80% of computation is usually done here; scale progress from 10 - 90&
+        { p -> progressCallback(10 + (p / 100.0 * 80).toInt()) }
+            .getOrElse { return Result.failure(it) }
+        progressCallback(90)
+
+        val mergedBBoxes = mergeBBoxes(bBoxesToDownload)
+            .getOrElse { return Result.failure(it) }
+        progressCallback(95)
+
+        val areaToDownloadInSqkm = computeAreaToDownload(mergedBBoxes)
+            .getOrElse { return Result.failure(it) }
+        progressCallback(100)
+
+        return Result.success(
+            GpxImportData(
+                true,
+                trackSampler.getOriginalPoints(),
+                mergedBBoxes.map { it.boundingBox },
+                areaToDownloadInSqkm
+            )
+        )
+    }
+
+    private suspend fun parseTrack(
+        inputStream: InputStream,
+        minDownloadDistance: Double,
+        findDownloadBoundingBoxes: Boolean,
+    ): Result<GpxTrackSampler> = withContext(Dispatchers.Default) {
+        val trackSampler = GpxTrackSampler(this, minDownloadDistance, findDownloadBoundingBoxes)
+        trackSampler.parse(inputStream)
+        if (!isActive) {
+            return@withContext Result.failure(CancellationException())
+        }
+        return@withContext Result.success(trackSampler)
+    }
+
+    /**
+     * Reduce a list of bounding boxes covering the imported GPX track:
+     * - discard boxes that are already contained in the download tiles of previously visited ones
+     * - collapse neighbouring bounding boxes if the collapsed area is not larger than downloading
+     *   them individually
+     */
+    private suspend fun determineBBoxesToDownload(
+        coveringBoundingBoxes: List<BoundingBox>,
+        progressCallback: suspend (progress: Int) -> Unit,
+    ): Result<List<DecoratedBoundingBox>> = withContext(Dispatchers.Default) {
+        var currentBBox: DecoratedBoundingBox? = null
+        val bBoxesToDownload = ArrayList<DecoratedBoundingBox>()
+        val uniqueTilesToDownload = HashSet<TilePos>()
+        for ((index, newBBox) in coveringBoundingBoxes.map { DecoratedBoundingBox(it.toPolygon()) }
+            .withIndex()) {
+            if (!isActive) {
+                return@withContext Result.failure(CancellationException())
+            }
+            if (index % (coveringBoundingBoxes.size / 20) == 0) {
+                Log.d(TAG, "index = $index")
+                progressCallback((index * 100) / coveringBoundingBoxes.size)
+            }
+
+            if (currentBBox == null) {
+                currentBBox = newBBox
+                continue
+            }
+
+            if (!newBBox.tiles.any { tilePos -> tilePos !in uniqueTilesToDownload }) {
+                Log.d(TAG, "omit bounding box #$index, all tiles already scheduled for download")
+                continue
+            }
+
+            val extendedBBox = DecoratedBoundingBox(currentBBox.polygon + newBBox.polygon)
+            if (
+            // no additional tile needed to extend the polygon and download newSquare with the same call
+                extendedBBox.numberOfTiles <= (currentBBox.tiles + newBBox.tiles).toHashSet().size
+                ||
+                // area is not increased by extending the current polygon instead of downloading separately
+                extendedBBox.area < currentBBox.area + newBBox.area
+            ) {
+                Log.d(TAG, "extend currentBBox with bounding box #$index")
+                currentBBox = extendedBBox
+            } else {
+                Log.d(TAG, "schedule currentBBox, start new with bounding box #$index")
+                bBoxesToDownload.add(currentBBox)
+                uniqueTilesToDownload.addAll(currentBBox.tiles)
+
+                currentBBox = newBBox
+            }
+        }
+        currentBBox?.let { bBoxesToDownload.add(it) }
+        return@withContext Result.success(bBoxesToDownload)
+    }
+
+    /**
+     * Iteratively merge bounding boxes to save download calls in trade for a few more unique tiles
+     * downloaded
+     */
+    private suspend fun mergeBBoxes(
+        originalBBoxes: List<DecoratedBoundingBox>,
+    ): Result<List<DecoratedBoundingBox>> = withContext(Dispatchers.Default) {
+        var bBoxes = originalBBoxes.toList()
+        val mergedBBoxes = ArrayList<DecoratedBoundingBox>()
+        while (mergedBBoxes.size < bBoxes.size) {
+            Log.d(TAG, "start a new round of bounding box merging")
+            var currentBBox: DecoratedBoundingBox? = null
+            for (bBox in bBoxes) {
+                if (!isActive) {
+                    return@withContext Result.failure(CancellationException())
+                }
+
+                if (currentBBox == null) {
+                    currentBBox = bBox
+                    continue
+                }
+                val mergedBBox = DecoratedBoundingBox(bBox.polygon + currentBBox.polygon)
+                // merge two adjacent boxes if at most one additional tile needs to be downloaded to save one call
+                currentBBox =
+                    if (mergedBBox.numberOfTiles <= (currentBBox.tiles + bBox.tiles).toHashSet().size + 1) {
+                        Log.d(TAG, "merge currentBBox with previous one")
+                        mergedBBox
+                    } else {
+                        Log.d(TAG, "keep currentBBox separate from previous one")
+                        mergedBBoxes.add(currentBBox)
+                        bBox
+                    }
+            }
+            currentBBox?.let { mergedBBoxes.add(it) }
+            if (mergedBBoxes.size < bBoxes.size) {
+                Log.d(TAG, "reduced bounding boxes from ${bBoxes.size} to ${mergedBBoxes.size}")
+                bBoxes = mergedBBoxes.toList()
+                mergedBBoxes.clear()
+            } else {
+                Log.d(TAG, "final number of bounding boxes: ${mergedBBoxes.size}")
+            }
+        }
+        return@withContext Result.success(mergedBBoxes)
+    }
+
+    /**
+     * Compute effective downloaded area - each unique tile is downloaded only once, as the
+     * downloader uses a cache
+     */
+    private suspend fun computeAreaToDownload(
+        bBoxesToDownload: List<DecoratedBoundingBox>,
+    ): Result<Double> = withContext(Dispatchers.Default) {
+        val uniqueTilesToDownload = HashSet<TilePos>()
+        for (bBox in bBoxesToDownload) {
+            if (!isActive) {
+                return@withContext Result.failure(CancellationException())
+            }
+            uniqueTilesToDownload.addAll(bBox.tiles)
+        }
+        return@withContext Result.success(
+            uniqueTilesToDownload.sumOf {
+                it.asBoundingBox(ApplicationConstants.DOWNLOAD_TILE_ZOOM).area()
+            } / 1000000
+        )
+    }
+
+    private class DecoratedBoundingBox(val polygon: Iterable<LatLon>) {
+        val boundingBox = polygon.enclosingBoundingBox()
+        val area = boundingBox.area()
+        val tiles = boundingBox.enclosingTilesRect(ApplicationConstants.DOWNLOAD_TILE_ZOOM)
+            .asTilePosSequence()
+        val numberOfTiles = tiles.count()
+    }
+
+    companion object {
+        private const val TAG = "GpxImporter"
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/import/GpxTrackSampler.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/import/GpxTrackSampler.kt
@@ -1,0 +1,182 @@
+package de.westnordost.streetcomplete.data.import
+
+import android.util.Log
+import de.westnordost.osmapi.common.Handler
+import de.westnordost.osmapi.common.errors.XmlParserException
+import de.westnordost.osmapi.traces.GpsTrackpoint
+import de.westnordost.osmapi.traces.GpxTrackParser
+import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.util.math.distanceTo
+import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
+import de.westnordost.streetcomplete.util.math.initialBearingTo
+import de.westnordost.streetcomplete.util.math.translate
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.isActive
+import java.io.InputStream
+import kotlin.math.sqrt
+
+/**
+ * Coroutine-enabled GpxTrackParser to collect the original trackpoints of a GPX track and resample
+ * it such that all area within minDownloadDistance of the track is covered by a list of aligned,
+ * uniformly sized bounding boxes.
+ */
+class GpxTrackSampler private constructor(
+    private val sampler: Sampler,
+) : GpxTrackParser(sampler) {
+
+    private var finishedParsing = false
+
+    override fun parse(`in`: InputStream?): Void? {
+        try {
+            super.parse(`in`)
+            finishedParsing = true
+        } catch (e: XmlParserException) {
+            if (e.cause != null && e.cause is CancellationException) {
+                // nothing to do, normal coroutine cancellation
+            } else {
+                throw e
+            }
+        }
+        return null
+    }
+
+    /**
+     * only call this method after parsing a file
+     */
+    fun getOriginalPoints(): List<LatLon> {
+        if (!finishedParsing) {
+            throw IllegalStateException("parse a file before calling this method")
+        }
+        return sampler.originalPoints
+    }
+
+    /**
+     * only call this method after parsing a file
+     */
+    fun getCoveringBoundingBoxes(): List<BoundingBox> {
+        if (!finishedParsing) {
+            throw IllegalStateException("parse a file before calling this method")
+        }
+        return sampler.getCoveringSquareCenters().map {
+            arrayListOf(
+                it.translate(sampler.coveringSquareHalfLength, 0.0),
+                it.translate(sampler.coveringSquareHalfLength, 90.0),
+                it.translate(sampler.coveringSquareHalfLength, 180.0),
+                it.translate(sampler.coveringSquareHalfLength, 270.0)
+            ).enclosingBoundingBox()
+        }
+    }
+
+    /**
+     * Handler to collect the original trackpoints and resample the track.
+     *
+     * Algorithm overview:
+     * Given that two resampled points A and B are at most 2 * minDownloadDistance away from each
+     * other and any trackpoint between them is at most minDownloadDistance away from either A or B,
+     * an area that fully contains the track between A and B is given by a square S_track centered
+     * on the middle point between A and B, with side length 2 * minDownloadDistance and rotated
+     * such that two of its sides align with the vector from A to B. As we need to cover the area
+     * within minDownloadDistance of any trackpoint (which might lie almost on the edge of S_track),
+     * a square S_min centered and rotated the same as S_track, but with
+     * side length = 4 * minDownloadDistance is a handy upper bound.
+     *
+     * If we download two non-rotated squares centered on A and B, they are guaranteed to contain
+     * S_min if their side length is at least 4 * minDownloadDistance / sqrt(2) - the worst case
+     * being were S_min is rotated 45 degrees with respect to the non-rotated squares.
+     */
+    private class Sampler(
+        private val coroutineScope: CoroutineScope,
+        private val minDownloadDistance: Double,
+        private val findCenterPoints: Boolean,
+    ) : Handler<GpsTrackpoint> {
+
+        val coveringSquareHalfLength: Double
+
+        init {
+            // values that are too small need a lot of computation on the device and many downloads
+            // values that are too big lead to huge downloaded areas
+            require(minDownloadDistance in 10.0..500.0) {
+                "minDownloadDistance needs to be of reasonable size"
+            }
+
+            coveringSquareHalfLength = 2 * minDownloadDistance / sqrt(2.0)
+        }
+
+        var originalPoints: MutableList<LatLon> = ArrayList()
+        private var centerPoints: MutableList<LatLon> = ArrayList()
+        private var candidatePoint: LatLon? = null
+
+        override fun handle(tea: GpsTrackpoint?) {
+            if (!coroutineScope.isActive) {
+                throw CancellationException()
+            }
+
+            tea?.position?.let {
+                val trackpoint = LatLon(it.latitude, it.longitude)
+                originalPoints.add(trackpoint)
+
+                if (!findCenterPoints) {
+                    // no need to do the hard work
+                    return
+                }
+
+                if (candidatePoint == null) {
+                    candidatePoint = trackpoint
+                    return
+                }
+
+                // interpolate between current trackpoint and last candidate point to ensure
+                // sampling rate is high enough
+                while (trackpoint.distanceTo(candidatePoint!!) > (2 * minDownloadDistance)) {
+                    if (!coroutineScope.isActive) {
+                        throw CancellationException()
+                    }
+
+                    centerPoints.add(candidatePoint!!)
+                    candidatePoint = candidatePoint!!.translate(
+                        distance = 2 * minDownloadDistance,
+                        angle = candidatePoint!!.initialBearingTo(trackpoint)
+                    )
+                    Log.d(TAG, "add interpolated point: $candidatePoint")
+                }
+
+                // discard redundant candidate points
+                if (centerPoints.isNotEmpty() &&
+                    centerPoints.last().distanceTo(candidatePoint!!) < minDownloadDistance &&
+                    trackpoint.distanceTo(candidatePoint!!) < minDownloadDistance
+                ) {
+                    Log.d(TAG, "omit point included in previous and next area: $candidatePoint")
+                    candidatePoint = trackpoint
+                    return
+                }
+
+                centerPoints.add(candidatePoint!!)
+                candidatePoint = trackpoint
+            }
+        }
+
+        fun getCoveringSquareCenters(): List<LatLon> {
+            if (!findCenterPoints) {
+                throw IllegalStateException("covering squares not available, as findCenterPoints was set to false ")
+            }
+
+            // add endpoint separately, as no point after it is visited by the handler
+            return centerPoints + listOfNotNull(candidatePoint)
+        }
+    }
+
+    companion object {
+        private const val TAG = "GpxTrackSampler"
+
+        operator fun invoke(
+            coroutineScope: CoroutineScope,
+            minDownloadDistance: Double,
+            findCoveringBoundingBoxes: Boolean,
+        ): GpxTrackSampler {
+            val sampler = Sampler(coroutineScope, minDownloadDistance, findCoveringBoundingBoxes)
+            return GpxTrackSampler(sampler)
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/import/ImportModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/import/ImportModule.kt
@@ -1,0 +1,15 @@
+package de.westnordost.streetcomplete.data.import
+
+import de.westnordost.streetcomplete.data.download.DownloadController
+import de.westnordost.streetcomplete.data.download.DownloadProgressSource
+import de.westnordost.streetcomplete.data.download.Downloader
+import de.westnordost.streetcomplete.data.download.strategy.MobileDataAutoDownloadStrategy
+import de.westnordost.streetcomplete.data.download.strategy.WifiAutoDownloadStrategy
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesController
+import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesSource
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+val importModule = module {
+    factory { GpxImporter() }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/MainActivity.kt
@@ -184,6 +184,23 @@ class MainActivity :
         mainFragment?.setCameraPosition(pos, zoom)
     }
 
+    private fun handleGpxUri() {
+        if (intent.action !in listOf(Intent.ACTION_SEND, Intent.ACTION_VIEW)) return
+        if (intent.data != null) {
+            val data = intent.data!!
+            if (data.scheme != "content") return
+            if (intent.type in listOf("application/gpx+xml", "application/xml+gpx")
+                || (intent.type == "application/octet-stream" && data.path?.endsWith(".gpx") == true)
+            ) {
+                mainFragment?.importTrack(data)
+            }
+        } else if (intent.clipData != null) {
+            if (intent.type in listOf("application/gpx+xml", "application/xml+gpx")) {
+                mainFragment?.importTrack(intent.clipData!!.getItemAt(0).uri)
+            }
+        }
+    }
+
     public override fun onStart() {
         super.onStart()
 
@@ -337,6 +354,7 @@ class MainActivity :
 
     override fun onMapInitialized() {
         handleGeoUri()
+        handleGpxUri()
     }
 
     /* ------------------------------- TutorialFragment.Listener -------------------------------- */

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -10,6 +10,7 @@ import android.graphics.PointF
 import android.graphics.Rect
 import android.graphics.RectF
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
@@ -36,6 +37,7 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.download.DownloadController
 import de.westnordost.streetcomplete.data.download.tiles.asBoundingBoxOfEnclosingTiles
 import de.westnordost.streetcomplete.data.edithistory.Edit
 import de.westnordost.streetcomplete.data.edithistory.EditKey
@@ -82,6 +84,8 @@ import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapOrientationA
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapPositionAware
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.MoveNodeFragment
 import de.westnordost.streetcomplete.screens.main.bottom_sheet.SplitWayFragment
+import de.westnordost.streetcomplete.screens.main.controls.GpxImportConfirmationDialog
+import de.westnordost.streetcomplete.screens.main.controls.GpxImportSettingsDialog
 import de.westnordost.streetcomplete.screens.main.controls.LocationStateButton
 import de.westnordost.streetcomplete.screens.main.controls.MainMenuButtonFragment
 import de.westnordost.streetcomplete.screens.main.controls.UndoButtonFragment
@@ -117,10 +121,12 @@ import de.westnordost.streetcomplete.util.viewBinding
 import de.westnordost.streetcomplete.view.insets_animation.respectSystemInsets
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 import org.koin.core.qualifier.named
 import java.util.concurrent.FutureTask
+import kotlin.coroutines.resume
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
@@ -168,6 +174,8 @@ class MainFragment :
     SelectedOverlaySource.Listener,
     // rest
     ShowsGeometryMarkers {
+
+    private val downloadController: DownloadController by inject()
 
     private val visibleQuestsSource: VisibleQuestsSource by inject()
     private val mapDataWithEditsSource: MapDataWithEditsSource by inject()
@@ -1190,6 +1198,39 @@ class MainFragment :
         mapFragment?.isNavigationMode = false
         mapFragment?.setInitialCameraPosition(CameraPosition(position, 0f, 0f, zoom))
         setIsFollowingPosition(false)
+    }
+
+    fun importTrack(uri: Uri) {
+        val ctx = context ?: return
+        val fragment = mapFragment ?: return
+        viewLifecycleScope.launch {
+            val importData = suspendCancellableCoroutine { cont ->
+                ctx.contentResolver?.openInputStream(uri)?.let { inputStream ->
+                    val dialog = GpxImportSettingsDialog(
+                        inputStream,
+                    ) { cont.resume(it) }
+                    dialog.show(parentFragmentManager, null)
+                }
+            }.getOrNull() ?: return@launch
+
+            if (!importData.downloadAlongTrack) {
+                fragment.replaceImportedTrack(importData.trackpoints)
+            } else if (importData.areaToDownloadInSqkm > ApplicationConstants.MAX_DOWNLOADABLE_AREA_IN_SQKM * 25) {
+                context?.toast(R.string.gpx_import_download_area_too_big, Toast.LENGTH_LONG)
+            } else {
+                suspendCancellableCoroutine { cont ->
+                    GpxImportConfirmationDialog(
+                        ctx,
+                        importData
+                    ) { cont.resume(it) }.show()
+                }
+
+                for (bBox in importData.downloadBBoxes) {
+                    downloadController.download(bBox)
+                }
+                fragment.replaceImportedTrack(importData.trackpoints)
+            }
+        }
     }
 
     //endregion

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/GpxImportConfirmationDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/GpxImportConfirmationDialog.kt
@@ -1,0 +1,42 @@
+package de.westnordost.streetcomplete.screens.main.controls
+
+import android.content.Context
+import android.content.DialogInterface
+import android.view.LayoutInflater
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.import.GpxImporter
+import org.koin.core.component.KoinComponent
+
+/** A dialog to confirm download of (potentially massive) data along imported GPX track */
+class GpxImportConfirmationDialog(
+    context: Context,
+    importData: GpxImporter.GpxImportData,
+    private val callback: (confirm: Boolean) -> Unit,
+) : AlertDialog(context), KoinComponent {
+    init {
+        val view =
+            LayoutInflater.from(context).inflate(R.layout.dialog_gpx_import_confirmation, null)
+        setView(view)
+
+        val downloadsToScheduleTextView = view.findViewById<TextView>(R.id.downloadsToScheduleText)
+        downloadsToScheduleTextView.text = context.getString(
+            R.string.gpx_import_number_of_downloads_to_schedule,
+            importData.downloadBBoxes.size
+        )
+        val areaToDownloadTextView = view.findViewById<TextView>(R.id.areaToDownloadText)
+        areaToDownloadTextView.text = context.getString(
+            R.string.gpx_import_area_to_download_sqkm,
+            importData.areaToDownloadInSqkm
+        )
+
+        setButton(DialogInterface.BUTTON_POSITIVE, context.getString(android.R.string.ok)) { _, _ ->
+            callback(true)
+            dismiss()
+        }
+        setButton(BUTTON_NEGATIVE, context.getString(android.R.string.cancel)) { _, _ ->
+            cancel()
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/GpxImportSettingsDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/GpxImportSettingsDialog.kt
@@ -1,0 +1,96 @@
+package de.westnordost.streetcomplete.screens.main.controls
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.core.view.children
+import androidx.fragment.app.DialogFragment
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.import.GpxImporter
+import de.westnordost.streetcomplete.databinding.DialogGpxImportSettingsBinding
+import de.westnordost.streetcomplete.util.ktx.spToPx
+import de.westnordost.streetcomplete.util.ktx.viewLifecycleScope
+import de.westnordost.streetcomplete.util.viewBinding
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.android.ext.android.inject
+import java.io.InputStream
+import kotlin.math.roundToInt
+
+/** A dialog to specify GPX import settings */
+class GpxImportSettingsDialog(
+    private val inputStream: InputStream,
+    private val callback: (result: Result<GpxImporter.GpxImportData>) -> Unit,
+) : DialogFragment(R.layout.dialog_gpx_import_settings) {
+    private val gpxImporter: GpxImporter by inject()
+    private val binding by viewBinding(DialogGpxImportSettingsBinding::bind)
+    private var worker: Deferred<Result<GpxImporter.GpxImportData>>? = null
+
+    private val minDownloadDistanceOptions: List<Double> = listOf(10.0, 100.0, 250.0, 500.0)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_FRAME, R.style.Theme_DialogFragment)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.minDownloadDistancePicker.wrapSelectorWheel = false
+        binding.minDownloadDistancePicker.displayedValues =
+            minDownloadDistanceOptions.map { it.roundToInt().toString() }.toTypedArray()
+        binding.minDownloadDistancePicker.minValue = 0
+        binding.minDownloadDistancePicker.maxValue = minDownloadDistanceOptions.size - 1
+        if (android.os.Build.VERSION.SDK_INT >= 29) {
+            binding.minDownloadDistancePicker.textSize = requireContext().spToPx(32)
+        }
+        binding.minDownloadDistancePicker.value = 1
+        // do not allow keyboard input
+        binding.minDownloadDistancePicker.disableEditTextsFocus()
+
+        binding.okButton.setOnClickListener {
+            viewLifecycleScope.launch { callback(processGpxFile()) }
+        }
+        binding.cancelButton.setOnClickListener {
+            worker?.cancel()
+            dismiss()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        worker?.cancel()
+    }
+
+    private suspend fun processGpxFile(): Result<GpxImporter.GpxImportData> {
+        binding.okButton.isEnabled = false
+
+        worker = viewLifecycleScope.async {
+            return@async gpxImporter.processGpxFile(
+                inputStream,
+                minDownloadDistanceOptions[binding.minDownloadDistancePicker.value],
+                binding.downloadCheckBox.isChecked
+            ) { p -> withContext(Dispatchers.Main) { binding.importProgress.progress = p } }
+        }
+        val importData = worker!!.await()
+
+        worker = null
+
+        dismiss()
+        return importData
+    }
+
+    private fun ViewGroup.disableEditTextsFocus() {
+        for (child in children) {
+            if (child is ViewGroup) {
+                child.disableEditTextsFocus()
+            } else if (child is EditText) {
+                child.isFocusable = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -18,6 +18,7 @@ import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderSource
 import de.westnordost.streetcomplete.screens.main.map.components.DownloadedAreaMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.FocusGeometryMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.GeometryMarkersMapComponent
+import de.westnordost.streetcomplete.screens.main.map.components.ImportedTrackMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.PinsMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.SelectedPinsMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.StyleableOverlayMapComponent
@@ -54,6 +55,7 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
     private var styleableOverlayManager: StyleableOverlayManager? = null
     private var downloadedAreaMapComponent: DownloadedAreaMapComponent? = null
     private var downloadedAreaManager: DownloadedAreaManager? = null
+    private var importedTrackMapComponent: ImportedTrackMapComponent? = null
 
     interface Listener {
         fun onClickedQuest(questKey: QuestKey)
@@ -129,6 +131,8 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
         viewLifecycleOwner.lifecycle.addObserver(downloadedAreaManager!!)
 
         selectedOverlaySource.addListener(overlayListener)
+
+        importedTrackMapComponent = ImportedTrackMapComponent(ctrl)
 
         super.onMapReady()
     }
@@ -309,5 +313,10 @@ class MainMapFragment : LocationAwareMapFragment(), ShowsGeometryMarkers {
     companion object {
         // see streetcomplete.yaml for the definitions of the below layers
         private const val CLICK_AREA_SIZE_IN_DP = 48
+    }
+
+    /* -------------------------------- Show imported tracks ------------------------------------ */
+    fun replaceImportedTrack(trackpoints: List<LatLon>) {
+        importedTrackMapComponent?.replaceImportedTrack(trackpoints)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/ImportedTrackMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/ImportedTrackMapComponent.kt
@@ -1,0 +1,32 @@
+package de.westnordost.streetcomplete.screens.main.map.components
+
+import com.mapzen.tangram.geometry.Polyline
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.screens.main.map.tangram.KtMapController
+import de.westnordost.streetcomplete.screens.main.map.tangram.toLngLat
+import org.koin.core.component.KoinComponent
+
+/** Shows imported track on the map */
+class ImportedTrackMapComponent(ctrl: KtMapController) : KoinComponent {
+
+    private val trackLayer = ctrl.addDataLayer(IMPORTED_TRACK_LAYER)
+
+    fun replaceImportedTrack(
+        trackpoints: List<LatLon>,
+    ) {
+        trackLayer.clear()
+        trackLayer.setFeatures(
+            listOf(
+                Polyline(
+                    trackpoints.map { it.toLngLat() }.toMutableList(),
+                    mutableMapOf("type" to "line")
+                )
+            )
+        )
+    }
+
+    companion object {
+        // see streetcomplete.yaml for the definitions of the layer
+        private const val IMPORTED_TRACK_LAYER = "streetcomplete_imported_track"
+    }
+}

--- a/app/src/main/res/layout/dialog_gpx_import_confirmation.xml
+++ b/app/src/main/res/layout/dialog_gpx_import_confirmation.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:orientation="vertical">
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/gpx_import_confirm"
+        android:textAppearance="@style/TextAppearance.Title" />
+
+    <TextView
+        android:id="@+id/downloadsToScheduleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="8dp"
+        android:text="@string/gpx_import_number_of_downloads_to_schedule" />
+
+
+    <TextView
+        android:id="@+id/areaToDownloadText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="8dp"
+        android:text="@string/gpx_import_area_to_download_sqkm" />
+</LinearLayout>
+

--- a/app/src/main/res/layout/dialog_gpx_import_settings.xml
+++ b/app/src/main/res/layout/dialog_gpx_import_settings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/gpx_import"
+        android:textAppearance="@style/TextAppearance.Title" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginHorizontal="8dp"
+            android:text="@string/gpx_import_download_within" />
+
+        <NumberPicker
+            android:id="@+id/minDownloadDistancePicker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="8dp"
+            android:layout_gravity="center" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginHorizontal="8dp"
+            android:text="@string/gpx_import_meters" />
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/downloadCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:padding="8dp"
+        android:text="@string/gpx_import_download_along_track" />
+
+    <ProgressBar
+        android:id="@+id/importProgress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="false" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center">
+
+        <Button
+            android:id="@+id/cancelButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@android:string/cancel"
+            style="@style/BottomSheetButtonBarItem" />
+
+        <Button
+            android:id="@+id/okButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@android:string/ok"
+            style="@style/BottomSheetButtonBarItem" />
+    </LinearLayout>
+</LinearLayout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -568,6 +568,17 @@ Before uploading your changes, the app checks with a &lt;a href=\"https://www.we
     <string name="pref_title_delete_cache">Delete cache</string>
     <string name="pref_title_delete_cache_summary">If you think some data is outdated</string>
 
+    <!-- GPX import dialogs -->
+    <string name="gpx_import">Import GPX track</string>
+    <string name="gpx_import_download_within">Download within</string>
+    <string name="gpx_import_meters">meters</string>
+    <string name="gpx_import_download_along_track">Download along track</string>
+
+    <string name="gpx_import_confirm">Confirm download</string>
+    <string name="gpx_import_number_of_downloads_to_schedule">%d downloads will be scheduled.</string>
+    <string name="gpx_import_area_to_download_sqkm">%.1f km^2 will be downloaded.</string>
+
+    <string name="gpx_import_download_area_too_big">Please import a shorter track or set a smaller download area</string>
 
     <!-- Quest selection screen -->
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -76,6 +76,10 @@
         <item name="android:windowAnimationStyle">@style/Animation.Dialog.Custom</item>
     </style>
 
+    <style name="Theme.DialogFragment" parent="Theme.MaterialComponents.DayNight.Dialog">
+        <item name="android:windowBackground">@drawable/background_white_corners</item>
+    </style>
+
     <style name="Toolbar.Button.Navigation.Tinted" parent="Widget.AppCompat.Toolbar.Button.Navigation">
         <item name="tint">?attr/colorControlNormal</item>
     </style>


### PR DESCRIPTION
To map along a predefined route, set your cache big enough and export a GPX track from some other routing app by sharing it with StreetComplete.

StreetComplete imports the track to show it on the map, and - if you accept the number of downloads and area - schedules tile downloading along the track for offline usage,