### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -26,7 +26,7 @@ jobs:
     - name: Rename APK
       run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$(git log -n 1 --format='%h').apk
     - name: Archive APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with: 
         name: debug-apk
         path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/generate-quest-list.yml
+++ b/.github/workflows/generate-quest-list.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -21,7 +21,7 @@ jobs:
         run: chmod +x gradlew
       - name: Generate quest list
         run: ./gradlew generateQuestList
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: quest-list.csv
           path: ./quest-list.csv

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,5 +16,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       lintResultFilename: ktlint-result.txt
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Kotlin linter
         id: ktlint-check
         uses: musichin/ktlint-check@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
Github drops support to Node JS 16 in Github actions -> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

- Bump checkout to v4 -> https://github.com/actions/checkout/releases/tag/v4.0.0
- Bump setup-java to v4 -> https://github.com/actions/setup-java/releases/tag/v4.0.0
- Bump upload-artifact to v4 -> https://github.com/actions/upload-artifact/releases/tag/v4.0.0 (I have noticed this version changes where the size of the artifact is obtained, before actions get the size of the content inside archive, now actions get the size of the archive)