### PR TITLE
Remove "bridge" from height limit texts, as pipelines and roofs will now appear as well

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1143,9 +1143,9 @@ If any lanes are reserved for buses, please leave a note instead."</string>
     <string name="quest_lit_title">"Is it lit here?"</string>
 
     <string name="quest_maxheight_title">"What’s the height limit here?"</string>
-    <string name="quest_maxheight_below_bridge_title">What’s the height limit below the bridge?</string>
+    <string name="quest_maxheight_below_bridge_title">What height limit is indicated here?</string>
     <string name="quest_maxheight_sign_title">"What height limit is indicated here?"</string>
-    <string name="quest_maxheight_sign_below_bridge_title">What height limit is indicated below the bridge?</string>
+    <string name="quest_maxheight_sign_below_bridge_title">What height limit is indicated here?</string>
     <string name="quest_maxheight_answer_noSign">There is no sign…</string>
     <string name="quest_maxheight_split_way_hint">If it doesn’t apply for the whole way, consider answering “%s”.</string>
     <string name="quest_maxheight_unusualInput_confirmation_description">This height looks implausible. Are you sure that it is correct?</string>


### PR DESCRIPTION
Additional fix for #5912