### PR TITLE
out of memory while running test.yml GitHub workflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 # Default value: -Xmx1024m
 android.enableJetifier=false
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
When trying to run test via GitHub workflow (e.g. https://github.com/mnalis/StreetComplete/actions/runs/7650904524/job/20847754195) it fails due to not enough memory. Suggested increase fixes the problem:



```
> Task :app:compileReleaseGooglePlayKotlin
> Task :app:compileReleaseKotlin
e: java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3537)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:228)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:582)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:179)
	at org.jetbrains.kotlin.com.intellij.openapi.util.text.Strings.join(Strings.java:600)
	at org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil.join(StringUtil.java:1466)
	at org.jetbrains.kotlin.cli.common.messages.OutputMessageUtil.formatOutputMessage(OutputMessageUtil.java:44)
	at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt$writeAll$1.invoke(outputUtils.kt:54)
	at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt$writeAll$1.invoke(outputUtils.kt:53)
	at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt.writeAll(outputUtils.kt:31)
	at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt.writeAll(outputUtils.kt:53)
	at org.jetbrains.kotlin.cli.jvm.compiler.CliCompilerUtilsKt.writeOutput(cliCompilerUtils.kt:134)
	at org.jetbrains.kotlin.cli.jvm.compiler.CliCompilerUtilsKt$createOutputFilesFlushingCallbackIfPossible$1.invoke(cliCompilerUtils.kt:95)
	at org.jetbrains.kotlin.cli.jvm.compiler.CliCompilerUtilsKt$createOutputFilesFlushingCallbackIfPossible$1.invoke(cliCompilerUtils.kt:93)
	at org.jetbrains.kotlin.codegen.state.GenerationStateKt$GenerationStateEventCallback$1.invoke(GenerationState.kt:412)
	at org.jetbrains.kotlin.codegen.state.GenerationStateKt$GenerationStateEventCallback$1.invoke(GenerationState.kt:411)
	at org.jetbrains.kotlin.codegen.state.GenerationState.afterIndependentPart(GenerationState.kt:363)
	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen(JvmIrCodegenFactory.kt:366)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.runCodegen(KotlinToJVMBytecodeCompiler.kt:347)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:122)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli$default(KotlinToJVMBytecodeCompiler.kt:43)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:165)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:50)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:104)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:48)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:463)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:62)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:477)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:400)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:281)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:125)


> Task :app:compileReleaseKotlin FAILED
```

```
Execution failed for task ':app:compileReleaseGooglePlayKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Not enough memory to run compilation. Try to increase it via 'gradle.properties':
     kotlin.daemon.jvmargs=-Xmx<size>
```