### PR TITLE
Use AppCompat ImageView instead ImageView

### DIFF
--- a/app/src/main/res/layout-land/fragment_achievement_info.xml
+++ b/app/src/main/res/layout-land/fragment_achievement_info.xml
@@ -20,7 +20,7 @@
 
     <ImageView
         android:id="@+id/shineView1"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="800dp"
         android:layout_height="800dp"
         app:layout_constraintTop_toTopOf="@id/dialogContainer"
@@ -31,7 +31,7 @@
 
     <ImageView
         android:id="@+id/shineView2"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="800dp"
         android:layout_height="800dp"
         android:rotation="180"

--- a/app/src/main/res/layout/cell_image_thumbnail.xml
+++ b/app/src/main/res/layout/cell_image_thumbnail.xml
@@ -19,7 +19,7 @@
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:padding="0dp"
-        android:src="@drawable/ic_close_24dp"
+        app:srcCompat="@drawable/ic_close_24dp"
         android:scaleType="center"
         app:tint="#fff"
         android:background="#9333"

--- a/app/src/main/res/layout/cell_labeled_icon_select_with_description_group.xml
+++ b/app/src/main/res/layout/cell_labeled_icon_select_with_description_group.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground">
@@ -60,7 +61,7 @@
             android:id="@+id/dropDownArrowImageView"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:src="@drawable/ic_arrow_right_96dp"
+            app:srcCompat="@drawable/ic_arrow_right_96dp"
             android:layout_centerVertical="true"
             android:layout_alignParentEnd="true"/>
 

--- a/app/src/main/res/layout/cell_panorama_select.xml
+++ b/app/src/main/res/layout/cell_panorama_select.xml
@@ -39,7 +39,7 @@
         android:id="@+id/dropDownArrowImageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_right_96dp"
+        app:srcCompat="@drawable/ic_arrow_right_96dp"
         app:tint="#fff"
         android:layout_centerVertical="true"
         android:layout_alignParentEnd="true"

--- a/app/src/main/res/layout/dialog_confirm_assembly_point.xml
+++ b/app/src/main/res/layout/dialog_confirm_assembly_point.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
@@ -17,7 +18,7 @@
         android:id="@+id/assemblyPointImage"
         android:layout_width="200dp"
         android:layout_height="200dp"
-        android:src="@drawable/ic_assembly_point"
+        app:srcCompat="@drawable/ic_assembly_point"
         android:contentDescription="@string/quest_accessPointRef_answer_assembly_point" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_achievement_info.xml
+++ b/app/src/main/res/layout/fragment_achievement_info.xml
@@ -20,7 +20,7 @@
 
     <ImageView
         android:id="@+id/shineView1"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="centerCrop"
@@ -34,7 +34,7 @@
 
     <ImageView
         android:id="@+id/shineView2"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:rotation="180"

--- a/app/src/main/res/layout/fragment_attach_photo.xml
+++ b/app/src/main/res/layout/fragment_attach_photo.xml
@@ -26,7 +26,7 @@
         android:layout_toEndOf="@id/takePhotoButton"
         android:layout_width="72dp"
         android:layout_height="72dp"
-        android:src="@drawable/ic_attach_gpx_24dp"
+        app:srcCompat="@drawable/ic_attach_gpx_24dp"
         app:tint="@color/disabled_text"
         android:visibility="gone"
         tools:visibility="visible"

--- a/app/src/main/res/layout/fragment_country_info_dialog.xml
+++ b/app/src/main/res/layout/fragment_country_info_dialog.xml
@@ -59,7 +59,7 @@
                 android:id="@+id/titleImageView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:src="@drawable/ic_flag_in"
+                app:srcCompat="@drawable/ic_flag_in"
                 android:scaleType="fitCenter"/>
 
         </de.westnordost.streetcomplete.view.CircularMaskFrameLayout>
@@ -90,7 +90,7 @@
                 <ImageView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/ic_star_48dp"/>
+                    app:srcCompat="@drawable/ic_star_48dp"/>
 
                 <TextView
                     android:id="@+id/editCountText"

--- a/app/src/main/res/layout/fragment_edit_type_info_dialog.xml
+++ b/app/src/main/res/layout/fragment_edit_type_info_dialog.xml
@@ -52,7 +52,7 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
-            android:src="@drawable/ic_quest_max_height"
+            app:srcCompat="@drawable/ic_quest_max_height"
             android:scaleType="fitCenter"
             android:elevation="24dp"/>
 
@@ -90,7 +90,7 @@
                 <ImageView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/ic_star_48dp"/>
+                    app:srcCompat="@drawable/ic_star_48dp"/>
 
                 <TextView
                     android:id="@+id/editCountText"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -22,7 +22,7 @@
         android:paddingLeft="@dimen/quest_form_leftOffset"
         android:paddingRight="@dimen/quest_form_rightOffset"
         android:layout_centerInParent="true"
-        android:src="@drawable/crosshair"
+        app:srcCompat="@drawable/crosshair"
         app:tint="@color/monochrome_icon"
         android:alpha="0.6"
         tools:ignore="RtlHardcoded" />
@@ -96,7 +96,7 @@
             android:background="@drawable/round_white_button"
             android:elevation="4dp"
             android:padding="14dp"
-            android:src="@drawable/ic_compass_needle_48dp"
+            app:srcCompat="@drawable/ic_compass_needle_48dp"
             app:layout_constraintTop_toBottomOf="@+id/main_menu_button_fragment"
             app:layout_constraintRight_toRightOf="parent" />
 
@@ -107,7 +107,7 @@
             android:layout_height="@dimen/map_button_size"
             android:contentDescription="@string/map_btn_stop_track"
             android:scaleType="center"
-            android:src="@drawable/ic_stop_recording_24dp"
+            app:srcCompat="@drawable/ic_stop_recording_24dp"
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintRight_toLeftOf="@id/gpsTrackingButton"
@@ -119,7 +119,7 @@
             android:layout_height="@dimen/map_button_size"
             android:scaleType="center"
             style="@style/RoundWhiteButton"
-            android:src="@drawable/ic_add_24dp"
+            app:srcCompat="@drawable/ic_add_24dp"
             android:contentDescription="@string/map_btn_zoom_in"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintBottom_toTopOf="@id/zoomOutButton"/>
@@ -130,7 +130,7 @@
             android:layout_height="@dimen/map_button_size"
             android:scaleType="center"
             style="@style/RoundWhiteButton"
-            android:src="@drawable/ic_subtract_24dp"
+            app:srcCompat="@drawable/ic_subtract_24dp"
             android:contentDescription="@string/map_btn_zoom_out"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintBottom_toTopOf="@id/gpsTrackingButton"/>
@@ -141,7 +141,7 @@
             android:layout_height="@dimen/map_button_size"
             android:scaleType="center"
             style="@style/RoundWhiteButton"
-            android:src="@drawable/ic_location_state_24dp"
+            app:srcCompat="@drawable/ic_location_state_24dp"
             app:tint="@color/activated_tint"
             android:contentDescription="@string/map_btn_gps_tracking"
             app:layout_constraintRight_toRightOf="parent"
@@ -166,7 +166,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             android:scaleType="centerInside"
-            android:src="@drawable/ic_add_48dp"
+            app:srcCompat="@drawable/ic_add_48dp"
             android:padding="20dp"
             android:layout_marginBottom="22dp"
             app:layout_constraintHorizontal_bias="0.25"

--- a/app/src/main/res/layout/fragment_main_menu_button.xml
+++ b/app/src/main/res/layout/fragment_main_menu_button.xml
@@ -18,7 +18,7 @@
             android:layout_height="match_parent"
             android:contentDescription="@string/map_btn_menu"
             android:scaleType="center"
-            android:src="@drawable/ic_menu_24dp" />
+            app:srcCompat="@drawable/ic_menu_24dp" />
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_move_node.xml
+++ b/app/src/main/res/layout/fragment_move_node.xml
@@ -27,7 +27,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingRight="16dp"
-                android:src="@drawable/pin"
+                app:srcCompat="@drawable/pin"
                 tools:ignore="RtlSymmetry"/>
 
             <ImageView
@@ -36,7 +36,7 @@
                 android:layout_height="42dp"
                 android:layout_marginTop="7dp"
                 android:layout_centerHorizontal="true"
-                android:src="@drawable/ic_quest_create_note" />
+                app:srcCompat="@drawable/ic_quest_create_note" />
 
         </RelativeLayout>
 
@@ -123,7 +123,7 @@
 
         <ImageView
             android:id="@+id/okButton"
-            android:src="@drawable/ic_check_48dp"
+            app:srcCompat="@drawable/ic_check_48dp"
             android:layout_width="@dimen/ok_button_size"
             android:layout_height="@dimen/ok_button_size"
             android:layout_alignParentEnd="true"

--- a/app/src/main/res/layout/fragment_overlay.xml
+++ b/app/src/main/res/layout/fragment_overlay.xml
@@ -15,7 +15,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingRight="16dp"
-            android:src="@drawable/pin"
+            app:srcCompat="@drawable/pin"
             tools:ignore="RtlHardcoded,RtlSymmetry"/>
 
         <ImageView
@@ -24,7 +24,7 @@
             android:layout_height="42dp"
             android:layout_marginTop="7dp"
             android:layout_centerHorizontal="true"
-            android:src="@drawable/ic_quest_create_note" />
+            app:srcCompat="@drawable/ic_quest_create_note" />
 
     </RelativeLayout>
 
@@ -102,7 +102,7 @@
                         android:id="@+id/moreButton"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:src="@drawable/ic_more_24dp"
+                        app:srcCompat="@drawable/ic_more_24dp"
                         android:padding="12dp"
                         android:background="?android:attr/selectableItemBackgroundBorderless"
                         app:layout_constraintBottom_toBottomOf="parent"
@@ -131,7 +131,7 @@
 
                         <ImageView
                             android:id="@+id/okButton"
-                            android:src="@drawable/ic_check_48dp"
+                            app:srcCompat="@drawable/ic_check_48dp"
                             android:scaleType="centerInside"
                             style="@style/RoundAccentButton"
                             android:layout_width="@dimen/ok_button_size"

--- a/app/src/main/res/layout/fragment_overlay_shops.xml
+++ b/app/src/main/res/layout/fragment_overlay_shops.xml
@@ -45,7 +45,7 @@
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_arrow_expand_down_24dp"
+            app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
             android:padding="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/fragment_overlays_button.xml
+++ b/app/src/main/res/layout/fragment_overlays_button.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageButton
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="@dimen/map_button_size"
     android:layout_height="@dimen/map_button_size"
     android:background="@drawable/round_white_button"
     android:elevation="4dp"
-    android:src="@drawable/ic_overlay_black_24dp"
+    app:srcCompat="@drawable/ic_overlay_black_24dp"
     android:contentDescription="@string/action_overlays"
     android:scaleType="centerInside" />

--- a/app/src/main/res/layout/fragment_overlays_tutorial.xml
+++ b/app/src/main/res/layout/fragment_overlays_tutorial.xml
@@ -29,13 +29,13 @@
             android:id="@+id/mapImageView"
             android:layout_width="226dp"
             android:layout_height="222dp"
-            android:src="@drawable/logo_osm_map" />
+            app:srcCompat="@drawable/logo_osm_map" />
 
         <ImageView
             android:id="@+id/overlayImageView"
             android:layout_width="226dp"
             android:layout_height="222dp"
-            android:src="@drawable/overlay_osm_map_animated"
+            app:srcCompat="@drawable/overlay_osm_map_animated"
             android:visibility="invisible"
             tools:visibility="visible" />
 
@@ -43,7 +43,7 @@
             android:id="@+id/overlayIcon1"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:src="@drawable/ic_preset_fas_shopping_cart"
+            app:srcCompat="@drawable/ic_preset_fas_shopping_cart"
             android:visibility="invisible"
             tools:visibility="visible"
             android:translationX="80dp"
@@ -53,7 +53,7 @@
             android:id="@+id/overlayIcon2"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:src="@drawable/ic_preset_maki_fuel"
+            app:srcCompat="@drawable/ic_preset_maki_fuel"
             android:visibility="invisible"
             tools:visibility="visible"
             android:translationX="180dp"
@@ -63,7 +63,7 @@
             android:id="@+id/overlaySelectedImageView"
             android:layout_width="226dp"
             android:layout_height="222dp"
-            android:src="@drawable/overlay_osm_map_edit_animated"
+            app:srcCompat="@drawable/overlay_osm_map_edit_animated"
             android:visibility="invisible"
             tools:visibility="visible"  />
 
@@ -74,7 +74,7 @@
         android:id="@+id/paintRollerView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/paint_roller_animated"
+        app:srcCompat="@drawable/paint_roller_animated"
         android:rotation="-45"
         android:visibility="invisible"
         tools:visibility="visible"
@@ -83,7 +83,7 @@
 
     <ImageView
         android:id="@+id/shineView1"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="196dp"
         android:layout_height="196dp"
         android:scaleType="centerCrop"
@@ -95,7 +95,7 @@
 
     <ImageView
         android:id="@+id/shineView2"
-        android:src="@drawable/shine"
+        app:srcCompat="@drawable/shine"
         android:layout_width="128dp"
         android:layout_height="128dp"
         android:scaleType="centerCrop"
@@ -117,7 +117,7 @@
         app:layout_constraintLeft_toRightOf="@id/mapImageContainer"
         app:layout_constraintBottom_toBottomOf="@id/mapImageContainer"
         android:layout_marginBottom="16dp"
-        android:src="@drawable/ic_overlay_black_24dp"
+        app:srcCompat="@drawable/ic_overlay_black_24dp"
         android:scaleType="centerInside" />
 
     <FrameLayout
@@ -238,19 +238,19 @@
                 android:id="@+id/dot1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/indicator_dot_selected"/>
+                app:srcCompat="@drawable/indicator_dot_selected"/>
 
             <ImageView
                 android:id="@+id/dot2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/indicator_dot_default"/>
+                app:srcCompat="@drawable/indicator_dot_default"/>
 
             <ImageView
                 android:id="@+id/dot3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/indicator_dot_default"/>
+                app:srcCompat="@drawable/indicator_dot_default"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -68,7 +68,7 @@
                     <ImageView
                         android:layout_width="32dp"
                         android:layout_height="32dp"
-                        android:src="@drawable/ic_star_48dp" />
+                        app:srcCompat="@drawable/ic_star_48dp" />
 
                     <TextView
                         android:id="@+id/editCountText"
@@ -301,7 +301,7 @@
                 <ImageView
                     android:layout_width="24dp"
                     android:layout_height="24dp"
-                    android:src="@drawable/ic_star_48dp" />
+                    app:srcCompat="@drawable/ic_star_48dp" />
 
                 <TextView
                     android:id="@+id/currentWeekEditCountText"

--- a/app/src/main/res/layout/fragment_quest_answer.xml
+++ b/app/src/main/res/layout/fragment_quest_answer.xml
@@ -71,7 +71,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:scaleType="center"
-                    android:src = "@drawable/ic_close_24dp"
+                    app:srcCompat = "@drawable/ic_close_24dp"
                     android:background="?android:attr/actionBarItemBackground"
                     android:visibility="gone"
                     android:contentDescription="@string/close"
@@ -174,7 +174,7 @@
 
         <ImageView
             android:id="@+id/okButton"
-            android:src="@drawable/ic_check_48dp"
+            app:srcCompat="@drawable/ic_check_48dp"
             android:scaleType="centerInside"
             style="@style/RoundAccentButton"
             android:layout_width="@dimen/ok_button_size"

--- a/app/src/main/res/layout/fragment_quest_presets.xml
+++ b/app/src/main/res/layout/fragment_quest_presets.xml
@@ -53,7 +53,7 @@
         android:id="@+id/addPresetButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_add_24dp"
+        app:srcCompat="@drawable/ic_add_24dp"
         android:contentDescription="@string/quest_presets_preset_add"
         android:layout_margin="16dp"
         android:layout_alignParentBottom="true"

--- a/app/src/main/res/layout/fragment_split_way.xml
+++ b/app/src/main/res/layout/fragment_split_way.xml
@@ -2,6 +2,7 @@
 <RelativeLayout android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/splitWayRoot">
 
@@ -11,7 +12,7 @@
         android:layout_height="wrap_content"
         android:rotation="-45"
         android:alpha="0"
-        android:src="@drawable/scissors_animation"/>
+        app:srcCompat="@drawable/scissors_animation"/>
 
     <de.westnordost.streetcomplete.view.SlidingRelativeLayout
         android:layout_width="@dimen/quest_form_width"
@@ -30,7 +31,7 @@
                 android:layout_height="64dp"
                 android:scaleType="center"
                 style="@style/RoundWhiteButton"
-                android:src="@drawable/ic_undo_24dp"
+                app:srcCompat="@drawable/ic_undo_24dp"
                 android:layout_marginEnd="32dp"
                 android:layout_marginStart="32dp"/>
 
@@ -101,7 +102,7 @@
 
         <ImageView
             android:id="@+id/okButton"
-            android:src="@drawable/ic_check_48dp"
+            app:srcCompat="@drawable/ic_check_48dp"
             android:layout_width="72dp"
             android:layout_height="72dp"
             android:layout_alignParentEnd="true"

--- a/app/src/main/res/layout/fragment_tutorial.xml
+++ b/app/src/main/res/layout/fragment_tutorial.xml
@@ -25,7 +25,7 @@
             android:id="@+id/mapImageView"
             android:layout_width="200dp"
             android:layout_height="200dp"
-            android:src="@drawable/logo_osm_map"
+            app:srcCompat="@drawable/logo_osm_map"
             app:layout_constraintBottom_toTopOf="@id/tutorialTextContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
@@ -34,7 +34,7 @@
             android:id="@+id/mapLightingImageView"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:src="@drawable/logo_osm_map_lighting"
+            app:srcCompat="@drawable/logo_osm_map_lighting"
             app:layout_constraintTop_toTopOf="@id/mapImageView"
             app:layout_constraintStart_toStartOf="@id/mapImageView"
             app:layout_constraintEnd_toEndOf="@id/mapImageView"
@@ -46,7 +46,7 @@
             android:layout_height="64dp"
             android:scaleType="center"
             style="@style/RoundWhiteButton"
-            android:src="@drawable/ic_location_state_24dp"
+            app:srcCompat="@drawable/ic_location_state_24dp"
             android:clickable="false"
             app:state_searching="true"
             android:layout_marginBottom="16dp"
@@ -72,7 +72,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingRight="16dp"
-                android:src="@drawable/pin"
+                app:srcCompat="@drawable/pin"
                 android:layout_gravity="right"
                 tools:ignore="RtlHardcoded,RtlSymmetry"/>
 
@@ -81,7 +81,7 @@
                 android:layout_height="42dp"
                 android:layout_marginTop="7dp"
                 android:layout_centerHorizontal="true"
-                android:src="@drawable/ic_quest_recycling" />
+                app:srcCompat="@drawable/ic_quest_recycling" />
 
         </RelativeLayout>
 
@@ -102,7 +102,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingRight="16dp"
-                android:src="@drawable/pin"
+                app:srcCompat="@drawable/pin"
                 android:layout_gravity="right"
                 tools:ignore="RtlHardcoded,RtlSymmetry"/>
 
@@ -111,7 +111,7 @@
                 android:layout_height="42dp"
                 android:layout_marginTop="7dp"
                 android:layout_centerHorizontal="true"
-                android:src="@drawable/ic_quest_street" />
+                app:srcCompat="@drawable/ic_quest_street" />
 
         </RelativeLayout>
 
@@ -132,7 +132,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingRight="16dp"
-                android:src="@drawable/pin"
+                app:srcCompat="@drawable/pin"
                 android:layout_gravity="right"
                 tools:ignore="RtlHardcoded,RtlSymmetry"/>
 
@@ -141,7 +141,7 @@
                 android:layout_height="42dp"
                 android:layout_marginTop="7dp"
                 android:layout_centerHorizontal="true"
-                android:src="@drawable/ic_quest_traffic_lights" />
+                app:srcCompat="@drawable/ic_quest_traffic_lights" />
 
         </RelativeLayout>
 
@@ -149,7 +149,7 @@
             android:id="@+id/checkmarkView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_animated_checkmark_circle"
+            app:srcCompat="@drawable/ic_animated_checkmark_circle"
             app:layout_constraintTop_toTopOf="@id/mapImageView"
             app:layout_constraintStart_toStartOf="@id/mapImageView"
             app:layout_constraintEnd_toEndOf="@id/mapImageView"
@@ -314,19 +314,19 @@
                     android:id="@+id/dot1"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/indicator_dot_selected"/>
+                    app:srcCompat="@drawable/indicator_dot_selected"/>
 
                 <ImageView
                     android:id="@+id/dot2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/indicator_dot_default"/>
+                    app:srcCompat="@drawable/indicator_dot_default"/>
 
                 <ImageView
                     android:id="@+id/dot3"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/indicator_dot_default"/>
+                    app:srcCompat="@drawable/indicator_dot_default"/>
 
             </LinearLayout>
 
@@ -345,7 +345,7 @@
             android:id="@+id/magnifierImageView"
             android:layout_width="185dp"
             android:layout_height="185dp"
-            android:src="@drawable/logo_osm_magnifier"
+            app:srcCompat="@drawable/logo_osm_magnifier"
             android:transformPivotX="140dp"
             android:transformPivotY="60dp"
             android:translationX="10dp"

--- a/app/src/main/res/layout/fragment_undo_button.xml
+++ b/app/src/main/res/layout/fragment_undo_button.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageButton
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/undoButton"
     android:layout_width="@dimen/map_button_size"
     android:layout_height="@dimen/map_button_size"
     android:scaleType="center"
     style="@style/RoundWhiteButton"
-    android:src="@drawable/ic_undo_24dp"
+    app:srcCompat="@drawable/ic_undo_24dp"
     android:contentDescription="@string/action_undo" />

--- a/app/src/main/res/layout/fragment_unread_osm_message.xml
+++ b/app/src/main/res/layout/fragment_unread_osm_message.xml
@@ -17,7 +17,7 @@
             android:id="@+id/mailOpenImageView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_animated_open_mail"
+            app:srcCompat="@drawable/ic_animated_open_mail"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
@@ -68,7 +68,7 @@
             android:id="@+id/mailFrontImageView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_mail_front"
+            app:srcCompat="@drawable/ic_mail_front"
             app:layout_constraintBottom_toBottomOf="@id/mailOpenImageView"
             app:layout_constraintEnd_toEndOf="@id/mailOpenImageView"
             app:layout_constraintStart_toStartOf="@id/mailOpenImageView"

--- a/app/src/main/res/layout/marker_create_note.xml
+++ b/app/src/main/res/layout/marker_create_note.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/markerLayoutContainer"
     android:layout_width="match_parent"
@@ -27,7 +28,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingRight="16dp"
-                android:src="@drawable/pin"
+                app:srcCompat="@drawable/pin"
                 tools:ignore="RtlSymmetry"/>
 
             <ImageView
@@ -36,7 +37,7 @@
                 android:layout_height="42dp"
                 android:layout_marginTop="7dp"
                 android:layout_centerHorizontal="true"
-                android:src="@drawable/ic_quest_create_note" />
+                app:srcCompat="@drawable/ic_quest_create_note" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/quest_building_levels.xml
+++ b/app/src/main/res/layout/quest_building_levels.xml
@@ -19,7 +19,7 @@
         android:id="@+id/buildingImage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/building_levels_illustration"
+        app:srcCompat="@drawable/building_levels_illustration"
         android:scaleType="fitEnd"
         android:layout_centerHorizontal="true"
         />

--- a/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
+++ b/app/src/main/res/layout/quest_building_levels_last_picked_button.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.AppCompat.Button.Small"
     android:layout_width="wrap_content"
@@ -18,7 +19,7 @@
         android:id="@+id/lastBuildingIllustrationIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_building_levels_illustration"
+        app:srcCompat="@drawable/ic_building_levels_illustration"
         tools:ignore="RtlHardcoded" />
 
     <TextView

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_de.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_de.xml
@@ -38,7 +38,7 @@
         android:id="@+id/suggestionsButton"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="@color/traffic_black"
         app:layout_constraintRight_toRightOf="@id/diameterInput"
         app:layout_constraintTop_toTopOf="@id/diameterInput"

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_fi.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_fi.xml
@@ -38,7 +38,7 @@
         android:id="@+id/suggestionsButton"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="@color/traffic_black"
         app:layout_constraintRight_toRightOf="@id/diameterInput"
         app:layout_constraintTop_toTopOf="@id/diameterInput"

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_generic.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_generic.xml
@@ -25,7 +25,7 @@
         android:layout_width="48dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="-48dp"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         style="@style/Base.Widget.AppCompat.Button.Borderless" />
 
     <TextView

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_nl.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_nl.xml
@@ -37,7 +37,7 @@
         android:id="@+id/suggestionsButton"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="@color/traffic_white"
         app:layout_constraintRight_toRightOf="@id/diameterInput"
         app:layout_constraintTop_toTopOf="@id/diameterInput"

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_pl.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_pl.xml
@@ -38,7 +38,7 @@
         android:id="@+id/suggestionsButton"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="@color/traffic_white"
         app:layout_constraintRight_toRightOf="@id/diameterInput"
         app:layout_constraintTop_toTopOf="@id/diameterInput"

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_uk.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_uk.xml
@@ -39,7 +39,7 @@
         android:id="@+id/suggestionsButton"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="@color/traffic_black"
         app:layout_constraintRight_toRightOf="@id/diameterInput"
         app:layout_constraintTop_toTopOf="@id/diameterInput"

--- a/app/src/main/res/layout/quest_lanes_select_type.xml
+++ b/app/src/main/res/layout/quest_lanes_select_type.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -36,7 +37,7 @@
                 android:paddingEnd="6dp"
                 android:paddingTop="6dp"
                 android:scaleType="fitCenter"
-                android:src="@drawable/ic_lanes_marked"
+                app:srcCompat="@drawable/ic_lanes_marked"
                 android:adjustViewBounds="true"/>
 
             <TextView
@@ -64,7 +65,7 @@
                 android:paddingEnd="6dp"
                 android:paddingTop="6dp"
                 android:scaleType="fitCenter"
-                android:src="@drawable/ic_lanes_unmarked"
+                app:srcCompat="@drawable/ic_lanes_unmarked"
                 android:adjustViewBounds="true"/>
 
             <TextView
@@ -92,7 +93,7 @@
                 android:paddingEnd="6dp"
                 android:paddingTop="6dp"
                 android:scaleType="fitCenter"
-                android:src="@drawable/ic_lanes_marked_odd"
+                app:srcCompat="@drawable/ic_lanes_marked_odd"
                 android:adjustViewBounds="true"/>
 
             <TextView

--- a/app/src/main/res/layout/quest_maxspeed_national_speed_limit_sign.xml
+++ b/app/src/main/res/layout/quest_maxspeed_national_speed_limit_sign.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nationalSpeedLimitImage"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:src="@drawable/ic_national_speed_limit"/>
+    app:srcCompat="@drawable/ic_national_speed_limit"/>

--- a/app/src/main/res/layout/quest_maxweight_axleload_sign.xml
+++ b/app/src/main/res/layout/quest_maxweight_axleload_sign.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -59,7 +60,7 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_axleload"
+        app:srcCompat="@drawable/ic_axleload"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"/>
 

--- a/app/src/main/res/layout/quest_maxweight_axleload_sign_fi.xml
+++ b/app/src/main/res/layout/quest_maxweight_axleload_sign_fi.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -59,7 +60,7 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_axleload"
+        app:srcCompat="@drawable/ic_axleload"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"/>
 

--- a/app/src/main/res/layout/quest_maxweight_mgv_sign.xml
+++ b/app/src/main/res/layout/quest_maxweight_mgv_sign.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -13,7 +14,7 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="36dp"
-        android:src="@drawable/ic_truck"
+        app:srcCompat="@drawable/ic_truck"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"/>
 

--- a/app/src/main/res/layout/quest_maxweight_mgv_sign_de.xml
+++ b/app/src/main/res/layout/quest_maxweight_mgv_sign_de.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -16,7 +17,7 @@
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_truck"
+            app:srcCompat="@drawable/ic_truck"
             android:layout_centerInParent="true"/>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/quest_maxweight_mgv_sign_fi.xml
+++ b/app/src/main/res/layout/quest_maxweight_mgv_sign_fi.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -13,7 +14,7 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="36dp"
-        android:src="@drawable/ic_truck"
+        app:srcCompat="@drawable/ic_truck"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"/>
 

--- a/app/src/main/res/layout/quest_maxweight_tandem_axleload_sign.xml
+++ b/app/src/main/res/layout/quest_maxweight_tandem_axleload_sign.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -59,6 +60,6 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_tandem_axleload"/>
+        app:srcCompat="@drawable/ic_tandem_axleload"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/quest_maxweight_tandem_axleload_sign_fi.xml
+++ b/app/src/main/res/layout/quest_maxweight_tandem_axleload_sign_fi.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="112dp"
     android:layout_height="112dp"
@@ -59,6 +60,6 @@
     <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_tandem_axleload"/>
+        app:srcCompat="@drawable/ic_tandem_axleload"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/quest_roadname_row.xml
+++ b/app/src/main/res/layout/quest_roadname_row.xml
@@ -51,7 +51,7 @@
         android:id="@+id/nameSuggestionsButton"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         app:tint="#fff"
         android:layout_toStartOf="@+id/deleteButton"
         android:layout_centerVertical="true"
@@ -60,7 +60,7 @@
 
     <ImageView
         android:id="@+id/deleteButton"
-        android:src="@drawable/ic_delete_24dp"
+        app:srcCompat="@drawable/ic_delete_24dp"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"

--- a/app/src/main/res/layout/quest_sanitary_dump_station.xml
+++ b/app/src/main/res/layout/quest_sanitary_dump_station.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -23,13 +24,13 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scaleType="centerInside"
-            android:src="@drawable/sanitary_dump_station_sign1" />
+            app:srcCompat="@drawable/sanitary_dump_station_sign1" />
 
         <ImageView
             android:layout_weight="1"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:src="@drawable/sanitary_dump_station_sign2" />
+            app:srcCompat="@drawable/sanitary_dump_station_sign2" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/quest_tactile_paving.xml
+++ b/app/src/main/res/layout/quest_tactile_paving.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -17,6 +18,6 @@
         android:adjustViewBounds="true"
         android:cropToPadding="false"
         android:scaleType="centerCrop"
-        android:src="@drawable/tactile_paving_illustration" />
+        app:srcCompat="@drawable/tactile_paving_illustration" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/quest_times_offday_row.xml
+++ b/app/src/main/res/layout/quest_times_offday_row.xml
@@ -38,7 +38,7 @@
         style="@style/TimesField"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_delete_24dp"
+        app:srcCompat="@drawable/ic_delete_24dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/offLabel"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/quest_times_weekday_row.xml
+++ b/app/src/main/res/layout/quest_times_weekday_row.xml
@@ -37,7 +37,7 @@
         style="@style/TimesField"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_delete_24dp"
+        app:srcCompat="@drawable/ic_delete_24dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/hoursLabel"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/quest_traffic_lights_vibration.xml
+++ b/app/src/main/res/layout/quest_traffic_lights_vibration.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
@@ -14,7 +15,7 @@
         android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:src="@drawable/vibrating_button_illustration" />
+        app:srcCompat="@drawable/vibrating_button_illustration" />
 
     <TextView
         android:layout_width="0dp"

--- a/app/src/main/res/layout/quest_wheelchair_toilets_explanation.xml
+++ b/app/src/main/res/layout/quest_wheelchair_toilets_explanation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
@@ -10,7 +11,7 @@
         android:layout_width="64dp"
         android:layout_height="64dp"
         android:layout_margin="10dp"
-        android:src="@drawable/ic_quest_wheelchair" />
+        app:srcCompat="@drawable/ic_quest_wheelchair" />
 
     <TextView
         android:id="@+id/descriptionLabel"

--- a/app/src/main/res/layout/row_edit_item.xml
+++ b/app/src/main/res/layout/row_edit_item.xml
@@ -81,7 +81,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:src="@drawable/pin_selection_ring" />
+            app:srcCompat="@drawable/pin_selection_ring" />
 
         <ImageView
             android:id="@+id/overlayIcon"
@@ -99,7 +99,7 @@
             android:background="@drawable/round_white_button"
             android:contentDescription="@string/action_undo"
             android:scaleType="centerInside"
-            android:src="@drawable/ic_undo_24dp"
+            app:srcCompat="@drawable/ic_undo_24dp"
             app:tint="#000"
             android:layout_margin="2dp"
             android:elevation="4dp"

--- a/app/src/main/res/layout/row_localizedname.xml
+++ b/app/src/main/res/layout/row_localizedname.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -32,7 +33,7 @@
         android:id="@+id/nameSuggestionsButton"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         android:layout_toStartOf="@+id/deleteButton"
         android:layout_centerVertical="true"
         android:layout_marginEnd="8dp"
@@ -40,7 +41,7 @@
 
     <ImageView
         android:id="@+id/deleteButton"
-        android:src="@drawable/ic_delete_24dp"
+        app:srcCompat="@drawable/ic_delete_24dp"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"

--- a/app/src/main/res/layout/row_quest_preset.xml
+++ b/app/src/main/res/layout/row_quest_preset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -24,7 +25,7 @@
         android:id="@+id/menuButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_more_24dp"
+        app:srcCompat="@drawable/ic_more_24dp"
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:clickable="true"
         android:padding="12dp"

--- a/app/src/main/res/layout/row_quest_selection.xml
+++ b/app/src/main/res/layout/row_quest_selection.xml
@@ -11,7 +11,7 @@
         android:id="@+id/dragHandle"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        android:src="@drawable/ic_drag_vertical"
+        app:srcCompat="@drawable/ic_drag_vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/sign_bicycle_boulevard.xml
+++ b/app/src/main/res/layout/sign_bicycle_boulevard.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/signBicycleBoulevard"
     android:layout_width="match_parent"
@@ -24,7 +25,7 @@
             android:id="@+id/bicycleIconView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_bicycle_white"/>
+            app:srcCompat="@drawable/ic_bicycle_white"/>
 
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/view_achievement_icon.xml
+++ b/app/src/main/res/layout/view_achievement_icon.xml
@@ -11,7 +11,7 @@
         android:id="@+id/frameView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:src="@drawable/achievement_frame"/>
+        app:srcCompat="@drawable/achievement_frame"/>
 
     <ImageView
         android:id="@+id/iconView"

--- a/app/src/main/res/layout/view_answers_counter.xml
+++ b/app/src/main/res/layout/view_answers_counter.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:parentTag="android.widget.RelativeLayout"
     android:layout_width="wrap_content"
@@ -26,7 +27,7 @@
         android:padding="8dp"
         android:layout_centerVertical="true"
         android:layout_alignParentLeft="true"
-        android:src="@drawable/ic_star_white_shadow_32dp"
+        app:srcCompat="@drawable/ic_star_white_shadow_32dp"
         tools:ignore="RtlHardcoded" />
 
     <RelativeLayout

--- a/app/src/main/res/layout/view_icon_progress.xml
+++ b/app/src/main/res/layout/view_icon_progress.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:parentTag="android.widget.RelativeLayout"
     tools:background="#f0f"
@@ -28,7 +29,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="6dp"
-        android:src="@drawable/ic_animated_checkmark_circle"
+        app:srcCompat="@drawable/ic_animated_checkmark_circle"
         android:alpha="0"
         tools:alpha="1"
         tools:src="@drawable/ic_checkmark_circle"/>

--- a/app/src/main/res/layout/view_image_select.xml
+++ b/app/src/main/res/layout/view_image_select.xml
@@ -34,7 +34,7 @@
         android:id="@+id/dropDownArrowImageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_expand_down_24dp"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
         android:padding="4dp"
         app:layout_constrainedWidth="true"
         app:layout_constraintStart_toEndOf="@id/selectTextView"

--- a/app/src/main/res/layout/view_little_compass.xml
+++ b/app/src/main/res/layout/view_little_compass.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/compassView"
     android:layout_width="32dp"
@@ -8,7 +9,7 @@
     android:textColor="#000"
     android:padding="4dp"
     android:layout_margin="8dp"
-    android:src="@drawable/ic_compass_needle_48dp"
+    app:srcCompat="@drawable/ic_compass_needle_48dp"
     android:layout_alignParentLeft="true"
     android:layout_alignParentTop="true"
     tools:ignore="RtlHardcoded" />

--- a/app/src/main/res/layout/view_messages_button.xml
+++ b/app/src/main/res/layout/view_messages_button.xml
@@ -9,7 +9,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:src="@drawable/ic_email_24dp"
+        app:srcCompat="@drawable/ic_email_24dp"
         app:tint="#000"/>
 
     <TextView

--- a/app/src/main/res/layout/view_plus_minus_control.xml
+++ b/app/src/main/res/layout/view_plus_minus_control.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -15,7 +16,7 @@
         android:layout_weight="1"
         android:padding="8dp"
         android:background="?android:attr/selectableItemBackground"
-        android:src="@drawable/ic_add_24dp"
+        app:srcCompat="@drawable/ic_add_24dp"
         android:contentDescription="+"
         tools:ignore="HardcodedText" />
 
@@ -26,7 +27,7 @@
         android:layout_weight="1"
         android:padding="8dp"
         android:background="?android:attr/selectableItemBackground"
-        android:src="@drawable/ic_subtract_24dp"
+        app:srcCompat="@drawable/ic_subtract_24dp"
         android:contentDescription="-"
         tools:ignore="HardcodedText"/>
 

--- a/app/src/main/res/layout/view_shop_type.xml
+++ b/app/src/main/res/layout/view_shop_type.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
@@ -31,7 +32,7 @@
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_arrow_expand_down_24dp"
+                app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
                 android:layout_centerVertical="true"
                 android:layout_alignParentEnd="true"
                 android:padding="8dp"/>

--- a/app/src/main/res/layout/view_street_or_place_name_input.xml
+++ b/app/src/main/res/layout/view_street_or_place_name_input.xml
@@ -62,7 +62,7 @@
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_town_silhouette"
+            app:srcCompat="@drawable/ic_town_silhouette"
             app:tint="#e0e0e0"
             android:layout_marginTop="-24dp"
             android:layout_marginBottom="-20dp"

--- a/app/src/main/res/layout/view_team_mode_color_circle.xml
+++ b/app/src/main/res/layout/view_team_mode_color_circle.xml
@@ -10,7 +10,7 @@
         android:id="@+id/teamModeColorCircleBackground"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="@drawable/background_white_circle"
+        app:srcCompat="@drawable/background_white_circle"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/view_upload_button.xml
+++ b/app/src/main/res/layout/view_upload_button.xml
@@ -9,7 +9,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:src="@drawable/ic_file_upload_24dp"
+        app:srcCompat="@drawable/ic_file_upload_24dp"
         app:tint="#000"/>
 
     <TextView

--- a/app/src/main/res/layout/widget_image_email.xml
+++ b/app/src/main/res/layout/widget_image_email.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+           xmlns:app="http://schemas.android.com/apk/res-auto"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
-           android:src="@drawable/ic_email_24dp" >
+           app:srcCompat="@drawable/ic_email_24dp" >
 </ImageView>

--- a/app/src/main/res/layout/widget_image_next.xml
+++ b/app/src/main/res/layout/widget_image_next.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+           xmlns:app="http://schemas.android.com/apk/res-auto"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
-           android:src="@drawable/ic_chevron_next_24dp" >
+           app:srcCompat="@drawable/ic_chevron_next_24dp" >
 </ImageView>

--- a/app/src/main/res/layout/widget_image_open_in_browser.xml
+++ b/app/src/main/res/layout/widget_image_open_in_browser.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+           xmlns:app="http://schemas.android.com/apk/res-auto"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
-           android:src="@drawable/ic_open_in_browser_24dp" >
+           app:srcCompat="@drawable/ic_open_in_browser_24dp" >
 </ImageView>


### PR DESCRIPTION
This PR replaces android:src by app:srcCompat
That improves the quality of drawables on older devices because AppCompat library does a better scaling that Android library -> more information here https://stackoverflow.com/questions/34936590/why-isnt-my-vector-drawable-scaling-as-expected
No impact in Kotlin code -> It's the same code to set icons with Android library and AppCompat library.