### PR TITLE
Don't ask pitch surface for high jump or pole vault

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -29,6 +29,7 @@ class AddPitchSurface : OsmFilterQuestType<SurfaceAndNote>() {
          and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
          and (access !~ private|no)
          and indoor != yes and (!building or building = no)
+         and (athletics !~ high_jump|pole_vault)
          and (
           !surface
           or surface older today -12 years


### PR DESCRIPTION
Prompted by https://community.openstreetmap.org/t/how-to-tag-a-high-jump-mattress/106241

Looking at https://taginfo.openstreetmap.org/keys/athletics#values I think the rest make sense to ask for surfaces if such pitches exist.

I just made the change through the browser, so untested.