### PR TITLE
Show name and ref as label for roads

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/util/NameAndLocationLabelTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/util/NameAndLocationLabelTest.kt
@@ -80,6 +80,28 @@ class NameAndLocationLabelTest {
         )))
     }
 
+    @Test fun roadWithName() {
+        assertEquals("Main Street (Residential Road)", getQuestLabel(mapOf(
+            "highway" to "residential",
+            "name" to "Main Street",
+        )))
+    }
+
+    @Test fun roadWitRef() {
+        assertEquals("A1 (Residential Road)", getQuestLabel(mapOf(
+            "highway" to "residential",
+            "ref" to "A1",
+        )))
+    }
+
+    @Test fun roadWithNameAndRef() {
+        assertEquals("Main Street [A1] (Residential Road)", getQuestLabel(mapOf(
+            "highway" to "residential",
+            "name" to "Main Street",
+            "ref" to "A1"
+        )))
+    }
+
     private fun getQuestLabel(tags: Map<String, String>): String? =
         getNameAndLocationLabel(
             Node(0, LatLon(0.0, 0.0), tags),

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/util/NameAndLocationLabelTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/util/NameAndLocationLabelTest.kt
@@ -84,6 +84,7 @@ class NameAndLocationLabelTest {
         assertEquals("Main Street (Residential Road)", getQuestLabel(mapOf(
             "highway" to "residential",
             "name" to "Main Street",
+            "operator" to "Road Agency",
         )))
     }
 
@@ -91,6 +92,7 @@ class NameAndLocationLabelTest {
         assertEquals("A1 (Residential Road)", getQuestLabel(mapOf(
             "highway" to "residential",
             "ref" to "A1",
+            "operator" to "Road Agency",
         )))
     }
 
@@ -98,7 +100,8 @@ class NameAndLocationLabelTest {
         assertEquals("Main Street [A1] (Residential Road)", getQuestLabel(mapOf(
             "highway" to "residential",
             "name" to "Main Street",
-            "ref" to "A1"
+            "ref" to "A1",
+            "operator" to "Road Agency",
         )))
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
@@ -9,6 +9,7 @@ import de.westnordost.osmfeatures.GeometryType
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.util.ktx.geometryType
 import java.util.Locale
 
@@ -111,6 +112,13 @@ fun getNameLabel(tags: Map<String, String>): String? {
     val localRef = tags["local_ref"]
     val ref = tags["ref"]
     val operator = tags["operator"]
+
+    if (tags["highway"] in ALL_ROADS) {
+        return if (name != null && localRef != null) "$name [$localRef]" else null
+            ?: if (name != null && ref != null) "$name [$ref]" else null
+            ?: name
+            ?: ref
+    }
 
     // Favour local ref over ref as it's likely to be more local/visible, e.g. bus stop point versus text code
     return if (name != null && localRef != null) "$name ($localRef)" else null

--- a/app/src/main/java/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
@@ -117,6 +117,7 @@ fun getNameLabel(tags: Map<String, String>): String? {
         return if (name != null && localRef != null) "$name [$localRef]" else null
             ?: if (name != null && ref != null) "$name [$ref]" else null
             ?: name
+            ?: localRef
             ?: ref
     }
 


### PR DESCRIPTION
Fixes #5427  as that seems to have support, and no comments against.

Now:
![Screenshot_20240105-123040~2](https://github.com/streetcomplete/StreetComplete/assets/77166354/a3a880f9-45b7-4543-b270-3dd490e451ed)

And:
![Screenshot_20240105-123111~2](https://github.com/streetcomplete/StreetComplete/assets/77166354/c4796aa7-ec18-40c9-b0f7-713824ba9df9)
