### PR TITLE
Update QUEST_GUIDELINES.md to reflect changes due to new overlays

### DIFF
--- a/QUEST_GUIDELINES.md
+++ b/QUEST_GUIDELINES.md
@@ -5,7 +5,7 @@ Do you have an idea for a new quest? Read this!
 Consider the following:
 
 ### Limitations of StreetComplete
-- 🌟 Only existing elements can be extended, no elements can be added or removed.
+- 🌟 Only existing elements can be extended, no elements can be added or removed (except point objects added through an overlay layer).
 - ✂️ The geometry of elements cannot be changed (except splitting up ways)
 - 🏷️ So, basically: Only tags can be edited
 


### PR DESCRIPTION
The quest guidelines currently state that StreetComplete can't add or remove elements. This is no longer strictly true with the new layers like "places", "things", "Addresses" and "Street parking" which all allow new point objects. 

I think there may also be a typo further down, where the text says 'A good pattern is to "ban" answering edge cases' I think this should read 'A good pattern is to "bin" answering edge cases', but this might be jargon I'm unfamiliar with so I have left this as-is. 