### PR TITLE
Check Date for opening_hours:signed

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -168,6 +168,7 @@ class AddOpeningHours(
         if (answer is NoOpeningHoursSign) {
             tags["opening_hours:signed"] = "no"
             tags.updateCheckDateForKey("opening_hours:signed")
+            tags.removeCheckDatesForKey("opening_hours")
             // don't delete current opening hours: these may be the correct hours, they are just not visible anywhere on the door
         } else {
             val openingHoursString = when (answer) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -11,6 +11,7 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.getLastCheckDateKeys
 import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.removeCheckDatesForKey
 import de.westnordost.streetcomplete.osm.setCheckDateForKey
 import de.westnordost.streetcomplete.osm.toCheckDate
 import de.westnordost.streetcomplete.osm.updateCheckDateForKey
@@ -27,7 +28,7 @@ class CheckOpeningHoursSigned(
         nodes, ways with
           opening_hours:signed = no
           and (
-            $hasOldOpeningHoursCheckDateFilter
+            $hasOldOpeningHoursSignedCheckDateFilter
             or older today -1 years
           )
           and access !~ private|no
@@ -37,8 +38,8 @@ class CheckOpeningHoursSigned(
           )
     """.toElementFilterExpression() }
 
-    private val hasOldOpeningHoursCheckDateFilter: String get() =
-        getLastCheckDateKeys("opening_hours").joinToString("\nor ") {
+    private val hasOldOpeningHoursSignedCheckDateFilter: String get() =
+        getLastCheckDateKeys("opening_hours:signed").joinToString("\nor ") {
             "$it < today -1 years"
         }
 
@@ -64,6 +65,7 @@ class CheckOpeningHoursSigned(
     override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         if (answer) {
             tags.remove("opening_hours:signed")
+            tags.removeCheckDatesForKey("opening_hours:signed")
             /* it is now signed: we set the check date for the opening hours to the previous edit
                timestamp because this or an older date is the date the opening hours were last
                checked. This is set so that the app will ask about the (signed) opening hours in
@@ -80,7 +82,7 @@ class CheckOpeningHoursSigned(
         } else {
             tags["opening_hours:signed"] = "no"
             // still unsigned: just set the check date to now, user was on-site
-            tags.updateCheckDateForKey("opening_hours")
+            tags.updateCheckDateForKey("opening_hours:signed")
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -28,6 +28,8 @@ class CheckOpeningHoursSigned(
         nodes, ways with
           opening_hours:signed = no
           and (
+            $hasOldOpeningHoursCheckDateFilter
+            or
             $hasOldOpeningHoursSignedCheckDateFilter
             or older today -1 years
           )
@@ -37,6 +39,11 @@ class CheckOpeningHoursSigned(
             or amenity ~ recycling|toilets|bicycle_rental|charging_station or leisure = park or barrier
           )
     """.toElementFilterExpression() }
+
+    private val hasOldOpeningHoursCheckDateFilter: String get() =
+        getLastCheckDateKeys("opening_hours").joinToString("\nor ") {
+            "$it < today -1 years"
+        }
 
     private val hasOldOpeningHoursSignedCheckDateFilter: String get() =
         getLastCheckDateKeys("opening_hours:signed").joinToString("\nor ") {

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
@@ -6,10 +6,12 @@ import de.westnordost.osm_opening_hours.model.Range
 import de.westnordost.osm_opening_hours.model.Rule
 import de.westnordost.osm_opening_hours.model.TimeSpan
 import de.westnordost.osm_opening_hours.model.Weekday
+import de.westnordost.streetcomplete.data.elementfilter.filters.RelativeDate
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
 import de.westnordost.streetcomplete.osm.toCheckDate
+import de.westnordost.streetcomplete.osm.toCheckDateString
 import de.westnordost.streetcomplete.quests.answerApplied
 import de.westnordost.streetcomplete.quests.answerAppliedTo
 import de.westnordost.streetcomplete.testutils.mock
@@ -61,7 +63,7 @@ class AddOpeningHoursTest {
         assertEquals(
             setOf(
                 StringMapEntryAdd("opening_hours:signed", "no"),
-                StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString())
+                StringMapEntryAdd("check_date:opening_hours:signed", nowAsCheckDateString())
             ),
             questType.answerApplied(NoOpeningHoursSign)
         )
@@ -71,7 +73,7 @@ class AddOpeningHoursTest {
         assertEquals(
             setOf(
                 StringMapEntryAdd("opening_hours:signed", "no"),
-                StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString())
+                StringMapEntryAdd("check_date:opening_hours:signed", nowAsCheckDateString())
             ),
             questType.answerAppliedTo(
                 NoOpeningHoursSign,
@@ -84,7 +86,7 @@ class AddOpeningHoursTest {
         assertEquals(
             setOf(
                 StringMapEntryAdd("opening_hours:signed", "no"),
-                StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString())
+                StringMapEntryAdd("check_date:opening_hours:signed", nowAsCheckDateString())
             ),
             questType.answerAppliedTo(NoOpeningHoursSign, mapOf("opening_hours" to "24/7"))
         )
@@ -279,14 +281,27 @@ class AddOpeningHoursTest {
         )))
     }
 
-    @Test fun `isApplicableTo returns false if the opening hours are not signed`() {
+    @Test fun `isApplicableTo returns false if the opening hours are not signed and signed check date is 1 year old`() {
         assertFalse(questType.isApplicableTo(node(
             tags = mapOf(
                 "shop" to "supermarket",
                 "name" to "Supi",
-                "opening_hours:signed" to "no"
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours:signed" to RelativeDate(-365f).date.toCheckDateString()
             ),
-            timestamp = "2000-11-11".toCheckDate()?.toEpochMilli()
+            timestamp = RelativeDate(-365f).date.toCheckDateString().toCheckDate()?.toEpochMilli()
+        )))
+    }
+
+    @Test fun `isApplicableTo returns true if the opening hours are not signed and signed check date is older than 1 year`() {
+        assertTrue(questType.isApplicableTo(node(
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours:signed" to RelativeDate(-420f).date.toCheckDateString()
+            ),
+            timestamp = RelativeDate(-365f).date.toCheckDateString().toCheckDate()?.toEpochMilli()
         )))
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
@@ -293,6 +293,42 @@ class AddOpeningHoursTest {
         )))
     }
 
+    @Test fun `isApplicableTo returns false if the opening hours check date is older than 1 year, while they are not signed and signed check date is less than 1 year old`() {
+        assertFalse(questType.isApplicableTo(node(
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours" to RelativeDate(-420f).date.toCheckDateString(),
+                "check_date:opening_hours:signed" to RelativeDate(-180f).date.toCheckDateString()
+            ),
+            timestamp = RelativeDate(-365f).date.toCheckDateString().toCheckDate()?.toEpochMilli()
+        )))
+    }
+
+    @Test fun `isApplicableTo returns false if the opening hours check date is older than 1 year, while they are not signed and no signed check date exists`() {
+        assertFalse(questType.isApplicableTo(node(
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours" to RelativeDate(-420f).date.toCheckDateString(),
+            ),
+            timestamp = RelativeDate(-365f).date.toCheckDateString().toCheckDate()?.toEpochMilli()
+        )))
+    }
+
+    @Test fun `isApplicableTo returns true if the last edit is older than 1 year and no check dates exists`() {
+        assertTrue(questType.isApplicableTo(node(
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours:signed" to "no"
+            ),
+            timestamp = RelativeDate(-420f).date.toCheckDateString().toCheckDate()?.toEpochMilli()
+        )))
+    }
+
     @Test fun `isApplicableTo returns true if the opening hours are not signed and signed check date is older than 1 year`() {
         assertTrue(questType.isApplicableTo(node(
             tags = mapOf(

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
@@ -32,7 +32,7 @@ class CheckOpeningHoursSignedTest {
     @Test fun `is applicable to place with old check_date`() {
         assertTrue(questType.isApplicableTo(node(tags = mapOf(
             "name" to "XYZ",
-            "check_date:opening_hours" to "2020-12-12",
+            "check_date:opening_hours:signed" to "2020-12-12",
             "opening_hours:signed" to "no"
         ))))
     }
@@ -40,7 +40,7 @@ class CheckOpeningHoursSignedTest {
     @Test fun `is not applicable to place with new check_date`() {
         assertFalse(questType.isApplicableTo(node(tags = mapOf(
             "name" to "XYZ",
-            "check_date:opening_hours" to nowAsCheckDateString(),
+            "check_date:opening_hours:signed" to nowAsCheckDateString(),
             "opening_hours:signed" to "no"
         ))))
     }
@@ -109,13 +109,17 @@ class CheckOpeningHoursSignedTest {
 
     @Test fun `apply yes answer with prior check date and existing opening hours`() {
         assertEquals(
-            setOf(StringMapEntryDelete("opening_hours:signed", "no")),
+            setOf(
+                StringMapEntryDelete("opening_hours:signed", "no"),
+                StringMapEntryDelete("check_date:opening_hours:signed", "2020-03-04"),
+                StringMapEntryAdd("check_date:opening_hours", "1970-01-01")
+            ),
             questType.answerAppliedTo(
                 true,
                 mapOf(
                     "opening_hours" to "\"oh\"",
                     "opening_hours:signed" to "no",
-                    "check_date:opening_hours" to "2020-03-04"
+                    "check_date:opening_hours:signed" to "2020-03-04"
                 ),
             )
         )
@@ -125,7 +129,7 @@ class CheckOpeningHoursSignedTest {
         assertEquals(
             setOf(
                 StringMapEntryModify("opening_hours:signed", "no", "no"),
-                StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString()),
+                StringMapEntryAdd("check_date:opening_hours:signed", nowAsCheckDateString()),
             ),
             questType.answerAppliedTo(
                 false,
@@ -138,13 +142,13 @@ class CheckOpeningHoursSignedTest {
         assertEquals(
             setOf(
                 StringMapEntryModify("opening_hours:signed", "no", "no"),
-                StringMapEntryModify("check_date:opening_hours", "2020-03-04", nowAsCheckDateString()),
+                StringMapEntryModify("check_date:opening_hours:signed", "2020-03-04", nowAsCheckDateString()),
             ),
             questType.answerAppliedTo(
                 false,
                 mapOf(
                     "opening_hours:signed" to "no",
-                    "check_date:opening_hours" to "2020-03-04"
+                    "check_date:opening_hours:signed" to "2020-03-04"
                 )
             )
         )
@@ -154,7 +158,7 @@ class CheckOpeningHoursSignedTest {
         assertEquals(
             setOf(
                 StringMapEntryModify("opening_hours:signed", "no", "no"),
-                StringMapEntryAdd("check_date:opening_hours", nowAsCheckDateString()),
+                StringMapEntryAdd("check_date:opening_hours:signed", nowAsCheckDateString()),
             ),
             questType.answerAppliedTo(
                 false,
@@ -170,14 +174,14 @@ class CheckOpeningHoursSignedTest {
         assertEquals(
             setOf(
                 StringMapEntryModify("opening_hours:signed", "no", "no"),
-                StringMapEntryModify("check_date:opening_hours", "2020-03-04", nowAsCheckDateString()),
+                StringMapEntryModify("check_date:opening_hours:signed", "2020-03-04", nowAsCheckDateString()),
             ),
             questType.answerAppliedTo(
                 false,
                 mapOf(
                     "opening_hours" to "Mo 10:00-12:00",
                     "opening_hours:signed" to "no",
-                    "check_date:opening_hours" to "2020-03-04"
+                    "check_date:opening_hours:signed" to "2020-03-04"
                 )
             )
         )

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
@@ -4,9 +4,11 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.osm.nowAsCheckDateString
+import de.westnordost.streetcomplete.osm.toCheckDate
 import de.westnordost.streetcomplete.quests.answerAppliedTo
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.util.ktx.toEpochMilli
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -66,6 +68,16 @@ class CheckOpeningHoursSignedTest {
             "opening_hours" to "Mo 10:00-12:00",
             "opening_hours:signed" to "yes"
         ))))
+    }
+    @Test fun `is applicable if the opening hours not signed and only check date for OH exists`() {
+        assertTrue(questType.isApplicableTo(node(
+            tags = mapOf(
+                "name" to "rundumdieuhr kiosk",
+                "opening_hours:signed" to "no",
+                "check_date:opening_hours" to "2021-03-01"
+            ),
+            timestamp = "2000-11-11".toCheckDate()?.toEpochMilli()
+        )))
     }
 
     @Test fun `apply yes answer with no prior check date`() {

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSignedTest.kt
@@ -75,8 +75,7 @@ class CheckOpeningHoursSignedTest {
                 "name" to "rundumdieuhr kiosk",
                 "opening_hours:signed" to "no",
                 "check_date:opening_hours" to "2021-03-01"
-            ),
-            timestamp = "2000-11-11".toCheckDate()?.toEpochMilli()
+            )
         )))
     }
 


### PR DESCRIPTION
Resolves #4273, ref #4276.

Is this, what we were looking for?

If the answer is that `opening_hours:signed=no` (either from quest/opening_hours or quest/opening_hours_signed) we add `check_date:opening_hours:signed`.

If the answer is that `opening_hours:signed=yes` (either from quest/opening_hours or quest/opening_hours_signed), that means `opening_hours:signed` is removed and `opening_hours=*` are set, we remove `check_date:opening_hours:signed` and try to set `check_date:opening_hours` to the last edit timestamp so that the apply check for opening_hours works.

quest/opening_hours_signed checks for this info being older than a year OR the element being last edited over a year.

quest/opening_hours now either filters for `opening_hours:signed != no` OR (`opening_hours:signed = no` AND `check_date:opening_hours:signed` older than 1 year)

Testing with applicable objects, the behaviour seems to be programmatically correct, yet, I am unable to formulate the Tests correctly, I might need help in understading how these work. I have thrown away my changes in the tests and will work on them again later -> WIP PR.

Also, please provide feedback on the setting/removing/interpretation of the various check dates.