### PR TITLE
More linting with Ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,6 @@ ktlint_standard_backing-property-naming = disabled
 ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_blank-line-between-when-conditions = disabled
 ktlint_standard_chain-wrapping = disabled
-ktlint_standard_comment-wrapping = disabled
 ktlint_standard_function-naming = disabled
 ktlint_standard_function-signature = disabled
 ktlint_standard_indent = disabled
@@ -47,8 +46,6 @@ ktlint_standard_statement-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_trailing-comma-on-call-site = disabled
 ktlint_standard_trailing-comma-on-declaration-site = disabled
-ktlint_standard_value-argument-comment = disabled
-ktlint_standard_value-parameter-comment = disabled
 ktlint_standard_wrapping = disabled
 
 # enable some experimental Ktlint rules

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
@@ -31,8 +31,8 @@ class EditElementsDaoTest : ApplicationDbTestCase() {
         ))
 
         dao.put(7, listOf(
-            ElementKey(ElementType.NODE, 0),  // referring to same element
-            ElementKey(ElementType.WAY, 1),  // but also another
+            ElementKey(ElementType.NODE, 0), // referring to same element
+            ElementKey(ElementType.WAY, 1), // but also another
         ))
 
         dao.put(3, listOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -128,7 +128,7 @@ class StreetCompleteApplication : Application() {
 
         setLoggerInstances()
 
-        /* Force logout users who are logged in with OAuth 1.0a, they need to re-authenticate with OAuth 2 */
+        // Force logout users who are logged in with OAuth 1.0a, they need to re-authenticate with OAuth 2
         if (prefs.getStringOrNull(Prefs.OAUTH1_ACCESS_TOKEN) != null) {
             userLoginStatusController.logOut()
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/Cleaner.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/Cleaner.kt
@@ -25,7 +25,7 @@ class Cleaner(
         noteController.deleteOlderThan(oldDataTimestamp, MAX_DELETE_ELEMENTS)
         mapDataController.deleteOlderThan(oldDataTimestamp, MAX_DELETE_ELEMENTS)
         downloadedTilesController.deleteOlderThan(oldDataTimestamp)
-        /* do this after cleaning map data and notes, because some metadata rely on map data */
+        // do this after cleaning map data and notes, because some metadata rely on map data
         questTypeRegistry.forEach { it.deleteMetadataOlderThan(oldDataTimestamp) }
 
         val oldLogTimestamp = nowAsEpochMilliseconds() - ApplicationConstants.DELETE_OLD_LOG_AFTER

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
@@ -70,7 +70,7 @@ class ElementFilterExpression(
     internal val elementsTypes: Set<ElementsTypeFilter>,
     internal val elementExprRoot: BooleanExpression<ElementFilter, Element>?
 ) {
-    /* Performance improvement: Allows to skip early on elements that have no tags at all */
+    // Performance improvement: Allows to skip early on elements that have no tags at all
     val mayEvaluateToTrueWithNoTags = elementExprRoot?.mayEvaluateToTrueWithNoTags ?: true
 
     /** returns whether the given element is found through (=matches) this expression */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParser.kt
@@ -316,7 +316,7 @@ private fun StringWithCursor.parseQuotedWord(quot: Char): String? {
     val word = advanceBy(length)
     return word
         .substring(1, word.length - 1) // remove quotes
-        .replace("\\$quot", "$quot")  // unescape quotes within string
+        .replace("\\$quot", "$quot") // unescape quotes within string
 }
 
 private fun StringWithCursor.parseWord(): String {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -280,7 +280,7 @@ class MapDataWithEditsSource internal constructor(
         val ids = way.nodeIds.toSet()
         val nodes = getNodes(ids)
 
-        /* If the way is (now) not complete, this is not acceptable */
+        // If the way is (now) not complete, this is not acceptable
         if (nodes.size < ids.size) return null
 
         return nodes
@@ -317,7 +317,7 @@ class MapDataWithEditsSource internal constructor(
     private fun getRelationElements(relation: Relation): MutableMapData = synchronized(this) {
         val elements = ArrayList<Element>()
         for (member in relation.members) {
-            /* for way members, also get their nodes */
+            // for way members, also get their nodes
             if (member.type == WAY) {
                 val wayComplete = getWayComplete(member.ref)
                 if (wayComplete != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
@@ -50,7 +50,7 @@ class NoteEditsUploader(
     private suspend fun uploadMissedImageActivations() {
         while (true) {
             val edit = noteEditsController.getOldestNeedingImagesActivation() ?: break
-            /* see uploadEdits */
+            // see uploadEdits
             withContext(scope.coroutineContext) {
                 imageUploader.activate(edit.noteId)
                 noteEditsController.markImagesActivated(edit.id)

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Area.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Area.kt
@@ -14,7 +14,7 @@ val IS_AREA_EXPRESSION = """
 
 private fun isAreaExpressionFragment(prefix: String? = null): String {
     val p = if (prefix != null) "$prefix:" else ""
-    /* roughly sorted by occurrence count */
+    // roughly sorted by occurrence count
     return """
         ${p}building
         or ${p}landuse

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -34,9 +34,9 @@ fun Element.isPlace(): Boolean =
 private val IS_PLACE_EXPRESSION by lazy {
     val tags = mapOf(
         "amenity" to listOf(
-            /* grouped by subcategory, sorted by alphabet */
+            // grouped by subcategory, sorted by alphabet
 
-            /* sustenance */
+            // sustenance
             "bar",
             "biergarten",
             "cafe",
@@ -46,7 +46,7 @@ private val IS_PLACE_EXPRESSION by lazy {
             "pub",
             "restaurant",
 
-            /* education */
+            // education
             "childcare",
             "college",
             "dancing_school",
@@ -64,7 +64,7 @@ private val IS_PLACE_EXPRESSION by lazy {
             "training",
             "university",
 
-            /* transportation */
+            // transportation
             "boat_rental", // usually there is some kind of office, even if it is just a small stall
             "car_rental", // usually there is some kind of office
             "car_wash",
@@ -72,14 +72,14 @@ private val IS_PLACE_EXPRESSION by lazy {
             "motorcycle_rental",
             "vehicle_inspection",
 
-            /* financial */
+            // financial
             "bank",
             "bureau_de_change",
             "mobile_money_agent",
             "money_transfer",
             "payment_centre",
 
-            /* healthcare */
+            // healthcare
             "clinic",
             "dentist",
             "doctors",
@@ -90,7 +90,7 @@ private val IS_PLACE_EXPRESSION by lazy {
             "social_facility",
             "veterinary",
 
-            /* entertainment, arts & culture */
+            // entertainment, arts & culture
             "archive",
             "arts_centre",
             "brothel",
@@ -113,7 +113,7 @@ private val IS_PLACE_EXPRESSION by lazy {
             "swingerclub",
             "theatre",
 
-            /* public service */
+            // public service
             "courthouse",
             "embassy", // deprecated now
             "fire_station",
@@ -125,11 +125,11 @@ private val IS_PLACE_EXPRESSION by lazy {
             "ranger_station",
             "townhall",
 
-            /* facilities */
+            // facilities
             "lavoir",
             "left_luggage",
 
-            /* others */
+            // others
             "animal_boarding",
             "animal_shelter",
             "animal_training",

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Things.kt
@@ -38,9 +38,9 @@ private val IS_THING_EXPRESSION by lazy {
             "windsock",
         ),
         "amenity" to listOf(
-            /* grouped by subcategory, sorted by alphabet */
+            // grouped by subcategory, sorted by alphabet
 
-            /* transportation */
+            // transportation
             "bicycle_parking",
             "bicycle_rental",
             "bicycle_repair_station",
@@ -56,23 +56,23 @@ private val IS_THING_EXPRESSION by lazy {
             "ticket_validator",
             "vacuum_cleaner",
 
-            /* financial */
+            // financial
             "atm",
             "payment_terminal",
 
-            /* healthcare */
+            // healthcare
             "baby_hatch",
             "kneipp_water_cure",
 
-            /* entertainment, arts & culture */
+            // entertainment, arts & culture
             "fountain",
             "public_bookcase",
             "whirlpool",
 
-            /* public service */
+            // public service
             // "post_box", - blocked by https://github.com/streetcomplete/StreetComplete/issues/4916
 
-            /* facilities & others */
+            // facilities & others
             "baking_oven",
             "bbq",
             "bench",
@@ -106,13 +106,13 @@ private val IS_THING_EXPRESSION by lazy {
             "water_point",
             "watering_place",
 
-            /* waste management */
+            // waste management
             // "recycling" only for containers, see bottom
             "sanitary_dump_station",
             "waste_basket",
             "waste_disposal",
 
-            /* animals */
+            // animals
             "feeding_place",
             "game_feeding",
             "hunting_stand",

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/WaysCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/WaysCrossing.kt
@@ -20,7 +20,7 @@ data class WaysCrossing(val node: Node, var barrierWays: List<Way>, var movingWa
  */
 fun findNodesAtCrossingsOf(barrierWays: Sequence<Way>, movingWays: Sequence<Way>, mapData: MapData): Iterable<WaysCrossing> {
     val barriersByNodeId = barrierWays.groupByNodeIds()
-    /* filter out nodes of roads that are the end of a barrier not continuing further */
+    // filter out nodes of roads that are the end of a barrier not continuing further
     barriersByNodeId.removeEndNodes()
 
     val waysByNodeId = movingWays.groupByNodeIds()
@@ -32,7 +32,7 @@ fun findNodesAtCrossingsOf(barrierWays: Sequence<Way>, movingWays: Sequence<Way>
      * https://www.openstreetmap.org/node/56606744 (with roads) */
     waysByNodeId.removeEndNodes()
 
-    /* filter out all nodes that are not shared nodes of both a road and a footway */
+    // filter out all nodes that are not shared nodes of both a road and a footway
     barriersByNodeId.keys.retainAll(waysByNodeId.keys)
     waysByNodeId.keys.retainAll(barriersByNodeId.keys)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/address/StreetOrPlaceNameViewController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/address/StreetOrPlaceNameViewController.kt
@@ -57,7 +57,7 @@ class StreetOrPlaceNameViewController(
         }
         get() = when (spinnerSelection) {
             STREET -> streetNameInputCtrl.streetName?.let { StreetName(it) }
-            PLACE ->  placeNameInput.nonBlankTextOrNull?.let { PlaceName(it) }
+            PLACE -> placeNameInput.nonBlankTextOrNull?.let { PlaceName(it) }
         }
 
     private var spinnerSelection: StreetOrPlace

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/building/BuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/building/BuildingType.kt
@@ -98,7 +98,7 @@ enum class BuildingType(val osmKey: String?, val osmValue: String?) {
             ("building" to "cottage") to BUNGALOW, // not documented
             ("building" to "ger") to TENT, // a Mongolian tent
             ("building" to "stilt_house") to HOUSE,
-            ("building" to "terrace_house") to HOUSE,  // not documented, auto-changing to house would be a loss of information
+            ("building" to "terrace_house") to HOUSE, // not documented, auto-changing to house would be a loss of information
             ("building" to "trullo") to HUT,
             ("building" to "pajaru") to HUT, // not documented, but similar to trullo https://it.wikipedia.org/wiki/Pajaru
 

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/cycleway/Cycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/cycleway/Cycleway.kt
@@ -34,7 +34,7 @@ fun LeftAndRightCycleway.wasNoOnewayForCyclistsButNowItIs(tags: Map<String, Stri
  *  is null because it is possible that the undefined side has a track in the contra-flow direction
  *  (e.g. either a normal track on the left side or a dual-track on the right side) */
 fun LeftAndRightCycleway.isNotOnewayForCyclistsNow(tags: Map<String, String>): Boolean? {
-    val onewayDir = when  {
+    val onewayDir = when {
         isForwardOneway(tags) -> FORWARD
         isReversedOneway(tags) -> BACKWARD
         else -> return true

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/cycleway/CyclewayCreator.kt
@@ -53,7 +53,7 @@ fun LeftAndRightCycleway.applyTo(tags: Tags, isLeftHandTraffic: Boolean) {
     ).applyTo(tags)
 }
 
-/* bare cycleway tags are interpreted differently for oneways */
+// bare cycleway tags are interpreted differently for oneways
 private fun expandBareTags(tags: Tags, isLeftHandTraffic: Boolean) {
     val cycleway = tags["cycleway"] ?: return
     // i.e. they are only expanded into one side. Which side depends on country, direction of oneway

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/lane_narrowing_traffic_calming/LaneNarrowingTrafficCalmingParser.kt
@@ -33,7 +33,7 @@ internal fun expandTrafficCalmingValue(values: String): List<String> =
     values
         .split(';') // split e.g. choker;table;island
         .flatMap {
-            when  {
+            when {
                 // e.g. choked_table, choked_island... anything chocked_* is also a choker
                 it.startsWith("choked_") ->
                     listOf("choker", it.substringAfter('_'))

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/sidewalk/SidewalkCreator.kt
@@ -27,7 +27,7 @@ fun LeftAndRightSidewalk.applyTo(tags: Tags) {
     tags.expandSides("sidewalk", includeBareTag = false)
     tags.separateConflatedSidewalk()
 
-    if (left != null)  tags["sidewalk:left"] = left.osmValue
+    if (left != null) tags["sidewalk:left"] = left.osmValue
     if (right != null) tags["sidewalk:right"] = right.osmValue
 
     // use shortcut syntax if possible, preferred by community according to usage numbers on taginfo

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/buildings/BuildingsOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/buildings/BuildingsOverlay.kt
@@ -23,7 +23,7 @@ class BuildingsOverlay : Overlay {
     override val achievements = listOf(BUILDING)
     override val hidesQuestTypes = setOf(AddBuildingType::class.simpleName!!)
 
-    /* building:use not supported, so don't offer to change it -> exclude from the overlay */
+    // building:use not supported, so don't offer to change it -> exclude from the overlay
     override fun getStyledElements(mapData: MapDataWithGeometry) = mapData.filter(
         """
             ways, relations with

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/StreetCyclewayOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/StreetCyclewayOverlayForm.kt
@@ -233,7 +233,7 @@ class StreetCyclewayOverlayForm : AStreetSideSelectOverlayForm<CyclewayAndDirect
         bicycleBoulevard == BicycleBoulevard.YES
 
     override fun hasChanges(): Boolean =
-        streetSideSelect.left?.value != originalCycleway?.left  ||
+        streetSideSelect.left?.value != originalCycleway?.left ||
         streetSideSelect.right?.value != originalCycleway?.right ||
         originalBicycleBoulevard != bicycleBoulevard
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -57,7 +57,7 @@ class AddAddressStreet : OsmElementQuestType<StreetOrPlaceName> {
         return addressesWithoutStreet
     }
 
-    /* cannot be determined because of the associated street relations */
+    // cannot be determined because of the associated street relations
     override fun isApplicableTo(element: Element): Boolean? =
         if (!filter.matches(element)) false else null
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
@@ -77,7 +77,7 @@ class AddIsAmenityIndoor(private val getFeature: (Element) -> Feature?) :
             buildings.any { building ->
                 val buildingGeometry = buildingGeometriesById[building.id]
 
-                if (buildingGeometry != null  && buildingGeometry.getBounds().contains(it.position)) {
+                if (buildingGeometry != null && buildingGeometry.getBounds().contains(it.position)) {
                     it.position.isInMultipolygon(buildingGeometry.polygons)
                 } else {
                     false

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReference.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReference.kt
@@ -91,7 +91,7 @@ class AddEntranceReference : OsmElementQuestType<EntranceAnswer> {
                 is Relation -> building.getMultipolygonNodeIds(mapData).toSet()
                 else -> emptyList()
             }
-            val buildingEntrances =  buildingsWayNodeIds.mapNotNull { mapData.getNode(it) }
+            val buildingEntrances = buildingsWayNodeIds.mapNotNull { mapData.getNode(it) }
                 .filter { entrancesFilter.matches(it) }
             if (buildingEntrances.count() < 2) continue
             result.addAll(buildingEntrances.filter { noEntranceRefFilter.matches(it) && it.id !in excludedWayNodeIds })

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
@@ -314,7 +314,11 @@ class AddMaxSpeedForm : AbstractOsmQuestForm<MaxSpeedAnswer>() {
     }
 
     companion object {
-        private val POSSIBLY_SLOWZONE_ROADS = listOf("residential", "unclassified", "tertiary" /*#1133*/)
+        private val POSSIBLY_SLOWZONE_ROADS = listOf(
+            "residential",
+            "unclassified",
+            "tertiary", // #1133
+        )
         private val MAYBE_LIVING_STREET = listOf("residential", "unclassified")
         private val ROADS_WITH_DEFINITE_SPEED_LIMIT = listOf("motorway", "living_street")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -79,7 +79,7 @@ class CheckOpeningHoursSigned(
             }
         } else {
             tags["opening_hours:signed"] = "no"
-            /* still unsigned: just set the check date to now, user was on-site */
+            // still unsigned: just set the check date to now, user was on-site
             tags.updateCheckDateForKey("opening_hours")
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/ReligionItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/ReligionItem.kt
@@ -20,7 +20,7 @@ import de.westnordost.streetcomplete.view.image_select.Item
 
 fun Religion.asItem(): DisplayItem<Religion>? {
     val iconResId = iconResId ?: return null
-    val titleResId = titleResId  ?: return null
+    val titleResId = titleResId ?: return null
     return Item(this, iconResId, titleResId)
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/SmokingAllowedForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoking/SmokingAllowedForm.kt
@@ -18,7 +18,7 @@ class SmokingAllowedForm : AListQuestForm<SmokingAllowed>() {
         val noOutdoorSmoking =
             tags["outdoor_seating"] == "no" &&
             tags["amenity"] != "nightclub" && tags["amenity"] != "stripclub" && tags["amenity"] != "pub"
-            /* nightclubs etc. might have outside smoking areas even when there is no seating outside */
+            // nightclubs etc. might have outside smoking areas even when there is no seating outside
 
         return listOfNotNull(
             TextItem(NO, R.string.quest_smoking_no),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSport.kt
@@ -14,7 +14,7 @@ class AddSport : OsmFilterQuestType<List<Sport>>() {
           and (!sport or sport ~ football|skating|hockey|team_handball)
           and access !~ private|no
     """
-    /* treat ambiguous values as if it is not set */
+    // treat ambiguous values as if it is not set
     override val changesetComment = "Specify sport played on pitches"
     override val wikiLink = "Key:sport"
     override val icon = R.drawable.ic_quest_sport

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -31,7 +31,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
         )
         and ~path|footway|cycleway|bridleway !~ link
     """
-    /* ~paved ways are less likely to change the surface type */
+    // ~paved ways are less likely to change the surface type
 
     override val changesetComment = "Specify path surfaces"
     override val wikiLink = "Key:surface"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -21,7 +21,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
         )
         and (access !~ private|no or (foot and foot !~ private|no))
     """
-    /* ~paved tracks are less likely to change the surface type */
+    // ~paved tracks are less likely to change the surface type
     override val changesetComment = "Specify tracktypes"
     override val wikiLink = "Key:tracktype"
     override val icon = R.drawable.ic_quest_tractor

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/LogsFiltersDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/LogsFiltersDialog.kt
@@ -113,7 +113,7 @@ class LogsFiltersDialog(
 
     private fun updateNewerThanInput() {
         binding.newerThanEditTextLayout.isEndIconVisible = timestampNewerThan != null
-        binding.newerThanEditText.setText(timestampNewerThan?.let {  dateTimeToString(locale, it) } ?: "")
+        binding.newerThanEditText.setText(timestampNewerThan?.let { dateTimeToString(locale, it) } ?: "")
     }
 
     private fun updateOlderThanInput() {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -726,7 +726,7 @@ class MainFragment :
     }
 
     private fun onClickCompassButton() {
-        /* Clicking the compass button will always rotate the map back to north and remove tilt */
+        // Clicking the compass button will always rotate the map back to north and remove tilt
         val mapFragment = mapFragment ?: return
         val camera = mapFragment.cameraPosition ?: return
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/UndoButtonFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/controls/UndoButtonFragment.kt
@@ -31,7 +31,7 @@ class UndoButtonFragment : Fragment(R.layout.fragment_undo_button) {
     }
     private val listener: Listener? get() = parentFragment as? Listener ?: activity as? Listener
 
-    /* undo button is not shown when there is nothing to undo */
+    // undo button is not shown when there is nothing to undo
     private val editHistoryListener = object : EditHistorySource.Listener {
         override fun onAdded(edit: Edit) { viewLifecycleScope.launch { animateInIfAnythingToUndo() } }
         override fun onSynced(edit: Edit) { viewLifecycleScope.launch { animateOutIfNothingLeftToUndo() } }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsFragment.kt
@@ -92,7 +92,7 @@ class SettingsFragment : TwoPaneListFragment(), HasTitle {
         override fun onUnhidAll() { setHiddenQuestsSummary() }
     }
 
-    private val onAutosyncChanged =  {
+    private val onAutosyncChanged = {
         if (Prefs.Autosync.valueOf(prefs.getStringOrNull(Prefs.AUTOSYNC) ?: "ON") != Prefs.Autosync.ON) {
             AlertDialog.Builder(requireContext())
                 .setView(layoutInflater.inflate(R.layout.dialog_tutorial_upload, null))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileFragment.kt
@@ -71,7 +71,7 @@ class ProfileFragment : Fragment(R.layout.fragment_profile) {
             viewLifecycleScope.launch { updateEditCountTexts() }
         }
         override fun onSubtractedOne(type: String) {
-            viewLifecycleScope.launch { updateEditCountTexts()  }
+            viewLifecycleScope.launch { updateEditCountTexts() }
         }
         override fun onUpdatedAll() {
             viewLifecycleScope.launch { updateStatisticsTexts() }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/statistics/CircularFlagView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/statistics/CircularFlagView.kt
@@ -63,7 +63,7 @@ class CircularFlagView @JvmOverloads constructor(
     }
 
     override fun setRotation(rotation: Float) {
-        /* this view can't handle rotation properly */
+        // this view can't handle rotation properly
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -137,7 +137,7 @@ class CircularFlagView @JvmOverloads constructor(
     }
 
     companion object {
-        /* make sure the YAML is only read once and kept once for all instances of SquareFlagView*/
+        // make sure the YAML is only read once and kept once for all instances of SquareFlagView
         private var map: Map<String, FlagAlignment>? = null
 
         private fun get(resources: Resources, countryCode: String): FlagAlignment? {

--- a/app/src/test/java/de/westnordost/streetcomplete/OpeningHoursParsingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/OpeningHoursParsingTest.kt
@@ -186,7 +186,7 @@ private fun TimesSelector.hasVariableTime(): Boolean = when (this) {
 
 private fun MonthsOrDateSelector.hasYear(): Boolean = when (this) {
     is Date -> hasYear()
-    is DateRange -> start.hasYear()  || end.hasYear()
+    is DateRange -> start.hasYear() || end.hasYear()
     is DatesInMonth -> year != null
     is MonthRange -> year != null
     is SingleMonth -> year != null

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/smoking/AddSmokingTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/smoking/AddSmokingTest.kt
@@ -50,7 +50,7 @@ class AddSmokingTest {
         ))))
     }
 
-    /* we assume that seating is not present if not indicated for bakery and similar */
+    // we assume that seating is not present if not indicated for bakery and similar
     @Test fun `not applicable to bakery without indicated seating`() {
         assertFalse(questType.isApplicableTo(node(tags = mapOf(
             "shop" to "bakery",
@@ -105,7 +105,7 @@ class AddSmokingTest {
         ))))
     }
 
-    /* nighclubs etc. may have outdoor smoking areas even if no seating is present */
+    // nighclubs etc. may have outdoor smoking areas even if no seating is present
     @Test fun `applicable to nightclub without any seating`() {
         assertTrue(questType.isApplicableTo(node(tags = mapOf(
             "amenity" to "nightclub",
@@ -120,7 +120,7 @@ class AddSmokingTest {
         ))))
     }
 
-    /* we assume that seating is present if not indicated for cafe and similar */
+    // we assume that seating is present if not indicated for cafe and similar
     @Test fun `applicable to cafe without indicated seating`() {
         assertTrue(questType.isApplicableTo(node(tags = mapOf(
             "amenity" to "cafe",

--- a/buildSrc/src/main/java/DownloadAndConvertPresetIconsTask.kt
+++ b/buildSrc/src/main/java/DownloadAndConvertPresetIconsTask.kt
@@ -109,7 +109,7 @@ open class DownloadAndConvertPresetIconsTask : DefaultTask() {
         }
 
         require(root != null) { "No root node found" }
-        require(root.tagName  == "svg") { "Root must be <svg>" }
+        require(root.tagName == "svg") { "Root must be <svg>" }
 
         var width = root.getAttribute("width")
         var height = root.getAttribute("height")


### PR DESCRIPTION
Relevant rule docs:

- [`no-single-line-block-comment`](https://pinterest.github.io/ktlint/latest/rules/standard/#no-single-line-block-comment) (not enabled permanently, as there are many header-style single line block comments in the code base)
- [`comment-wrapping`](https://pinterest.github.io/ktlint/latest/rules/standard/#comment-wrapping)
- [`value-argument-comment`](https://pinterest.github.io/ktlint/latest/rules/standard/#value-argument-comment)
- [`value-parameter-comment`](https://pinterest.github.io/ktlint/latest/rules/standard/#value-parameter-comment)
- [`no-multi-spaces`](https://pinterest.github.io/ktlint/latest/rules/standard/#no-multi-spaces) (not enabled permanently, as there is a lot of manual formatting in the code base)

I'm going to merge this PR without a review, since it's only minor lint changes, but feel free to comment on it afterwards.