### PR TITLE
Replay edits done during quests download

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -66,10 +66,10 @@ class MapDataWithEditsSource internal constructor(
     private val onReplacedForBBoxLock = Any()
 
     // access to isReplacingForBBox is atomic (didn't want to pull in kotlinx-atomicfu dependency just for this)
-    private var isReplacingForBBoxLock = Any()
+    private val isReplacingForBBoxLock = Any()
     private var isReplacingForBBox: Boolean = false
 
-    private var updatesWhileReplacingBBox = MapDataWithGeometryUpdates()
+    private val updatesWhileReplacingBBox = MapDataWithGeometryUpdates()
 
     private val mapDataListener = object : MapDataController.Listener {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -19,6 +19,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataController
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataUpdates
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometryUpdates
 import de.westnordost.streetcomplete.data.osm.mapdata.MutableMapData
 import de.westnordost.streetcomplete.data.osm.mapdata.MutableMapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
@@ -60,6 +61,15 @@ class MapDataWithEditsSource internal constructor(
     private val deletedElements = HashSet<ElementKey>()
     private val updatedElements = HashMap<ElementKey, Element>()
     private val updatedGeometries = HashMap<ElementKey, ElementGeometry?>()
+
+    // onReplacedForBBox may not be called in parallel
+    private val onReplacedForBBoxLock = Any()
+
+    // access to isReplacingForBBox is atomic (didn't want to pull in kotlinx-atomicfu dependency just for this)
+    private var isReplacingForBBoxLock = Any()
+    private var isReplacingForBBox: Boolean = false
+
+    private var updatesWhileReplacingBBox = MapDataWithGeometryUpdates()
 
     private val mapDataListener = object : MapDataController.Listener {
 
@@ -136,12 +146,21 @@ class MapDataWithEditsSource internal constructor(
         }
 
         override fun onReplacedForBBox(bbox: BoundingBox, mapDataWithGeometry: MutableMapDataWithGeometry) {
-            synchronized(this) {
-                rebuildLocalChanges()
-                modifyBBoxMapData(bbox, mapDataWithGeometry)
-            }
+            synchronized(onReplacedForBBoxLock) {
+                synchronized(isReplacingForBBoxLock) { isReplacingForBBox = true }
 
-            callOnReplacedForBBox(bbox, mapDataWithGeometry)
+                synchronized(this) {
+                    rebuildLocalChanges()
+                    modifyBBoxMapData(bbox, mapDataWithGeometry)
+                }
+
+                callOnReplacedForBBox(bbox, mapDataWithGeometry)
+
+                synchronized(isReplacingForBBoxLock) { isReplacingForBBox = false }
+
+                callOnUpdated(updatesWhileReplacingBBox.updated, updatesWhileReplacingBBox.deleted)
+                updatesWhileReplacingBBox.clear()
+            }
         }
 
         override fun onCleared() {
@@ -515,9 +534,15 @@ class MapDataWithEditsSource internal constructor(
         listeners.remove(listener)
     }
 
-    private fun callOnUpdated(updated: MapDataWithGeometry = MutableMapDataWithGeometry(), deleted: Collection<ElementKey> = emptyList()) {
+    private fun callOnUpdated(updated: MapDataWithGeometry, deleted: Collection<ElementKey>) {
         if (updated.size == 0 && deleted.isEmpty()) return
         listeners.forEach { it.onUpdated(updated, deleted) }
+
+        synchronized(isReplacingForBBoxLock) {
+            if (isReplacingForBBox) {
+                updatesWhileReplacingBBox.add(updated, deleted)
+            }
+        }
     }
     private fun callOnReplacedForBBox(bbox: BoundingBox, mapDataWithGeometry: MapDataWithGeometry) {
         if (mapDataWithGeometry.size == 0) return

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataWithGeometryUpdates.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataWithGeometryUpdates.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.data.osm.mapdata
+
+data class MapDataWithGeometryUpdates(
+    val updated: MutableMapDataWithGeometry = MutableMapDataWithGeometry(),
+    val deleted: MutableList<ElementKey> = ArrayList()
+) {
+    fun add(updated: MapDataWithGeometry, deleted: Collection<ElementKey>) {
+        this.deleted.removeAll(updated.map { it.key })
+        this.deleted.addAll(deleted)
+
+        this.updated.removeAll(deleted)
+        this.updated.putAll(updated)
+    }
+
+    fun clear() {
+        updated.clear()
+        deleted.clear()
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometry.kt
@@ -62,6 +62,18 @@ class MutableMapDataWithGeometry() : MapDataWithGeometry {
         }
     }
 
+    fun putAll(other: MapDataWithGeometry) {
+        for (node in other.nodes) {
+            put(node, other.getNodeGeometry(node.id))
+        }
+        for (way in other.ways) {
+            put(way, other.getWayGeometry(way.id))
+        }
+        for (relation in other.relations) {
+            put(relation, other.getRelationGeometry(relation.id))
+        }
+    }
+
     fun putElement(element: Element) {
         val id = element.id
         when (element) {
@@ -77,6 +89,22 @@ class MutableMapDataWithGeometry() : MapDataWithGeometry {
             ElementType.WAY -> wayGeometriesById[id] = geometry
             ElementType.RELATION -> relationGeometriesById[id] = geometry
         }
+    }
+
+
+    fun removeAll(deleted: Collection<ElementKey>) {
+        for (key in deleted) {
+            remove(key.type, key.id)
+        }
+    }
+
+    fun clear() {
+        nodesById.clear()
+        waysById.clear()
+        relationsById.clear()
+        nodeGeometriesById.clear()
+        wayGeometriesById.clear()
+        relationGeometriesById.clear()
     }
 
     override fun iterator(): Iterator<Element> {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
@@ -5,11 +5,11 @@ class Listeners<T> {
     private var listeners: Set<T> = HashSet()
 
     fun add(element: T) {
-        synchronized(this) { listeners += element }
+        synchronized(this) { listeners = listeners + element }
     }
 
     fun remove(element: T) {
-        synchronized(this) { listeners -= element }
+        synchronized(this) { listeners = listeners - element }
     }
 
     fun forEach(action: (T) -> Unit) {

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
@@ -2,24 +2,20 @@ package de.westnordost.streetcomplete.util
 
 /** Lightweight wrapper around `HashSet` for storing listeners in a thread-safe way */
 class Listeners<T> {
-    private val listeners = HashSet<T>()
+    private var listeners: Set<T> = HashSet()
 
-    fun add(element: T): Boolean {
-        synchronized(this) {
-            return listeners.add(element)
-        }
+    fun add(element: T) {
+        synchronized(this) { listeners += element }
     }
 
-    fun remove(element: T): Boolean {
-        synchronized(this) {
-            return listeners.remove(element)
-        }
+    fun remove(element: T) {
+        synchronized(this) { listeners -= element }
     }
 
     fun forEach(action: (T) -> Unit) {
-        val listenersCopy = synchronized(this) { ArrayList(listeners) }
+        val listeners = synchronized(this) { listeners }
         // the executing of the action itself is not synchronized, only the access to the set,
         // because it should be possible to call several Listeners::forEach at the same time
-        listenersCopy.forEach(action)
+        listeners.forEach(action)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Listeners.kt
@@ -17,8 +17,9 @@ class Listeners<T> {
     }
 
     fun forEach(action: (T) -> Unit) {
-        synchronized(this) {
-            listeners.forEach(action)
-        }
+        val listenersCopy = synchronized(this) { ArrayList(listeners) }
+        // the executing of the action itself is not synchronized, only the access to the set,
+        // because it should be possible to call several Listeners::forEach at the same time
+        listenersCopy.forEach(action)
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometryTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/mapdata/MutableMapDataWithGeometryTest.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.testutils.rel
 import de.westnordost.streetcomplete.testutils.way
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class MutableMapDataWithGeometryTest {
@@ -64,5 +65,57 @@ class MutableMapDataWithGeometryTest {
         m.put(rel, geom)
         assertEquals(rel, m.getRelation(rel.id))
         assertEquals(geom, m.getRelationGeometry(rel.id))
+    }
+
+    @Test fun clear() {
+        val m = MutableMapDataWithGeometry()
+        m.put(node(0), ElementPointGeometry(p()))
+        m.put(way(0), ElementPolylinesGeometry(listOf(), p()))
+        m.put(rel(0), ElementPolygonsGeometry(listOf(), p()))
+
+        assertEquals(3, m.size)
+
+        m.clear()
+        assertEquals(0, m.size)
+        assertEquals(0, m.nodes.size)
+        assertEquals(0, m.ways.size)
+        assertEquals(0, m.relations.size)
+        assertNull(m.getNodeGeometry(0))
+        assertNull(m.getWayGeometry(0))
+        assertNull(m.getRelationGeometry(0))
+    }
+
+    @Test fun putAll() {
+        val m = MutableMapDataWithGeometry()
+        m.put(node(0), ElementPointGeometry(p()))
+        m.put(way(0), ElementPolylinesGeometry(listOf(), p()))
+        m.put(rel(0), ElementPolygonsGeometry(listOf(), p()))
+
+        val n = MutableMapDataWithGeometry()
+        n.putAll(m)
+
+        assertEquals(3, n.size)
+        assertEquals(1, m.nodes.size)
+        assertEquals(1, m.ways.size)
+        assertEquals(1, m.relations.size)
+        assertNotNull(m.getNodeGeometry(0))
+        assertNotNull(m.getWayGeometry(0))
+        assertNotNull(m.getRelationGeometry(0))
+    }
+
+    @Test fun removeAll() {
+        val m = MutableMapDataWithGeometry()
+        m.put(node(0), ElementPointGeometry(p()))
+        m.put(node(1), ElementPointGeometry(p()))
+        m.put(way(0), ElementPolylinesGeometry(listOf(), p()))
+
+        m.removeAll(listOf(ElementKey(ElementType.NODE, 0), ElementKey(ElementType.WAY, 0)))
+
+        assertNull(m.getNode(0))
+        assertNull(m.getNodeGeometry(0))
+        assertNull(m.getWay(0))
+        assertNull(m.getWayGeometry(0))
+        assertNotNull(m.getNode(1))
+        assertNotNull(m.getNodeGeometry(1))
     }
 }


### PR DESCRIPTION
fixes #4258

This actually does not only concern quests, but also overlays, which is why the solution has been done in `MapDataWithEditsSource` rather than in `OsmQuestController`.

Rather than making it really complicated for edge cases to deal with possible parallelism in `onReplacedForBBox`, I made it so that it cannot be executed in parallel. This doesn't change anything for the current configuration because OSM downloads can not happen in parallel (and it is very unlikely that this is ever changed).

---

Note that while testing this solution, I noticed that I could not reproduce the issue in the first place. This was because `Listeners.kt` replaced the previous `CopyOnWriteArrayList`-based listeners and `Listeners` just synchronizes **all** access:

I.e. any `Listeners.forEach(action)` was synchronized, meaning that a parallel 
```listeners.forEach { it.onReplacedForBBox(bbox, mapDataWithGeometry) }```
after map data download which triggers creating anew the quests for the downloaded map data and 
```listeners.forEach { it.onUpdated(updated, deleted) }```
after a single update of the data via an edit which triggers checking quests for just that one quest was not possible anymore. They were always executed in order.

**So, when trying to solve a quest while the osm data is being updated (=the quests are created), the UI would just seemingly freeze. Argh! The very thing I wanted to avoid.** I fixed this now, I hope my fix is fine. Second or third pair of eyes appreciated.