### PR TITLE
add support for highway=busway (fixes #5749)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Highway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Highway.kt
@@ -1,10 +1,10 @@
 package de.westnordost.streetcomplete.osm
 
 val ALL_ROADS = setOf(
-    "motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
-    "secondary", "secondary_link", "tertiary", "tertiary_link",
+    "motorway", "motorway_link", "trunk", "trunk_link",
+    "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
     "unclassified", "residential", "living_street", "pedestrian",
-    "service", "track", "road"
+    "service", "track", "busway", "road",
 )
 
 val ALL_PATHS = setOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/RoadWidth.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/RoadWidth.kt
@@ -39,7 +39,7 @@ fun guessRoadwayWidth(tags: Map<String, String>): Float {
         "motorway" -> 2 * BROAD_LANE
         "motorway_link" -> BROAD_LANE
         "trunk", "primary" -> BROAD_LANE // to pay respect to that primary roads are usually broader than secondary etc
-        "secondary", "tertiary", "unclassified" -> LANE
+        "secondary", "tertiary", "unclassified", "busway" -> LANE
         "service" -> 2.5f
         else -> LANE
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
@@ -110,7 +110,7 @@ private fun getStreetCyclewayStyle(element: Element, countryInfo: CountryInfo): 
 
 private val cyclewayTaggingNotExpectedFilter by lazy { """
     ways with
-      highway ~ track|living_street|pedestrian|service|motorway_link|motorway
+      highway ~ track|living_street|pedestrian|service|motorway_link|motorway|busway
       or motorroad = yes
       or expressway = yes
       or maxspeed <= 20

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
@@ -96,7 +96,7 @@ private fun getSidewalkStyle(element: Element): PolylineStyle {
 
 private val sidewalkTaggingNotExpectedFilter by lazy { """
     ways with
-      highway ~ living_street|pedestrian|service|motorway_link
+      highway ~ living_street|pedestrian|service|motorway_link|busway
       or motorroad = yes
       or expressway = yes
       or maxspeed <= 10

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -17,7 +17,7 @@ class AddCrossing : OsmElementQuestType<CrossingAnswer> {
 
     private val roadsFilter by lazy { """
         ways with
-          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential
+          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
           and area != yes
           and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -118,7 +118,7 @@ class AddCycleway(
 // streets that may have cycleway tagging
 private val roadsFilter by lazy { """
     ways with
-      highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service
+      highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
       and area != yes
       and motorroad != yes
       and expressway != yes

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -98,7 +98,7 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>() {
         private val ROADS_WITH_LANES = listOf(
             "motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
             "secondary", "secondary_link", "tertiary", "tertiary_link",
-            "unclassified"
+            "unclassified", "busway",
         )
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -28,7 +28,7 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
     private val roadsWithoutMaxHeightFilter by lazy { """
         ways with
         (
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|track|road
+          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|track|road|busway
           or (highway = service and access !~ private|no and vehicle !~ private|no)
         )
         and $noMaxHeight

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -17,7 +17,7 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>() {
 
     override val elementFilter = """
         ways with
-         highway ~ motorway|trunk|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential
+         highway ~ motorway|trunk|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
          and !maxspeed and !maxspeed:advisory and !maxspeed:forward and !maxspeed:backward
          and ${MAXSPEED_TYPE_KEYS.joinToString(" and ") { "!$it" }}
          and surface !~ ${UNPAVED_SURFACES.joinToString("|")}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -14,7 +14,7 @@ class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>() {
 
     override val elementFilter = """
         ways with
-         highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service
+         highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|busway
          and bridge and bridge != no
          and service != driveway
          and !maxweight and maxweight:signed != no

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -24,7 +24,7 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
 
     /** find only those roads eligible for asking for oneway */
     private val elementFilter by lazy { """
-        ways with highway ~ living_street|residential|service|tertiary|unclassified
+        ways with highway ~ living_street|residential|service|tertiary|unclassified|busway
          and width <= 4 and (!lanes or lanes <= 1)
          and !oneway and area != yes and junction != roundabout
          and (access !~ private|no or (foot and foot !~ private|no))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -15,7 +15,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>() {
 
     override val elementFilter = """
         ways with
-          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian
+          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
           and !name and !name:left and !name:right
           and !ref
           and noname != yes

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -57,14 +57,14 @@ private val roadsFilter by lazy { """
     ways with
       (
         (
-          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service
+          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
           and motorroad != yes
           and expressway != yes
           and foot != no
         )
         or
         (
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service
+          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
           and (foot ~ yes|designated or bicycle ~ yes|designated)
         )
       )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -53,6 +53,6 @@ val SURFACES_FOR_SMOOTHNESS = listOf(
 private val ROADS_TO_ASK_SMOOTHNESS_FOR = arrayOf(
     // "trunk","trunk_link","motorway","motorway_link", // too much, motorways are almost by definition smooth asphalt (or concrete)
     "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
-    "unclassified", "residential", "living_street", "pedestrian", "track",
-    // "service", // this is too much, and the information value is very low
+    "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
+    // "service", // this is too much (e.g. includes driveways), and the information value is very low
 )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -18,7 +18,7 @@ class AddRoadSurface : OsmFilterQuestType<SurfaceAndNote>() {
         ways with (
           highway ~ ${listOf(
             "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
-            "unclassified", "residential", "living_street", "pedestrian", "track",
+            "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
             ).joinToString("|")
           }
           or highway = service and service !~ driveway|slipway

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -14,7 +14,7 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>() {
     // Only roads with 'complete' sidewalk tagging (at least one side has sidewalk, other side specified)
     override val elementFilter = """
         ways with
-            highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|living_street
+            highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|living_street|busway
             and area != yes
             and (
                 sidewalk ~ both|left|right or

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -64,7 +64,9 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
     }
 
     companion object {
-        private val LIT_RESIDENTIAL_ROADS = arrayOf("residential", "living_street", "pedestrian")
+        private val LIT_RESIDENTIAL_ROADS = arrayOf(
+            "residential", "living_street", "pedestrian", "busway"
+        )
 
         private val LIT_NON_RESIDENTIAL_ROADS = arrayOf(
             "motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
@@ -28,7 +28,7 @@ class AddRoadWidth(
     private val wayFilter by lazy { """
         ways with (
           (
-            highway ~ trunk|primary|secondary|tertiary|unclassified|residential
+            highway ~ trunk|primary|secondary|tertiary|unclassified|residential|busway
             and (lane_markings = no or lanes < 2)
           ) or (
             highway = residential


### PR DESCRIPTION
- `AddRoadName` OK. 62% of busways already have a name
- `AddLanes` OK. Some will have 2, some (the oneway ones) will have 1.
- `AddOneway` OK. 70% of busways are tagged with oneway=yes
- `AddMaxSpeed`, `AddMaxWeight`, `AddMaxHeight` OK. Signage for buses is the same as signage for car traffic in general
- `AddRoadSurface`, `SurfaceOverlay` OK
- `AddRoadSmoothness` OK.
- `AddRoadWidth` Hmm, OK. It is only asked under very specific circumstances anyway, i.e. `lanes < 2` or `lane_markings=no` and also` access != no` (like many others)
- `AddWayLit`, `WayLitOverlay` OK, could make sense for the big picture
- ~`AddSidewalk`~, ~`AddCycleway`~ While theoretically possible, it has zero usage. Oftentimes busways are layouted in the same way trams would be layouted, i.e. in the middle of the road, between the car lanes. Of course there is no sidewalk or cycleway. However, it **should** be asked in the case that the busway has invalid sidewalk or cycleway tagging
- `AddSidewalkSurface` OK. This is only asked for ways that DO have a sidewalk already tagged
- ~`AddProhibitedForPedestrians`~ No need to ask.
- ~`StreetParkingOverlay`~ Can't park there anyway
- `AddCrossing` OK. Pedestrian crossings with busways are possible.
- `AddBarrierOnRoad` OK. If a fence intersects with a busway, it is fair to ask about the type of opening in that barrier for the busway
- `AddKerbHeight`, `AddTactilePavingKerb` OK. (when footway crosses busway)
- `SidewalkOverlay`, `CyclewayOverlay` OK. Theoretically possible after all. But it should not be highlighted in red (i.e. as missing).