### PR TITLE
Ask crossing height if either `kerb:left` or `kerb:right` is missing

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
@@ -21,7 +21,7 @@ class AddCrossingKerbHeight : OsmElementQuestType<KerbHeight> {
           highway = crossing
           and foot != no
           and crossing
-          and !kerb:left and !kerb:right
+          and (!kerb:left or !kerb:right)
           and (
             !kerb
             or kerb ~ yes|unknown


### PR DESCRIPTION
I just noticed https://github.com/streetcomplete/StreetComplete/commit/9f501df0a3b2fea7b9d6dd0f54143465e748ba34. The commit message ("do not ask for crossing kerb height if kerb:left ***and*** kerb:right are set", emphasis mine) does not match its implementation. If the current implementation is correct, please just close this PR. Otherwise, this PR changes the implementation to match the commit message.