### PR TITLE
callOnUpdated if an updated element does not have a local edit

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -84,9 +84,7 @@ class MapDataWithEditsSource internal constructor(
                  *  * The modified versions of all elements in updated are the same before and after
                  *    rebuildLocalChanges, except for the timestamp (expected to have few ms
                  *    difference) and version (never updated locally).
-                 * However, we do want to callOnUpdated if an updated element does not have an associated
-                 * modification, because in that case we cannot know whether the updated version is changed
-                 * compared to the previous version.
+                 *   * No new elements are being added
                  */
                 val deletedIsUnchanged = deletedElements.containsAll(deleted)
                 val hasUnknownElement = updated.any { it.key !in updatedElements }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -87,7 +87,7 @@ class MapDataWithEditsSource internal constructor(
                  *   * No new elements are being added
                  */
                 val deletedIsUnchanged = deletedElements.containsAll(deleted)
-                val hasUnknownElement = updated.any { it.key !in updatedElements }
+                val hasNewElements = updated.any { it.key !in updatedElements }
                 val elementsThatMightHaveChangedByKey = updated.mapNotNull { element ->
                     val key = element.key
                     if (element.isEqualExceptVersionAndTimestamp(updatedElements[key])) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -101,7 +101,7 @@ class MapDataWithEditsSource internal constructor(
 
                 /* nothingChanged can be false at this point when e.g. there are two edits on the
                    same element, and onUpdated is called after the first edit is uploaded. */
-                val nothingChanged = deletedIsUnchanged && !hasUnknownElement && elementsThatMightHaveChangedByKey.all {
+                val nothingChanged = deletedIsUnchanged && !hasNewElements && elementsThatMightHaveChangedByKey.all {
                     val updatedElement = get(it.first.type, it.first.id)
                     // old and new elements are equal except version and timestamp, or both are null
                     it.second?.isEqualExceptVersionAndTimestamp(updatedElement) ?: (updatedElement == null)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSource.kt
@@ -78,14 +78,18 @@ class MapDataWithEditsSource internal constructor(
             val modifiedDeleted = ArrayList<ElementKey>()
             synchronized(this) {
                 /* We don't want to callOnUpdated if none of the changes affects map data provided
-                 * by MapDataWithEditsSource.
+                 * by MapDataWithEditsSource
                  * This is the case if
                  *  * All keys in deleted are already in deletedElements.
                  *  * The modified versions of all elements in updated are the same before and after
                  *    rebuildLocalChanges, except for the timestamp (expected to have few ms
                  *    difference) and version (never updated locally).
+                 * However, we do want to callOnUpdated if an updated element does not have an associated
+                 * modification, because in that case we cannot know whether the updated version is changed
+                 * compared to the previous version.
                  */
                 val deletedIsUnchanged = deletedElements.containsAll(deleted)
+                val hasUnknownElement = updated.any { it.key !in updatedElements }
                 val elementsThatMightHaveChangedByKey = updated.mapNotNull { element ->
                     val key = element.key
                     if (element.isEqualExceptVersionAndTimestamp(updatedElements[key])) {
@@ -99,7 +103,7 @@ class MapDataWithEditsSource internal constructor(
 
                 /* nothingChanged can be false at this point when e.g. there are two edits on the
                    same element, and onUpdated is called after the first edit is uploaded. */
-                val nothingChanged = deletedIsUnchanged && elementsThatMightHaveChangedByKey.all {
+                val nothingChanged = deletedIsUnchanged && !hasUnknownElement && elementsThatMightHaveChangedByKey.all {
                     val updatedElement = get(it.first.type, it.first.id)
                     // old and new elements are equal except version and timestamp, or both are null
                     it.second?.isEqualExceptVersionAndTimestamp(updatedElement) ?: (updatedElement == null)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/MapDataWithEditsSourceTest.kt
@@ -1222,6 +1222,29 @@ class MapDataWithEditsSourceTest {
         verify(listener).onUpdated(eq(updatedMapData), eq(emptyList()))
     }
 
+    @Test
+    fun `does call onUpdated when updated element is not in local changes`() {
+        val nd = node(1, p(0.1, 0.0))
+        val ndModified = node(1, p(0.3, 0.0))
+        val nd2 = node(2, p(0.5, 0.4))
+        val p2 = ElementGeometryEntry(NODE, 2, pGeom(0.5, 0.4))
+
+        originalElementsAre(nd, nd2)
+        mapDataChangesAre(modifications = listOf(ndModified))
+
+        val s = create()
+        val listener = mock<MapDataWithEditsSource.Listener>()
+        s.addListener(listener)
+
+        val updatedMapData = MutableMapDataWithGeometry(
+            elements = listOf(nd2),
+            geometryEntries = listOf(p2)
+        )
+        mapDataListener.onUpdated(updatedMapData, emptyList())
+
+        verify(listener).onUpdated(eq(updatedMapData), eq(emptyList()))
+    }
+
     //endregion
 
     //region MapDataController.Listener ::onReplacedForBBox


### PR DESCRIPTION
Fixes #5745 as in the latest comments.
(the new test fails without the changes to `MapDataWithEditsSource`)