### PR TITLE
Replace deprecated toLowerCase / toUpperCase with lowercase / uppercase

### DIFF
--- a/buildSrc/src/main/java/POEditorDownloader.kt
+++ b/buildSrc/src/main/java/POEditorDownloader.kt
@@ -52,7 +52,7 @@ private fun fetchLocalizationDownloadUrl(apiToken: String, projectId: String, la
         connection.doOutput = true
         connection.requestMethod = "POST"
         connection.outputStream.bufferedWriter().use { it.write(
-            "api_token=$apiToken&id=$projectId&language=${languageCode.toLowerCase(Locale.US)}&type=$format&filters=translated"
+            "api_token=$apiToken&id=$projectId&language=${languageCode.lowercase()}&type=$format&filters=translated"
         ) }
     }) { inputStream ->
         val response = Parser.default().parse(inputStream) as JsonObject

--- a/buildSrc/src/main/java/UpdateNsiPresetsTask.kt
+++ b/buildSrc/src/main/java/UpdateNsiPresetsTask.kt
@@ -6,7 +6,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.net.URL
-import java.util.Locale
 
 /** Download and split the brand presets from the name suggestion index by countries they are in:
  *  Instead of one big presets file, sort those brands that only exist in certain countries into own
@@ -77,7 +76,7 @@ open class UpdateNsiPresetsTask : DefaultTask() {
         }
 
         for ((country, jsonObject) in byCountryMap.entries) {
-            val name = "$targetDir/presets${ if (country != null) "-${country.toUpperCase(Locale.US)}" else "" }.json"
+            val name = "$targetDir/presets${ if (country != null) "-${country.uppercase()}" else "" }.json"
             File(name).writeText(jsonObject.toJsonString())
         }
     }
@@ -124,7 +123,7 @@ private fun expandM49Codes(codes: MutableList<String>) {
         val expandedCodes = M49Codes[cc]
         if (expandedCodes != null) {
             codes.removeAt(i)
-            codes.addAll(i, expandedCodes.map { it.toLowerCase(Locale.US) })
+            codes.addAll(i, expandedCodes.map { it.lowercase() })
         } else {
             ++i
         }

--- a/buildSrc/src/main/java/UpdateStoreDescriptionsTask.kt
+++ b/buildSrc/src/main/java/UpdateStoreDescriptionsTask.kt
@@ -2,7 +2,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
-import java.util.Locale
 
 /** Update the metadata that contain the store descriptions for the app (for F-Droid) */
 open class UpdateStoreDescriptionsTask : DefaultTask() {
@@ -19,7 +18,7 @@ open class UpdateStoreDescriptionsTask : DefaultTask() {
         val languageCodes = fetchAvailableLocalizations(apiToken, projectId).map { it.code }
 
         for (languageCode in languageCodes) {
-            if (languageCode.toLowerCase(Locale.US) == "en-us") continue
+            if (languageCode.lowercase() == "en-us") continue
             println(languageCode)
             val translations = fetchLocalizationJson(apiToken, projectId, languageCode)
 

--- a/buildSrc/src/main/java/UpdateWebsiteTranslationsTask.kt
+++ b/buildSrc/src/main/java/UpdateWebsiteTranslationsTask.kt
@@ -51,7 +51,7 @@ open class UpdateWebsiteTranslationsTask : DefaultTask() {
         for (languageCode in languageCodes) {
             println(languageCode)
             val translations = fetchLocalizationJson(apiToken, projectId, languageCode)
-            val lang = if (languageCode.toLowerCase() == "en-us") "en" else languageCode.toLowerCase()
+            val lang = if (languageCode.lowercase() == "en-us") "en" else languageCode.lowercase()
             val strings = translations.filterKeys { it in keys || it in requiredKeys }
             // only accept complete translations
             if (requiredKeys.all { it in strings.keys }) {


### PR DESCRIPTION
Without arguments `lowercase()` uses the invariant culture by default, whereas `toLowerCase()` uses the system's default locale. Using the invariant culture is better because it leads to the same result on every system.

Replace `toLowerCase(Locale.US)` with `lowercase()` for simplicity. Analogous for `toUpperCase(Locale.US)`.