### PR TITLE
Add hint locales for localized name input

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LocalizedNameAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LocalizedNameAdapter.kt
@@ -2,12 +2,17 @@ package de.westnordost.streetcomplete.quests
 
 import android.content.Context
 import android.graphics.Typeface
+import android.os.Build
+import android.os.LocaleList
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.Menu.NONE
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
+import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
@@ -316,6 +321,9 @@ class LocalizedNameAdapter(
             buttonLanguage.text = if (languageTag == "international") "🌍" else languageTag
             updateNameSuggestions()
             updateAbbreviations()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                updateHintLocales(Locale.forLanguageTag(languageTag))
+            }
         }
 
         private fun updateNameSuggestions() {
@@ -342,6 +350,16 @@ class LocalizedNameAdapter(
                     abbreviationsByLocale?.get(Locale(localizedName.languageTag))
                 }
             }
+        }
+
+        @RequiresApi(Build.VERSION_CODES.N)
+        private fun updateHintLocales(locale: Locale) {
+            if (locale.toString().isEmpty()) {
+                input.imeHintLocales = null
+            } else {
+                input.imeHintLocales = LocaleList(locale)
+            }
+            context.getSystemService(InputMethodManager::class.java).restartInput(input)
         }
     }
 


### PR DESCRIPTION
fixes #5351 

The behavior is already described in https://github.com/streetcomplete/StreetComplete/issues/5351#issuecomment-1826262994
`input.imeHintLocales` is only available starting at API24.
`restartInput` is necessary for the changed hint locales to get applied immediately.
`locale.toString().isEmpty()` is used for checking whether a valid `Locale` was created (using `Locale.forLanguageTag`). Maybe there are better ways to test this...