### PR TITLE
Upgrade Ktlint to version 1.2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,7 @@ indent_size = 4
 # disable Ktlint rules that are too strict for this project
 ktlint_standard_annotation = disabled
 ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_backing-property-naming = disabled
 ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_block-comment-initial-star-alignment = disabled
 ktlint_standard_chain-wrapping = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,7 @@ ktlint_standard_annotation = disabled
 ktlint_standard_argument-list-wrapping = disabled
 ktlint_standard_backing-property-naming = disabled
 ktlint_standard_blank-line-before-declaration = disabled
+ktlint_standard_blank-line-between-when-conditions = disabled
 ktlint_standard_block-comment-initial-star-alignment = disabled
 ktlint_standard_chain-wrapping = disabled
 ktlint_standard_comment-wrapping = disabled

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         id: ktlint-check
         uses: musichin/ktlint-check@v3.0.0
         with:
-          ktlint-version: "1.1.1"
+          ktlint-version: "1.2.0"
           reporter: plain?group_by_file,output=${{ env.lintResultFilename }}
           relative: true
         continue-on-error: true

--- a/app/src/main/java/de/westnordost/streetcomplete/data/upload/UploadModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/upload/UploadModule.kt
@@ -11,15 +11,15 @@ val uploadModule = module {
     factory { VersionIsBannedChecker("https://www.westnordost.de/streetcomplete/banned_versions.txt", ApplicationConstants.USER_AGENT) }
 
     single { Uploader(get(), get(), get(), get(), get(), get(named("SerializeSync"))) }
-    /** uploading and downloading should be serialized, i.e. may not run in parallel, to avoid
-     *  certain race-condition.
+    /* uploading and downloading should be serialized, i.e. may not run in parallel, to avoid
+     * certain race-condition.
      *
-     *  Example:
-     *  A download of refreshed OSM data takes 10 seconds. While the download is executing, the user
-     *  solves a quest (based on the previously downloaded data) which is immediately uploaded,
-     *  resulting in the updated element to be persisted.
-     *  When the download finally finishes, it got the data from 10 seconds ago, before the element
-     *  has been updated. Thus, the old element overwrites the new one. */
+     * Example:
+     * A download of refreshed OSM data takes 10 seconds. While the download is executing, the user
+     * solves a quest (based on the previously downloaded data) which is immediately uploaded,
+     * resulting in the updated element to be persisted.
+     * When the download finally finishes, it got the data from 10 seconds ago, before the element
+     * has been updated. Thus, the old element overwrites the new one. */
     single(named("SerializeSync")) { Mutex() }
 
     single<UploadProgressSource> { get<Uploader>() }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsSource.kt
@@ -28,7 +28,6 @@ interface StatisticsSource {
     /** Number of days the active days range has */
     val activeDatesRange: Int
 
-    /** Return the total amount of quests solved*/
     /** Users' global rank in the last 7 days. If <= 0, it's not set yet */
     val currentWeekRank: Int
 

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/RoadWidth.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/RoadWidth.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.osm.street_parking.estimatedWidthOffRoad
 import de.westnordost.streetcomplete.osm.street_parking.estimatedWidthOnRoad
 import de.westnordost.streetcomplete.osm.street_parking.parseStreetParkingSides
 
-/** Functions to estimate road width(s). */
+/* Functions to estimate road width(s). */
 
 /** Estimated width of the roadway "from curb to curb". So, including any parking
  *  lanes on the street, cycle lanes, shoulders etc.

--- a/app/src/main/java/de/westnordost/streetcomplete/util/math/FlatEarthMath.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/math/FlatEarthMath.kt
@@ -8,11 +8,11 @@ import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sqrt
 
-/** Calculate stuff assuming an (almost) flat Earth. The main exception from assuming a completely
- *  flat earth is use of cos(lat) to take into account decreasing longitude distance at
- *  high latitudes.
- *  Optimized for performance with precision within 1 m of spherical functions for up to
- *  0.03° difference between points (several km at common latitudes). */
+/* Calculate stuff assuming an (almost) flat Earth. The main exception from assuming a completely
+ * flat earth is use of cos(lat) to take into account decreasing longitude distance at
+ * high latitudes.
+ * Optimized for performance with precision within 1 m of spherical functions for up to
+ * 0.03° difference between points (several km at common latitudes). */
 
 // ~5 times faster than spherical version
 /** Returns the approximate distance from this point to the other point.

--- a/app/src/main/java/de/westnordost/streetcomplete/util/math/SphericalEarthMath.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/math/SphericalEarthMath.kt
@@ -19,7 +19,7 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 import kotlin.math.tan
 
-/** Calculate stuff assuming a spherical Earth. The Earth is not spherical, but it is a good
+/* Calculate stuff assuming a spherical Earth. The Earth is not spherical, but it is a good
  * approximation and totally sufficient for our use here.  */
 
 /** In meters. See https://en.wikipedia.org/wiki/Earth_radius#Mean_radius */

--- a/buildSrc/src/main/java/GenerateQuestListTask.kt
+++ b/buildSrc/src/main/java/GenerateQuestListTask.kt
@@ -1,17 +1,3 @@
-/**
- * This Gradle task generates a CSV file with information about quest types (see `writeCsvFile` function).
- *
- * First, it fetches and parses the table in the OSM Wiki (`WikiQuest`).
- * Then it reads and parses the quest types from the repository code (`RepoQuest`) and
- * matches them to the corresponding WikiQuest (if possible).
- *
- * The generated CSV file contains 3 sections of rows:
- * 1. WikiQuests that could not be matched with RepoQuests
- * 2. RepoQuests that could not be matched with WikiQuests
- * 3. RepoQuests that could be matched with WikiQuests
- *    (note that the "Default Priority" column may be different from the wiki)
- */
-
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -27,6 +13,19 @@ const val wikiRowSpan2 = " rowspan=\"2\" |"
 const val noteQuestName = "OsmNoteQuest"
 const val noteQuestPackageName = "note_discussion"
 
+/**
+ * This Gradle task generates a CSV file with information about quest types (see `writeCsvFile` function).
+ *
+ * First, it fetches and parses the table in the OSM Wiki (`WikiQuest`).
+ * Then it reads and parses the quest types from the repository code (`RepoQuest`) and
+ * matches them to the corresponding WikiQuest (if possible).
+ *
+ * The generated CSV file contains 3 sections of rows:
+ * 1. WikiQuests that could not be matched with RepoQuests
+ * 2. RepoQuests that could not be matched with WikiQuests
+ * 3. RepoQuests that could be matched with WikiQuests
+ *    (note that the "Default Priority" column may be different from the wiki)
+ */
 open class GenerateQuestListTask : DefaultTask() {
     @get:Input lateinit var targetFile: String
     @get:InputDirectory lateinit var projectDirectory: File


### PR DESCRIPTION
See https://github.com/pinterest/ktlint/releases/tag/1.2.0. Relevant rule docs:

* [`backing-property-naming`](https://pinterest.github.io/ktlint/latest/rules/experimental/#backing-property-naming) (disabled because we have backing fields for private properties in 9 files)
* [`blank-lines-between-when-conditions`](https://pinterest.github.io/ktlint/latest/rules/experimental/#blank-lines-between-when-conditions) (disabled because this would cause changes in more than 100 files)
* [`kdoc`](https://pinterest.github.io/ktlint/latest/rules/experimental/#kdoc) (enabled, see changes in this MR)

I'm going to merge this PR without a review, since it's only minor lint changes, but feel free to comment on it afterwards.