### PR TITLE
Added Hungarian sign to quest fire_hydrant_diameter

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -33,6 +33,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
         "DE", "BE", "LU",
         // not "AT", - see https://community.openstreetmap.org/t/streetcomplete-quest-zu-hydrantendurchmesser-in-osterreich/108899
         "GB", "IE",
+        "HU",
         "PL",
         "FI",
         "NL"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameterForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameterForm.kt
@@ -142,6 +142,7 @@ class AddFireHydrantDiameterForm : AbstractOsmQuestForm<FireHydrantDiameterAnswe
 
 private fun getHydrantDiameterSignLayoutResId(countryCode: String): Int = when (countryCode) {
     "DE", "BE", "LU", "AT" -> R.layout.quest_fire_hydrant_diameter_sign_de
+    "HU" -> R.layout.quest_fire_hydrant_diameter_sign_hu
     "FI" -> R.layout.quest_fire_hydrant_diameter_sign_fi
     "NL" -> R.layout.quest_fire_hydrant_diameter_sign_nl
     "PL" -> R.layout.quest_fire_hydrant_diameter_sign_pl

--- a/app/src/main/res/drawable/fire_hydrant_sign_hu.xml
+++ b/app/src/main/res/drawable/fire_hydrant_sign_hu.xml
@@ -1,0 +1,34 @@
+<vector
+    android:viewportHeight="330"
+    android:viewportWidth="735"
+    android:width="320dp"
+    android:height="143.67346dp"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <path
+        android:fillColor="#fff"
+        android:pathData="m75,25h585c50,0 50,0 50,50v460c0,50 0,50 -50,50h-585c-50,0 -50,0 -50,-50v-460c0,-50 0,-50 50,-50z"
+        android:strokeColor="#ba2726"
+        android:strokeWidth="50"/>
+    <path
+        android:pathData="m131.45,214 l472.96,-0.236m-229.17,0.195 l0.266,148.2"
+        android:strokeColor="#000"
+        android:strokeWidth="18"/>
+    <path
+        android:pathData="m216.17,84.12h-83.834m43.834,-6.232v98.954"
+        android:strokeColor="#000"
+        android:strokeWidth="14"/>
+    <path
+        android:pathData="M0,0 H 735 V 610 H 0 Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:startColor="@color/fade_out_transparent"
+                android:endColor="@color/fade_out"
+                android:startX="0"
+                android:endX="0"
+                android:startY="230"
+                android:endY="330"
+                android:type="linear" />
+        </aapt:attr>
+    </path>
+</vector>

--- a/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_hu.xml
+++ b/app/src/main/res/layout/quest_fire_hydrant_diameter_sign_hu.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/fireHydrantSign"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/fire_hydrant_sign_hu" />
+
+    <EditText
+        android:id="@+id/diameterInput"
+        android:layout_width="136dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="120dp"
+        android:layout_marginTop="28dp"
+        android:background="#25000000"
+        android:includeFontPadding="false"
+        android:inputType="number"
+        android:maxLength="4"
+        tools:text="1500"
+        android:fontFamily="monospace"
+        android:textColor="@color/traffic_black"
+        android:textStyle="bold"
+        android:textSize="52dp"
+        android:textAlignment="center"
+        app:layout_constraintLeft_toLeftOf="@+id/fireHydrantSign"
+        app:layout_constraintTop_toTopOf="@+id/fireHydrantSign"
+        tools:ignore="RtlHardcoded,SpUsage" />
+
+    <ImageView
+        android:id="@+id/suggestionsButton"
+        android:layout_width="48dp"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_arrow_expand_down_24dp"
+        app:tint="@color/traffic_black"
+        app:layout_constraintRight_toRightOf="@id/diameterInput"
+        app:layout_constraintTop_toTopOf="@id/diameterInput"
+        app:layout_constraintBottom_toBottomOf="@id/diameterInput"
+        style="@style/Base.Widget.AppCompat.Button.Borderless" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Since [the German sign for fire hydrants](https://commons.wikimedia.org/wiki/File:Bachs_Garten,_Arnstadt.jpg) is very similar to [the Hungarian one](https://wiki.openstreetmap.org/wiki/Hungary/Jel%C3%B6l%C3%A9si_p%C3%A9ld%C3%A1k/T%C5%B1zcsap), I forked that one and modified the `H` to `T` (for _Tűzcsap_). I compiled a debug build from this version and tested it in the emulator, it seemed to work well, see screenshot below.

![Screenshot of debug build running in Android Studio emulator](https://github.com/streetcomplete/StreetComplete/assets/163115/992c5c31-5fa0-400b-a760-08cad8526c02)
