### PR TITLE
Don't highlight roads in cycleway overlay where cycling is not allowed

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
@@ -115,6 +115,7 @@ private val cyclewayTaggingNotExpectedFilter by lazy { """
       or maxspeed <= 20
       or cyclestreet = yes
       or bicycle_road = yes
+      or bicycle = no
       or surface ~ ${ANYTHING_UNPAVED.joinToString("|")}
       or ~"${(MAXSPEED_TYPE_KEYS + "maxspeed").joinToString("|")}" ~ ".*:(zone)?:?([1-9]|[1-2][0-9]|30)"
 """.toElementFilterExpression() }


### PR DESCRIPTION
The cycleway quest already ignores roads with bicycle=no, but the cycleway overlay did not.

(Since this is a very minor change/fix, I directly created a PR.)