### PR TITLE
Do not ask payment methods if payment:others=no is set

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -17,7 +17,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
           amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar
           or (shop and shop !~ no|vacant|mall)
         )
-        and !payment:credit_cards and !payment:debit_cards
+        and !payment:credit_cards and !payment:debit_cards and !payment:others
         and !brand and !wikipedia:brand and !wikidata:brand
         and (!seasonal or seasonal = no)
         and (name or brand or noname = yes or name:signed = no)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -17,7 +17,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
           amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar
           or (shop and shop !~ no|vacant|mall)
         )
-        and !payment:credit_cards and !payment:debit_cards and !payment:others
+        and !payment:credit_cards and !payment:debit_cards and payment:others != no
         and !brand and !wikipedia:brand and !wikidata:brand
         and (!seasonal or seasonal = no)
         and (name or brand or noname = yes or name:signed = no)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -45,7 +45,7 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>() {
               or tourism ~ ${tourismsWithImpliedFees.joinToString("|")}
               or tourism ~ ${tourismsWithoutImpliedFees.joinToString("|")} and fee = yes
             )
-            and !payment:cash and !payment:coins and !payment:notes
+            and !payment:cash and !payment:coins and !payment:notes and !payment:others
             and (name or brand or noname = yes or name:signed = no)
         """
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -45,7 +45,7 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>() {
               or tourism ~ ${tourismsWithImpliedFees.joinToString("|")}
               or tourism ~ ${tourismsWithoutImpliedFees.joinToString("|")} and fee = yes
             )
-            and !payment:cash and !payment:coins and !payment:notes and !payment:others
+            and !payment:cash and !payment:coins and !payment:notes and payment:others != no
             and (name or brand or noname = yes or name:signed = no)
         """
     }


### PR DESCRIPTION
The [wiki](https://wiki.openstreetmap.org/wiki/Key:payment:*#Others) says that `payment:others=no` can be used if you have already indicated **all** methods of payment which are accepted. Do not need to ask whether cash or cards are accepted if this key is set.