### PR TITLE
Resolve button text confusion

### DIFF
--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1385,7 +1385,7 @@ Additionally, some overlays allow you to add new data at the position of a displ
 You can find donation information on our website or project home, Google Play does not allow us to provide the link within the app."</string>
     <string name="quest_isAmenityIndoor_outside_covered">"Not inside, but covered"</string>
     <string name="lit_value_unsupported">"Specific lit status that is not selectable in this app"</string>
-    <string name="quest_generic_otherAnswers2">"Er…"</string>
+    <string name="quest_generic_otherAnswers2">"Uh…"</string>
     <string name="quest_pedestrian_crossing_signals2">"Are there traffic signals that show when to cross here?"</string>
     <string name="quest_moped_access_title">"Is there a sign indicating access for mopeds on this bike path?"</string>
     <string name="quest_moped_access_allowed">"There is no sign"</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -30,6 +30,8 @@
         <item name="android:listPopupWindowStyle">@style/Theme.Bubble.Popup</item>
         <item name="listPopupWindowStyle">@style/Theme.Bubble.Popup</item>
         <item name="preferenceTheme">@style/Theme.Preferences</item>
+
+        <item name="materialButtonStyle">@style/Theme.Button</item>
     </style>
 
     <style name="Theme.Bubble.ToolbarPopup"  parent="Theme.MaterialComponents.DayNight.NoActionBar"/>
@@ -80,6 +82,10 @@
     <style name="Theme.CustomDialog" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="android:windowBackground">@color/background_transparent</item>
         <item name="android:windowAnimationStyle">@style/Animation.Dialog.Custom</item>
+    </style>
+
+    <style name="Theme.Button" parent="Widget.MaterialComponents.Button">
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="Theme.Button.Alert" parent="Widget.MaterialComponents.Button.TextButton">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -69,6 +69,7 @@
              can be disabled for dialogs - which would be the behavior one (=the developer) would
              expect. -->
         <item name="android:splitMotionEvents">false</item>
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="Theme.Bubble.Dialog.Alert"/>


### PR DESCRIPTION
- Use mixed-case in all application buttons
- Use Uh... instead of Er... in en-GB to avoid confusion with "Error"

Resolves #5671