### PR TITLE
Existence quests: skip other features that disappear and come back again

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -76,6 +76,8 @@ class CheckExistence(
         ))
         and access !~ no|private
         and (!seasonal or seasonal = no)
+        and (!intermittent or intermittent = no)
+        and (!permanent or permanent = yes)
     """.toElementFilterExpression() }
     // - traffic_calming = table is often used as a property of a crossing: we don't want the app
     //    to delete the crossing if the table is not there anymore, so exclude that


### PR DESCRIPTION
we already skip [seasonal=yes](https://wiki.openstreetmap.org/wiki/Key:seasonal), but not similar [intermittent=yes](https://wiki.openstreetmap.org/wiki/Key:intermittent) and [permanent=no](https://wiki.openstreetmap.org/wiki/FR:Key:permanent) (used e.g.  for election boards)

Closes https://github.com/streetcomplete/StreetComplete/issues/5394 
