### PR TITLE
Do not ask width in endless loop on segments of road tagged with traffic_calming=choker

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
@@ -44,6 +44,7 @@ class AddRoadWidth(
         )
         and area != yes
         and (!width or source:width ~ ".*estimat.*")
+        and (traffic_calming !~ ${ROAD_NARROWERS.joinToString("|")} or !maxwidth or source:maxwidth ~".*estimat.*")
         and (surface ~ ${ANYTHING_PAVED.joinToString("|")} or highway ~ ${ROADS_ASSUMED_TO_BE_PAVED.joinToString("|")})
         and (access !~ private|no or (foot and foot !~ private|no))
         and foot != no

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/width/AddRoadWidthTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/width/AddRoadWidthTest.kt
@@ -77,6 +77,32 @@ class AddRoadWidthTest {
         ))))
     }
 
+    @Test fun `is applicable to road with choker`() {
+        assertTrue(quest.isApplicableTo(way(tags = mapOf(
+            "maxspeed" to "DE:zone30",
+            "highway" to "residential",
+            "surface" to "asphalt",
+            "traffic_calming" to "choker"
+        ))))
+    }
+
+    @Test fun `is not applicable to road with choker and maxwidth`() {
+        assertFalse(quest.isApplicableTo(way(tags = mapOf(
+            "maxspeed" to "DE:zone30",
+            "highway" to "residential",
+            "surface" to "asphalt",
+            "traffic_calming" to "choker",
+            "maxwidth" to "3"
+        ))))
+        assertFalse(quest.isApplicableTo(way(tags = mapOf(
+            "maxspeed" to "DE:zone30",
+            "highway" to "residential",
+            "surface" to "asphalt",
+            "traffic_calming" to "choker",
+            "width" to "3"
+        ))))
+    }
+
     @Test fun `apply to street`() {
         assertEquals(
             setOf(StringMapEntryAdd("width", "3")),


### PR DESCRIPTION
Fixes: https://github.com/streetcomplete/StreetComplete/issues/5569


--- 

Description:

If the road had `traffic_calming=choker` (or similar), we were tagging [`maxwidth` instead of `width`]( https://github.com/streetcomplete/StreetComplete/blob/38203c669a5448414f9965b95dcd8d6defee2e35/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt#L74).
However, in element selection code, we only selected _ways_ with non-existent `width` tag. This PR adds also a check for `maxwidth` too if the road way segment has [ROAD_NARROWERS](https://github.com/streetcomplete/StreetComplete/blob/38203c669a5448414f9965b95dcd8d6defee2e35/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt#L91).

I've also added [automated tests](https://github.com/mnalis/StreetComplete/actions/runs/8668878845/job/23774730168) for this use case, and also checked manually with [v57.1-based debug APK](https://github.com/mnalis/StreetComplete/actions/runs/8668430767) for [w1228191464](https://www.openstreetmap.org/way/1228191464) from the bug report, and it seems to work fine now (not asking width for that road segment anymore).

(we also [already have code](https://github.com/streetcomplete/StreetComplete/blob/38203c669a5448414f9965b95dcd8d6defee2e35/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt#L21-L26) in that quest that handles traffic choker _nodes_; I didn't touch that part).