### PR TITLE
Don't highlight tunnels in parking overlay

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -81,6 +81,7 @@ private val streetParkingTaggingNotExpected by lazy { """
       highway ~ service|pedestrian
       or motorroad = yes
       or expressway = yes
+      or tunnel = yes
       or junction = roundabout
       or ~"${(MAXSPEED_TYPE_KEYS + "maxspeed").joinToString("|")}" ~ ".*:(rural|nsl_single|nsl_dual)"
       or maxspeed >= 70


### PR DESCRIPTION
Parking in tunnels is very rare (can't think of any cases where parking in a road tunnel would be allowed, mainly for safety reasons). The parking overlay therefore should not highlight tunnels that don't have information on parking to avoid spam.

(Since this is a very minor change, I directly created a PR.) 