### PR TITLE
Optimization of elementFilter in AddAcceptsCards quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -20,7 +20,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
         and !payment:credit_cards and !payment:debit_cards and payment:others != no
         and !brand and !wikipedia:brand and !wikidata:brand
         and (!seasonal or seasonal = no)
-        and (name or brand or noname = yes or name:signed = no)
+        and (name or noname = yes or name:signed = no)
         and access !~ private|no
     """
     override val changesetComment = "Survey whether payment with cards is accepted"


### PR DESCRIPTION
The filter is already checking that the tag `brand` is *not* set, so the check for having it in line 23 is probably obsolete.