### PR TITLE
Ask for opening width on cycle_barrier=single|diagonal too

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
@@ -21,7 +21,7 @@ class AddBarrierOpening(
         nodes with
             (
                 barrier ~ gate|entrance|sliding_gate|swing_gate|wicket_gate|bollard|block
-                or cycle_barrier ~ single|diagonal
+                or barrier = cycle_barrier and cycle_barrier ~ single|diagonal
             )
             and (!maxwidth:physical or source:maxwidth_physical ~ ".*estimat.*")
             and (!width or source:width ~ ".*estimat.*")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
@@ -19,7 +19,10 @@ class AddBarrierOpening(
 
     private val nodeFilter by lazy { """
         nodes with
-            barrier ~ gate|entrance|sliding_gate|swing_gate|wicket_gate|bollard|block
+            (
+                barrier ~ gate|entrance|sliding_gate|swing_gate|wicket_gate|bollard|block
+                or cycle_barrier ~ single|diagonal
+            )
             and (!maxwidth:physical or source:maxwidth_physical ~ ".*estimat.*")
             and (!width or source:width ~ ".*estimat.*")
             and (!maxwidth or source:maxwidth ~ ".*estimat.*")
@@ -39,7 +42,7 @@ class AddBarrierOpening(
         get() = if (!checkArSupport()) R.string.default_disabled_msg_no_ar else 0
 
     override fun getTitle(tags: Map<String, String>) =
-        if (tags["barrier"] == "bollard" || tags["barrier"] == "block") {
+        if (tags["barrier"] == "bollard" || tags["barrier"] == "block" || tags["cycle_barrier"] == "diagonal") {
             R.string.quest_barrier_opening_width_bollard
         } else {
             R.string.quest_barrier_opening_width_gate


### PR DESCRIPTION
As noted by @ERYpTION in https://github.com/streetcomplete/StreetComplete/discussions/5812#discussioncomment-10393218, `AddBarrierOpening` quest would benefit from being asked on `cycle_barrier=single` and `cycle_barrier=diagonal` too. This PR implements it.

It _perhaps_ might also be implemented on `cycle_barrier=tilted`, but it might be confusing/require new wording (due to it having different widths at different heights), so it is not proposed here. Other cycle barrier types are much more complex, so are ignored here (see [this wiki section](https://wiki.openstreetmap.org/wiki/Tag:barrier=cycle_barrier#Passableness_for_cargo_bikes,_trailers,_wheelchairs,_etc.)) 