### PR TITLE
New statistics page: Add wikilinks to overlays, that haven't already got one

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
@@ -23,7 +23,7 @@ class PlacesOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override val title = R.string.overlay_places
     override val icon = R.drawable.ic_quest_shop
     override val changesetComment = "Survey shops, places etc."
-    override val wikiLink = null
+    override val wikiLink = "StreetComplete#ol_places"
     override val achievements = listOf(EditTypeAchievement.CITIZEN)
     override val hidesQuestTypes = setOf(
         AddPlaceName::class.simpleName!!,

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
@@ -23,7 +23,7 @@ class PlacesOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override val title = R.string.overlay_places
     override val icon = R.drawable.ic_quest_shop
     override val changesetComment = "Survey shops, places etc."
-    override val wikiLink = "StreetComplete#ol_places"
+    override val wikiLink = "StreetComplete/Overlays#Places"
     override val achievements = listOf(EditTypeAchievement.CITIZEN)
     override val hidesQuestTypes = setOf(
         AddPlaceName::class.simpleName!!,

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
@@ -20,7 +20,7 @@ class ThingsOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override val title = R.string.overlay_things
     override val icon = R.drawable.ic_quest_dot
     override val changesetComment = "Survey small map features"
-    override val wikiLink = "StreetComplete#ol_things"
+    override val wikiLink = "StreetComplete/Overlays#Things"
     override val achievements = listOf(EditTypeAchievement.CITIZEN)
     override val isCreateNodeEnabled = true
 

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
@@ -20,7 +20,7 @@ class ThingsOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override val title = R.string.overlay_things
     override val icon = R.drawable.ic_quest_dot
     override val changesetComment = "Survey small map features"
-    override val wikiLink = null
+    override val wikiLink = "StreetComplete#ol_things"
     override val achievements = listOf(EditTypeAchievement.CITIZEN)
     override val isCreateNodeEnabled = true
 


### PR DESCRIPTION
Adding a `wikiLink` to `Things` and `Places` overlays.

Links point to the corresponding overlay description on SC's wiki page that I've added link anchors to prior.

~Can't test or show pictures as test in Android Studio emulator crashes constantly.~ Wireless Debugging to the rescue, there are images now:

| Link in statistics | Wiki |
| --- | --- |
| <img src="https://i.imgur.com/0LsSa4d.jpeg" /> | <img src="https://i.imgur.com/IPrzzb9.jpeg" /> |



