### PR TITLE
Grill fuel quest -- add OtherAnswer that this is just a firering, not a Grill

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -9,10 +9,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
 
-
-
 class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
-
     override val elementFilter = """
         nodes, ways with
           amenity = bbq
@@ -37,7 +34,7 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
             }
-            else -> {
+            is BbqFuel -> {
                 tags["fuel"] = answer.osmValue
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -34,7 +34,7 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
             }
-            is BbqFuel -> {
+            else -> {
                 tags["fuel"] = answer.osmValue
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -10,12 +10,14 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.osm.Tags
 
 class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
+
     override val elementFilter = """
         nodes, ways with
           amenity = bbq
           and !fuel
           and access !~ no|private
     """
+
     override val changesetComment = "Specify barbecue fuel"
     override val wikiLink = "Key:amenity=bbq"
     override val icon = R.drawable.ic_quest_fire

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -9,6 +9,8 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
 
+
+
 class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
 
     override val elementFilter = """
@@ -17,7 +19,6 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
           and !fuel
           and access !~ no|private
     """
-
     override val changesetComment = "Specify barbecue fuel"
     override val wikiLink = "Key:amenity=bbq"
     override val icon = R.drawable.ic_quest_fire
@@ -32,11 +33,11 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
 
     override fun applyAnswerTo(answer: BbqFuelAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
-            is NotBbq -> {
+            NOT_BBQ -> {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
             }
-            is BbqFuel -> {
+            else -> {
                 tags["fuel"] = answer.osmValue
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -33,7 +33,7 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
     override fun applyAnswerTo(answer: BbqFuelAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
             is BbqFuel -> tags["fuel"] = answer.osmValue
-            NOT_BBQ -> {
+            IsFirePitAnswer -> {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
 
-class AddBbqFuel : OsmFilterQuestType<BbqFuel>() {
+class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -30,7 +30,15 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuel>() {
 
     override fun createForm() = AddBbqFuelForm()
 
-    override fun applyAnswerTo(answer: BbqFuel, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        tags["fuel"] = answer.osmValue
+    override fun applyAnswerTo(answer: BbqFuelAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        when (answer) {
+            is NotBbq -> {
+                tags.remove("amenity")
+                tags["leisure"] = "firepit"
+            }
+            is BbqFuel -> {
+                tags["fuel"] = answer.osmValue
+            }
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -8,9 +8,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
-class AddBbqFuel : OsmFilterQuestType<BbqFuel>() {
+class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
     override val elementFilter = """
         nodes, ways with
           amenity = bbq
@@ -29,14 +28,12 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuel>() {
 
     override fun createForm() = AddBbqFuelForm()
 
-    override fun applyAnswerTo(answer: BbqFuel, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+    override fun applyAnswerTo(answer: BbqFuelAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
+            is BbqFuel -> tags["fuel"] = answer.osmValue
             NOT_BBQ -> {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
-            }
-            is BbqFuel -> {
-                tags["fuel"] = answer.osmValue
             }
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
-class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
+class AddBbqFuel : OsmFilterQuestType<BbqFuel>() {
     override val elementFilter = """
         nodes, ways with
           amenity = bbq
@@ -29,7 +29,7 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
 
     override fun createForm() = AddBbqFuelForm()
 
-    override fun applyAnswerTo(answer: BbqFuelAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+    override fun applyAnswerTo(answer: BbqFuel, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
             NOT_BBQ -> {
                 tags.remove("amenity")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
 class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
     override val elementFilter = """
@@ -34,7 +35,7 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
                 tags.remove("amenity")
                 tags["leisure"] = "firepit"
             }
-            else -> {
+            is BbqFuel -> {
                 tags["fuel"] = answer.osmValue
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -2,24 +2,18 @@ package de.westnordost.streetcomplete.quests.bbq_fuel
 
 import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
-//import de.westnordost.streetcomplete.quests.AListQuestForm
+import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-//import de.westnordost.streetcomplete.quests.TextItem
+import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
 
-class AddBbqFuelForm : AbstractOsmQuestForm<BbqFuelAnswer>() {
-//    override val items = listOf(
-//        TextItem(WOOD, R.string.quest_bbq_fuel_wood),
-//        TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
-//        TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
-//    )
-    override val buttonPanelAnswers = listOf(
-        AnswerItem(R.string.quest_bbq_fuel_wood) { applyAnswer(WOOD) },
-        AnswerItem( R.string.quest_bbq_fuel_electric) { applyAnswer(ELECTRIC) },
-        AnswerItem(R.string.quest_bbq_fuel_charcoal) { applyAnswer(CHARCOAL) },
+class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
+    override val items: List<TextItem<BbqFuelAnswer>> = listOf(
+        TextItem(WOOD, R.string.quest_bbq_fuel_wood),
+        TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
+        TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
     )
 
     override val otherAnswers = listOfNotNull(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -2,18 +2,24 @@ package de.westnordost.streetcomplete.quests.bbq_fuel
 
 import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.quests.AListQuestForm
+import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
+//import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
-import de.westnordost.streetcomplete.quests.TextItem
+//import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
 
-class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
-    override val items = listOf(
-        TextItem(WOOD, R.string.quest_bbq_fuel_wood),
-        TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
-        TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
+class AddBbqFuelForm : AbstractOsmQuestForm<BbqFuelAnswer>() {
+//    override val items = listOf(
+//        TextItem(WOOD, R.string.quest_bbq_fuel_wood),
+//        TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
+//        TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
+//    )
+    override val buttonPanelAnswers = listOf(
+        AnswerItem(R.string.quest_bbq_fuel_wood) { applyAnswer(WOOD) },
+        AnswerItem( R.string.quest_bbq_fuel_electric) { applyAnswer(ELECTRIC) },
+        AnswerItem(R.string.quest_bbq_fuel_charcoal) { applyAnswer(CHARCOAL) },
     )
 
     override val otherAnswers = listOfNotNull(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -8,9 +8,8 @@ import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
-import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
-class AddBbqFuelForm : AListQuestForm<BbqFuel>() {
+class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
     override val items = listOf(
         TextItem(WOOD, R.string.quest_bbq_fuel_wood),
         TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
-class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
+class AddBbqFuelForm : AListQuestForm<BbqFuel>() {
     override val items = listOf(
         TextItem(WOOD, R.string.quest_bbq_fuel_wood),
         TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -4,17 +4,18 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.TextItem
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
 
 class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
-
     override val items = listOf(
-        TextItem(BbqFuel.WOOD, R.string.quest_bbq_fuel_wood),
-        TextItem(BbqFuel.ELECTRIC, R.string.quest_bbq_fuel_electric),
-        TextItem(BbqFuel.CHARCOAL, R.string.quest_bbq_fuel_charcoal),
+        TextItem(WOOD, R.string.quest_bbq_fuel_wood),
+        TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
+        TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
     )
 
     override val otherAnswers = listOfNotNull(
-        AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { applyAnswer(NotBbq) },
-
+        AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { applyAnswer(NOT_BBQ) },
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -17,6 +17,15 @@ class AddBbqFuelForm : AListQuestForm<BbqFuel>() {
     )
 
     override val otherAnswers = listOfNotNull(
-        AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { applyAnswer(NOT_BBQ) },
+        AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { confirmNotBbq() },
     )
+
+    private fun confirmNotBbq() {
+        val ctx = context ?: return
+        AlertDialog.Builder(ctx)
+            .setTitle(R.string.quest_bbq_fuel_not_a_bbq_confirmation_title)
+            .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ -> applyAnswer(NOT_BBQ) }
+            .setNegativeButton(R.string.quest_generic_confirmation_no, null)
+            .show()
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.quests.bbq_fuel
 
+import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.quests.bbq_fuel
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
+import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.TextItem
 
 class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -4,11 +4,16 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AListQuestForm
 import de.westnordost.streetcomplete.quests.TextItem
 
-class AddBbqFuelForm : AListQuestForm<BbqFuel>() {
+class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
 
     override val items = listOf(
         TextItem(BbqFuel.WOOD, R.string.quest_bbq_fuel_wood),
         TextItem(BbqFuel.ELECTRIC, R.string.quest_bbq_fuel_electric),
         TextItem(BbqFuel.CHARCOAL, R.string.quest_bbq_fuel_charcoal),
+    )
+
+    override val otherAnswers = listOfNotNull(
+        AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { applyAnswer(NotBbq) },
+
     )
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.NOT_BBQ
 
 class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
     override val items = listOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -24,7 +24,7 @@ class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
         val ctx = context ?: return
         AlertDialog.Builder(ctx)
             .setTitle(R.string.quest_bbq_fuel_not_a_bbq_confirmation_title)
-            .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ -> applyAnswer(NOT_BBQ) }
+            .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ -> applyAnswer(IsFirePitAnswer) }
             .setNegativeButton(R.string.quest_generic_confirmation_no, null)
             .show()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -16,7 +16,7 @@ class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
         TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
     )
 
-    override val otherAnswers = listOfNotNull(
+    override val otherAnswers = listOf(
         AnswerItem(R.string.quest_bbq_fuel_not_a_bbq) { confirmNotBbq() },
     )
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -23,7 +23,8 @@ class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
     private fun confirmNotBbq() {
         val ctx = context ?: return
         AlertDialog.Builder(ctx)
-            .setTitle(R.string.quest_bbq_fuel_not_a_bbq_confirmation_title)
+            .setTitle(R.string.quest_generic_confirmation_title)
+            .setMessage(R.string.quest_bbq_fuel_not_a_bbq_confirmation)
             .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ -> applyAnswer(IsFirePitAnswer) }
             .setNegativeButton(R.string.quest_generic_confirmation_no, null)
             .show()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -1,7 +1,11 @@
 package de.westnordost.streetcomplete.quests.bbq_fuel
 
+sealed interface BbqFuelAnswer
+
 enum class BbqFuel(val osmValue: String) {
     WOOD("wood"),
     ELECTRIC("electric"),
     CHARCOAL("charcoal")
-}
+} : BbqFuelAnswer
+
+object NotBbq : BbqFuelAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -5,7 +5,7 @@ sealed interface BbqFuelAnswer
 enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     WOOD("wood"),
     ELECTRIC("electric"),
-    CHARCOAL("charcoal")
+    CHARCOAL("charcoal"),
+    NOT_BBQ
 }
 
-object NOT_BBQ : BbqFuelAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -8,4 +8,4 @@ enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     CHARCOAL("charcoal")
 }
 
-object NotBbq : BbqFuelAnswer
+object NOT_BBQ : BbqFuelAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -1,9 +1,0 @@
-package de.westnordost.streetcomplete.quests.bbq_fuel
-
-enum class BbqFuel(val osmValue: String) {
-    WOOD("wood"),
-    ELECTRIC("electric"),
-    CHARCOAL("charcoal"),
-    NOT_BBQ("NOT_BBQ")  // magic value
-}
-

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -6,6 +6,6 @@ enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     WOOD("wood"),
     ELECTRIC("electric"),
     CHARCOAL("charcoal"),
-    NOT_BBQ
+    NOT_BBQ("NOT_BBQ")
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -4,6 +4,6 @@ enum class BbqFuel(val osmValue: String) {
     WOOD("wood"),
     ELECTRIC("electric"),
     CHARCOAL("charcoal"),
-    NOT_BBQ("NOT_BBQ")
+    NOT_BBQ("NOT_BBQ")  // magic value
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -1,8 +1,6 @@
 package de.westnordost.streetcomplete.quests.bbq_fuel
 
-sealed interface BbqFuelAnswer
-
-enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
+enum class BbqFuel(val osmValue: String) {
     WOOD("wood"),
     ELECTRIC("electric"),
     CHARCOAL("charcoal"),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuel.kt
@@ -2,10 +2,10 @@ package de.westnordost.streetcomplete.quests.bbq_fuel
 
 sealed interface BbqFuelAnswer
 
-enum class BbqFuel(val osmValue: String) {
+enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     WOOD("wood"),
     ELECTRIC("electric"),
     CHARCOAL("charcoal")
-} : BbqFuelAnswer
+}
 
 object NotBbq : BbqFuelAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
@@ -8,4 +8,4 @@ enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     CHARCOAL("charcoal")
 }
 
-object NOT_BBQ : BbqFuelAnswer
+object IsFirePitAnswer : BbqFuelAnswer

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
@@ -1,0 +1,11 @@
+package de.westnordost.streetcomplete.quests.bbq_fuel
+
+sealed interface BbqFuelAnswer
+
+enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
+    WOOD("wood"),
+    ELECTRIC("electric"),
+    CHARCOAL("charcoal")
+}
+
+object NOT_BBQ : BbqFuelAnswer

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1299,7 +1299,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
     <string name="quest_bbq_fuel_not_a_bbq">"It's a fire enclosure"</string>
-    <string name="quest_bbq_fuel_not_a_bbq_confirmation">"Fire enclosure doesn't have cooking surface (e.g. grate/plate), while grill does. Is this just a fire enclosure?"</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation">"Fire enclosure doesn't have cooking surface (e.g. grate/plate), as opposed to grill."</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,8 +1298,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
-    <string name="quest_bbq_fuel_not_a_bbq">Just a fire enclosure, without cooking surface</string>
-    <string name="quest_bbq_fuel_not_a_bbq_confirmation_title">Is this really just a fire ring / fire pit?</string>
+    <string name="quest_bbq_fuel_not_a_bbq">It's a fire enclosure</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation">Fire enclosure doesn't have cooking surface (e.g. grate/plate), while grill does. Is this just a fire enclosure?</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,6 +1298,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
+    <string name="quest_bbq_fuel_not_a_bbq">This is just a firepit, not a grill</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,8 +1298,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
-    <string name="quest_bbq_fuel_not_a_bbq">It's a fire enclosure</string>
-    <string name="quest_bbq_fuel_not_a_bbq_confirmation">Fire enclosure doesn't have cooking surface (e.g. grate/plate), while grill does. Is this just a fire enclosure?</string>
+    <string name="quest_bbq_fuel_not_a_bbq">"It's a fire enclosure"</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation">"Fire enclosure doesn't have cooking surface (e.g. grate/plate), while grill does. Is this just a fire enclosure?"</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,7 +1298,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
-    <string name="quest_bbq_fuel_not_a_bbq">This is just a firepit, not a grill</string>
+    <string name="quest_bbq_fuel_not_a_bbq">Not a grill - lacks a cooking surface</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation_title">Is this really just a fire ring instead of full grill?</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,8 +1298,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
-    <string name="quest_bbq_fuel_not_a_bbq">"It's a fire enclosure"</string>
-    <string name="quest_bbq_fuel_not_a_bbq_confirmation">"Fire enclosure doesn't have cooking surface (e.g. grate/plate), as opposed to grill."</string>
+    <string name="quest_bbq_fuel_not_a_bbq">It’s a fire enclosure</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation">Fire enclosures don’t have a cooking surface (e.g. grate/plate), as opposed to grills.</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,8 +1298,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
-    <string name="quest_bbq_fuel_not_a_bbq">Not a grill - lacks a cooking surface</string>
-    <string name="quest_bbq_fuel_not_a_bbq_confirmation_title">Is this really just a fire ring instead of full grill?</string>
+    <string name="quest_bbq_fuel_not_a_bbq">Just a fire enclosure, without cooking surface</string>
+    <string name="quest_bbq_fuel_not_a_bbq_confirmation_title">Is this really just a fire ring / fire pit?</string>
 
     <string name="quest_railway_crossing_barrier_title2">What barriers are used at this railway crossing?</string>
     <string name="quest_railway_crossing_barrier_none2">No barriers</string>


### PR DESCRIPTION
[amenity=bbq](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbbq) requires that there is (usually metal) cooking surface (grill/grate/plate) for it to be a Grill/Bbq. However, it is incorrectly tagged for lots of places which only have fire-containment walls, and not a cooking surface i.e. fire rings / firepits (that are tagged with [leisure=firepit](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dfirepit) instead).

This PR adds `OtherAnswer` to indicate this is not a grill/bbq but instead a firering/firepit only. [Tested](https://github.com/mnalis/StreetComplete/actions/runs/6840861319) and works fine.

See https://community.openstreetmap.org/t/amenity-bbq-without-grill-grate/9220 for discussion about tagging itself.

(Suggestions for better English texts are always welcome)