### PR TITLE
Patch ref:FR:SIRET, ref:FR:SIREN and ref:FR:NAF when changing place

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -284,6 +284,7 @@ private val KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED = listOf(
     "name_?[1-9]?(:.*)?", ".*_name_?[1-9]?(:.*)?", "noname", "branch(:.*)?", "brand(:.*)?",
     "not:brand(:.*)?", "network(:wikidata)?", "operator(:.*)?", "operator_type", "ref",
     "ref:vatin", "designation", "SEP:CLAVEESC", "identifier", "ref:FR:SIRET", "ref:FR:SIREN",
+    "ref:FR:NAF",
     // contacts
     "contact_person", "contact(:.*)?", "phone(:.*)?", "phone_?[1-9]?", "emergency:phone",
     "emergency_telephone_code",

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -283,7 +283,7 @@ private val KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED = listOf(
     // names and identifications
     "name_?[1-9]?(:.*)?", ".*_name_?[1-9]?(:.*)?", "noname", "branch(:.*)?", "brand(:.*)?",
     "not:brand(:.*)?", "network(:wikidata)?", "operator(:.*)?", "operator_type", "ref",
-    "ref:vatin", "designation", "SEP:CLAVEESC", "identifier",
+    "ref:vatin", "designation", "SEP:CLAVEESC", "identifier", "ref:FR:SIRET", "ref:FR:SIREN",
     // contacts
     "contact_person", "contact(:.*)?", "phone(:.*)?", "phone_?[1-9]?", "emergency:phone",
     "emergency_telephone_code",


### PR DESCRIPTION
Currently, changing a place using the overlay removes most of old tags that no longer apply to the new place, such as opening_hours, brand, and many more. The same should apply to the french SIRET, SIRENE and NAF codes, as discussed [here](https://forum.openstreetmap.fr/t/attention-au-layer-lieux-sur-streetcomplete/27288) (in french).

https://en.wikipedia.org/wiki/SIRET_code
https://en.wikipedia.org/wiki/SIREN_code
https://wiki.openstreetmap.org/wiki/Key:ref:FR:NAF

This patch addresses the situation