### PR TITLE
Make question mark parsing code more readable

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -224,23 +224,25 @@ private fun Note.shouldShowAsQuest(
 }
 
 private fun Note.probablyContainsQuestion(): Boolean {
-    /* from left to right (if smartass IntelliJ wouldn't mess up left-to-right):
-       - latin question mark
-       - greek question mark (a different character than semikolon, though same appearance)
-       - semikolon (often used instead of proper greek question mark)
-       - mirrored question mark (used in script written from right to left, like Arabic)
-       - armenian question mark
-       - ethopian question mark
-       - full width question mark (often used in modern Chinese / Japanese)
-       (Source: https://en.wikipedia.org/wiki/Question_mark)
-
-        NOTE: some languages, like Thai, do not use any question mark, so this would be more
-        difficult to determine.
-   */
-    val questionMarksAroundTheWorld = "[?;;؟՞፧？]"
+    /**
+     * Source: https://en.wikipedia.org/wiki/Question_mark
+     *
+     * NOTE: some languages, like Thai, do not use any question mark, so this would be more
+     * difficult to determine.
+     */
+    val questionMarksAroundTheWorld = listOf(
+        "?", // Latin question mark
+        ";", // Greek question mark (a different character than semicolon, though same appearance)
+        ";", // semicolon (often used instead of proper greek question mark)
+        "؟", // mirrored question mark (used in script written from right to left, like Arabic)
+        "՞", // Armenian question mark
+        "፧", // Ethiopian question mark
+        "？", // full width question mark (often used in modern Chinese / Japanese)
+    )
+    val questionMarkPattern = ".*[${questionMarksAroundTheWorld.joinToString("")}].*"
 
     val text = comments.firstOrNull()?.text
-    return text?.matches(Regex(".*$questionMarksAroundTheWorld.*", RegexOption.DOT_MATCHES_ALL)) ?: false
+    return text?.matches(questionMarkPattern.toRegex(RegexOption.DOT_MATCHES_ALL)) ?: false
 }
 
 private fun Note.containsSurveyRequiredMarker(): Boolean =

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -237,6 +237,7 @@ private fun Note.probablyContainsQuestion(): Boolean {
         "؟", // mirrored question mark (used in script written from right to left, like Arabic)
         "՞", // Armenian question mark
         "፧", // Ethiopian question mark
+        "꘏", // Vai question mark
         "？", // full width question mark (often used in modern Chinese / Japanese)
     )
     val questionMarkPattern = ".*[${questionMarksAroundTheWorld.joinToString("")}].*"

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
@@ -199,7 +199,8 @@ class OsmNoteQuestControllerTest {
         on(noteSource.get(3)).thenReturn(note(3, comments = listOf(comment(text = "mirrored question mark: ؟"))))
         on(noteSource.get(4)).thenReturn(note(4, comments = listOf(comment(text = "Armenian question mark: ՞"))))
         on(noteSource.get(5)).thenReturn(note(5, comments = listOf(comment(text = "Ethiopian question mark: ፧"))))
-        on(noteSource.get(6)).thenReturn(note(6, comments = listOf(comment(text = "full width question mark: ？"))))
+        on(noteSource.get(6)).thenReturn(note(6, comments = listOf(comment(text = "Vai question mark: ꘏"))))
+        on(noteSource.get(7)).thenReturn(note(7, comments = listOf(comment(text = "full width question mark: ？"))))
         on(notesPreferences.showOnlyNotesPhrasedAsQuestions).thenReturn(true)
 
         assertEquals(1, ctrl.getVisible(1)?.id)
@@ -208,6 +209,7 @@ class OsmNoteQuestControllerTest {
         assertEquals(4, ctrl.getVisible(4)?.id)
         assertEquals(5, ctrl.getVisible(5)?.id)
         assertEquals(6, ctrl.getVisible(6)?.id)
+        assertEquals(7, ctrl.getVisible(7)?.id)
     }
 
     @Test fun `get quest with comment containing survey required marker returns non-null`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
@@ -193,6 +193,23 @@ class OsmNoteQuestControllerTest {
         assertEquals(OsmNoteQuest(1, p(1.0, 1.0)), ctrl.getVisible(1))
     }
 
+    @Test fun `get quest phrased as question in other scripts returns non-null`() {
+        on(noteSource.get(1)).thenReturn(note(1, comments = listOf(comment(text = "Greek question mark: ;"))))
+        on(noteSource.get(2)).thenReturn(note(2, comments = listOf(comment(text = "semicolon: ;"))))
+        on(noteSource.get(3)).thenReturn(note(3, comments = listOf(comment(text = "mirrored question mark: ؟"))))
+        on(noteSource.get(4)).thenReturn(note(4, comments = listOf(comment(text = "Armenian question mark: ՞"))))
+        on(noteSource.get(5)).thenReturn(note(5, comments = listOf(comment(text = "Ethiopian question mark: ፧"))))
+        on(noteSource.get(6)).thenReturn(note(6, comments = listOf(comment(text = "full width question mark: ？"))))
+        on(notesPreferences.showOnlyNotesPhrasedAsQuestions).thenReturn(true)
+
+        assertEquals(1, ctrl.getVisible(1)?.id)
+        assertEquals(2, ctrl.getVisible(2)?.id)
+        assertEquals(3, ctrl.getVisible(3)?.id)
+        assertEquals(4, ctrl.getVisible(4)?.id)
+        assertEquals(5, ctrl.getVisible(5)?.id)
+        assertEquals(6, ctrl.getVisible(6)?.id)
+    }
+
     @Test fun `get quest with comment containing survey required marker returns non-null`() {
         on(noteSource.get(1)).thenReturn(note(
             1,


### PR DESCRIPTION
See individual commits:

1. Add a test about this, so that the refactoring doesn't break anything.
2. Change string + large comment to a list of single-character strings with individual comments that are later joined back together.
3. Add another question mark character listed on the linked Wikipedia page. [Vai](https://en.wikipedia.org/wiki/Vai_syllabary) seems to be a language/script that is in use today, so it's probably worth adding.