### PR TITLE
add 'gas' as an option for bbq fuel

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuelForm.kt
@@ -7,6 +7,7 @@ import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.quests.TextItem
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.CHARCOAL
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.ELECTRIC
+import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.GAS
 import de.westnordost.streetcomplete.quests.bbq_fuel.BbqFuel.WOOD
 
 class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
@@ -14,6 +15,7 @@ class AddBbqFuelForm : AListQuestForm<BbqFuelAnswer>() {
         TextItem(WOOD, R.string.quest_bbq_fuel_wood),
         TextItem(ELECTRIC, R.string.quest_bbq_fuel_electric),
         TextItem(CHARCOAL, R.string.quest_bbq_fuel_charcoal),
+        TextItem(GAS, R.string.quest_bbq_fuel_gas),
     )
 
     override val otherAnswers = listOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bbq_fuel/BbqFuelAnswer.kt
@@ -5,7 +5,8 @@ sealed interface BbqFuelAnswer
 enum class BbqFuel(val osmValue: String) : BbqFuelAnswer {
     WOOD("wood"),
     ELECTRIC("electric"),
-    CHARCOAL("charcoal")
+    CHARCOAL("charcoal"),
+    GAS("gas"),
 }
 
 data object IsFirePitAnswer : BbqFuelAnswer

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1317,6 +1317,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_bbq_fuel_wood">Wood</string>
     <string name="quest_bbq_fuel_electric">Electric</string>
     <string name="quest_bbq_fuel_charcoal">Charcoal</string>
+    <string name="quest_bbq_fuel_gas">Gas</string>
     <string name="quest_bbq_fuel_not_a_bbq">It’s a fire enclosure</string>
     <string name="quest_bbq_fuel_not_a_bbq_confirmation">Fire enclosures don’t have a cooking surface (e.g. grate/plate), as opposed to grills.</string>
 


### PR DESCRIPTION
#5211 added a new quest to tag the fuel of a barbeque. The current options are [`wood`](https://taginfo.osm.org/tags/fuel=wood), [`electric`](https://taginfo.osm.org/tags/fuel=electric), or [`charcoal`](https://taginfo.osm.org/tags/fuel=charcoal).

From my experience in Australia and New Zealand, public barbeques can sometimes be powered by gas. This could be LPG, gas mains, or BYO propane tank.

This PR adds [`gas`](https://taginfo.osm.org/tags/fuel=gas) as a new option.