### PR TITLE
Simplify max speed quest logic

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
@@ -249,22 +249,18 @@ class AddMaxSpeedForm : AbstractOsmQuestForm<MaxSpeedAnswer>() {
 
     private fun determineImplicitMaxspeedType() {
         val highwayTag = element.tags["highway"]!!
-        if (countryInfo.countryCode == "GB") {
-            if (ROADS_WITH_DEFINITE_SPEED_LIMIT_GB.contains(highwayTag)) {
-                applyNoSignAnswer(highwayTag)
-            } else {
-                askIsDualCarriageway(
-                    onYes = { applyNoSignAnswer("nsl_dual") },
-                    onNo = {
-                        determineLit(
-                            onYes = { applyNoSignAnswer("nsl_restricted", true) },
-                            onNo = { applyNoSignAnswer("nsl_single", false) }
-                        )
-                    }
-                )
-            }
-        } else if (ROADS_WITH_DEFINITE_SPEED_LIMIT.contains(highwayTag)) {
+        if (ROADS_WITH_DEFINITE_SPEED_LIMIT.contains(highwayTag)) {
             applyNoSignAnswer(highwayTag)
+        } else if (countryInfo.countryCode == "GB") {
+            askIsDualCarriageway(
+                onYes = { applyNoSignAnswer("nsl_dual") },
+                onNo = {
+                    determineLit(
+                        onYes = { applyNoSignAnswer("nsl_restricted", true) },
+                        onNo = { applyNoSignAnswer("nsl_single", false) }
+                    )
+                }
+            )
         } else {
             askUrbanOrRural(
                 onUrban = { applyNoSignAnswer("urban") },
@@ -321,7 +317,6 @@ class AddMaxSpeedForm : AbstractOsmQuestForm<MaxSpeedAnswer>() {
         private val POSSIBLY_SLOWZONE_ROADS = listOf("residential", "unclassified", "tertiary" /*#1133*/)
         private val MAYBE_LIVING_STREET = listOf("residential", "unclassified")
         private val ROADS_WITH_DEFINITE_SPEED_LIMIT = listOf("motorway", "living_street")
-        private val ROADS_WITH_DEFINITE_SPEED_LIMIT_GB = listOf("motorway", "living_street") /*#2750*/
 
         private var LAST_INPUT_SLOW_ZONE: Int? = null
     }


### PR DESCRIPTION
Since #5378, `ROADS_WITH_DEFINITE_SPEED_LIMIT` and `ROADS_WITH_DEFINITE_SPEED_LIMIT_GB` are identical. Thus, the more complicated implementation of #2811 and #2812 is no longer necessary and can be simplified.

@arrival-spring could you please confirm this?