### PR TITLE
Use platform CancellationSignal

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
@@ -6,13 +6,13 @@ import android.location.Location
 import android.location.LocationManager
 import android.location.LocationManager.GPS_PROVIDER
 import android.location.LocationManager.NETWORK_PROVIDER
+import android.os.CancellationSignal
 import android.os.Looper
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
-import androidx.core.os.CancellationSignal
 import androidx.core.util.Consumer
 import de.westnordost.streetcomplete.util.ktx.elapsedDuration
 import kotlin.time.Duration.Companion.minutes


### PR DESCRIPTION
The Jetpack [`CancellationSignal`](https://developer.android.com/reference/androidx/core/os/CancellationSignal) class has been deprecated as the Core library now requires at least API level 19.