### PR TITLE
Add hint label to note text

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -402,7 +402,12 @@ abstract class AbstractOverlayForm :
 
     protected fun composeNote(element: Element) {
         val overlayTitle = englishResources.getString(overlay.title)
-        val leaveNoteContext = "In context of \"$overlayTitle\" overlay"
+        val hintLabel = getNameAndLocationLabel(element, englishResources, featureDictionary)
+        val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
+            "In context of \"$overlayTitle\" overlay"
+        } else {
+            "In context of \"$overlayTitle\" overlay for $hintLabel"
+        }
         listener?.onComposeNote(overlay, element, geometry, leaveNoteContext)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -404,9 +404,9 @@ abstract class AbstractOverlayForm :
         val overlayTitle = englishResources.getString(overlay.title)
         val hintLabel = getNameAndLocationLabel(element, englishResources, featureDictionary)
         val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
-            "In context of \"$overlayTitle\" overlay"
+            "In context of overlay \"$overlayTitle\""
         } else {
-            "In context of \"$overlayTitle\" overlay for $hintLabel"
+            "In context of overlay \"$overlayTitle – $hintLabel\""
         }
         listener?.onComposeNote(overlay, element, geometry, leaveNoteContext)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -406,7 +406,7 @@ abstract class AbstractOverlayForm :
         val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
             "In context of overlay \"$overlayTitle\""
         } else {
-            "In context of overlay \"$overlayTitle – $hintLabel\""
+            "In context of overlay \"$overlayTitle\" – $hintLabel"
         }
         listener?.onComposeNote(overlay, element, geometry, leaveNoteContext)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -245,7 +245,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
         val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
             "Unable to answer \"$questTitle\""
         } else {
-            "Unable to answer \"$questTitle\" for $hintLabel"
+            "Unable to answer \"$questTitle – $hintLabel\""
         }
         listener?.onComposeNote(osmElementQuestType, element, geometry, leaveNoteContext)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -245,7 +245,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
         val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
             "Unable to answer \"$questTitle\""
         } else {
-            "Unable to answer \"$questTitle – $hintLabel\""
+            "Unable to answer \"$questTitle\" – $hintLabel"
         }
         listener?.onComposeNote(osmElementQuestType, element, geometry, leaveNoteContext)
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -241,7 +241,12 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
 
     protected fun composeNote() {
         val questTitle = englishResources.getQuestTitle(osmElementQuestType, element.tags)
-        val leaveNoteContext = "Unable to answer \"$questTitle\""
+        val hintLabel = getNameAndLocationLabel(element, englishResources, featureDictionary)
+        val leaveNoteContext = if (hintLabel.isNullOrBlank()) {
+            "Unable to answer \"$questTitle\""
+        } else {
+            "Unable to answer \"$questTitle\" for $hintLabel"
+        }
         listener?.onComposeNote(osmElementQuestType, element, geometry, leaveNoteContext)
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
@@ -87,7 +87,7 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment() {
     override fun onComposedNote(text: String, imagePaths: List<String>) {
         val fullText = mutableListOf<String>()
         leaveNoteContext?.let { fullText += it }
-        fullText += "for https://osm.org/${elementType.name.lowercase()}/$elementId"
+        fullText += " <https://osm.org/${elementType.name.lowercase()}/$elementId>"
         fullText += "via ${ApplicationConstants.USER_AGENT}:\n\n$text"
 
         viewLifecycleScope.launch {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
@@ -87,7 +87,7 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment() {
     override fun onComposedNote(text: String, imagePaths: List<String>) {
         val fullText = mutableListOf<String>()
         leaveNoteContext?.let { fullText += it }
-        fullText += "https://osm.org/${elementType.name.lowercase()}/$elementId"
+        fullText += "– https://osm.org/${elementType.name.lowercase()}/$elementId"
         fullText += "via ${ApplicationConstants.USER_AGENT}:\n\n$text"
 
         viewLifecycleScope.launch {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteInsteadFragment.kt
@@ -87,7 +87,7 @@ class LeaveNoteInsteadFragment : AbstractCreateNoteFragment() {
     override fun onComposedNote(text: String, imagePaths: List<String>) {
         val fullText = mutableListOf<String>()
         leaveNoteContext?.let { fullText += it }
-        fullText += " <https://osm.org/${elementType.name.lowercase()}/$elementId>"
+        fullText += "https://osm.org/${elementType.name.lowercase()}/$elementId"
         fullText += "via ${ApplicationConstants.USER_AGENT}:\n\n$text"
 
         viewLifecycleScope.launch {


### PR DESCRIPTION
fixes #5398

This changes the note text as discussed in #5398.
I chose to use `<` and `>` for the link, as I suspect that links are parsed by different consumers (osm.org, notesReview, and probably more that I don't think of) and ideally none of them should produce broken links.

Though I'm not sure how nice this is in all cases, e.g. with level:
_Unable to answer "Are these opening hours still correct?" for on level 2: Mobile Service (Mobile Phone Shop) <https://...>_