### PR TITLE
Keep quest pins if they are in current view

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -177,7 +177,7 @@ class QuestPinsManager(
             withContext(Dispatchers.IO) { visibleQuestsSource.getAllVisible(bbox) }
         }
         val pins = questsInViewMutex.withLock {
-            questsInView.clear()
+            questsInView.entries.removeAll { it.value.size == 1 || it.value.none { it.position in bbox } }
             quests.forEach { questsInView[it.key] = createQuestPins(it) }
             questsInView.values.flatten()
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -177,11 +177,12 @@ class QuestPinsManager(
             withContext(Dispatchers.IO) { visibleQuestsSource.getAllVisible(bbox) }
         }
         val pins = questsInViewMutex.withLock {
-            /* Quests have only a single position, but may have multiple pins (see
+            /* Usually, we would call questsInView.clear() here. However,
+               wuests have only a single position, but may have multiple pins (see
                Quest::markerLocations), e.g. at the start and end of a long road. A pin of a quest
                whose center is outside the current view may hence be within the current view. Quest
                pins like these should not disappear when panning the map.
-               Therefore, remove all quests that are not in view anymore that that ...
+               Therefore, remove all quests that are not in view anymore that  ...
               */
             questsInView.entries.removeAll { (_, pins) ->
                 // only have one pin (pin position = quest position)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -178,7 +178,7 @@ class QuestPinsManager(
         }
         val pins = questsInViewMutex.withLock {
             /* Usually, we would call questsInView.clear() here. However,
-               wuests have only a single position, but may have multiple pins (see
+               quests have only a single position, but may have multiple pins (see
                Quest::markerLocations), e.g. at the start and end of a long road. A pin of a quest
                whose center is outside the current view may hence be within the current view. Quest
                pins like these should not disappear when panning the map.


### PR DESCRIPTION
Quests have only a single position, but may have multiple pins.
In some cases, e.g. on long roads, the quest position (i.e. center) may be in a different map tile than some of the displayed pins.
Since the `QuestPinsManager` clears and reloads existing quests in `setQuestPins`, there are cases where pins disappear on scrolling along a long road that has quests.

With the proposed change, previously visible quests are kept if they have a pin in the `bbox`.
No need to check for quests with a single pin, because here the pin position is always the quest position.
Performance impact is low: Even with ~2000 quests in the visible area, the new way of checking before removing takes ~3-5 ms on Galaxy A3 (debug APK).

This change does not make things perfect though. When answering a quest where the center in not in the current tile, the follow-up quests will not appear unless you scroll to the quest position / way center.