### PR TITLE
Ask if amenity=car_sharing is still there

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -35,6 +35,7 @@ class CheckExistence(
             or amenity = post_box
             or leisure = picnic_table
             or amenity = bbq
+            or amenity = car_sharing
             or leisure = firepit
             or (leisure = pitch and sport ~ table_tennis|chess|table_soccer|teqball)
             or leisure = fitness_station


### PR DESCRIPTION
It has been briefly mentioned in the original "is it still there" issue (https://github.com/streetcomplete/StreetComplete/issues/2074) but hasn't been implemented or discussed any further.


> I've just opened a few notes for car sharing stations which are probably gone. Would be useful to add this imo.



Originally posted by @dreua in https://github.com/streetcomplete/StreetComplete/issues/2074#issuecomment-1841807400
This PR fixes #5399