### PR TITLE
Exclude `intermittent=yes` water source from drinking water quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -19,6 +19,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
         )
         and access !~ private|no and indoor != yes
         and !drinking_water and !drinking_water:legal and amenity != drinking_water
+        and (!intermittent or intermittent = no)
         and (!seasonal or seasonal = no)
         and (!disused or disused = no)
         and (!ruins or ruins = no)


### PR DESCRIPTION
`seasonal=yes` was already excluded, but `intermittent=yes` is another such attribute: https://wiki.openstreetmap.org/wiki/Key:intermittent.