### PR TITLE
Docs: suggest reducing image size for new quests

### DIFF
--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -466,6 +466,8 @@ The [rescaling script](https://github.com/matkoniecz/rescaling_for_android) may 
 
 Please make sure that the images do not take too much disk space. On StretComplete images, JPEG quality of 60% usually looks exactly the same as 80% (or 90%) while being noticeably smaller, and sometimes reducing it down to even 20% will not degrade quality visibly! Play with settings to see which is the smallest size which does not degrade image quality visibly.
 
+There are online tools like [squoosh](https://squoosh.app/) which allow for quick visual comparison if you prefer that.
+
 After adding a photo, remember to update [the credits file](app/src/main/res/authors.txt) (different to the one for icons).
 
 ## Resurvey

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -336,7 +336,7 @@ Keep similar style to existing ones and the app in general. Note that the backgr
 
 Once the quest icon is ready:
 
-- when using Inkscape, save as "Optimized SVG" to remove unnecessary cruft or use another tool for that, like [svgo](https://github.com/svg/svgo)
+- when using Inkscape, save as "Optimized SVG" to remove unnecessary cruft or use another tool for that, like [svgo](https://github.com/svg/svgo) or online [SVGOMG](https://svgomg.net/)
 - Put SVG into [`res/graphics/quest`](res/graphics/quest) folder
   - SVG is a standard format editable in various software, unlike internal Android Studio XML that will be produced in the next steps.
 - Open Android Studio

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -464,7 +464,7 @@ Each of these folders should hold the same image resized to a different resoluti
 
 The [rescaling script](https://github.com/matkoniecz/rescaling_for_android) may be useful, but you can also do this manually with Gimp or similar software.
 
-Please make sure that the images do not take too much disk space. Most useful way to do that is by lowering JPEG quality, which can make images noticeably smaller. Useful range is usually between 20% and 85%. Play with settings to see which is the smallest size which does not degrade image quality visibly.
+Please make sure that the images do not take too much disk space. Most useful way to do that is by lowering JPEG quality, which can make images noticeably smaller. Play with settings to see which is the smallest size which does not degrade image quality visibly.
 
 [GIMP](https://gimp.org/) allows such previews while saving JPG files, and there are also online tools like [squoosh](https://squoosh.app/) which allow for quick visual comparison if you prefer that.
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -464,7 +464,7 @@ Each of these folders should hold the same image resized to a different resoluti
 
 The [rescaling script](https://github.com/matkoniecz/rescaling_for_android) may be useful, but you can also do this manually with Gimp or similar software.
 
-Please make sure that the images do not take too much disk space. On StretComplete images, JPEG quality of 60% usually looks exactly the same as 80% (or 90%) while being noticeably smaller, and sometimes reducing it down to even 20% will not degrade quality visibly! Play with settings to see which is the smallest size which does not degrade image quality visibly.
+Please make sure that the images do not take too much disk space. Most useful way to do that is by lowering JPEG quality, which can make images noticeably smaller. Useful range is usually between 20% and 85%. Play with settings to see which is the smallest size which does not degrade image quality visibly.
 
 There are online tools like [squoosh](https://squoosh.app/) which allow for quick visual comparison if you prefer that.
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -466,7 +466,7 @@ The [rescaling script](https://github.com/matkoniecz/rescaling_for_android) may 
 
 Please make sure that the images do not take too much disk space. Most useful way to do that is by lowering JPEG quality, which can make images noticeably smaller. Useful range is usually between 20% and 85%. Play with settings to see which is the smallest size which does not degrade image quality visibly.
 
-There are online tools like [squoosh](https://squoosh.app/) which allow for quick visual comparison if you prefer that.
+[GIMP](https://gimp.org/) allows such previews while saving JPG files, and there are also online tools like [squoosh](https://squoosh.app/) which allow for quick visual comparison if you prefer that.
 
 After adding a photo, remember to update [the credits file](app/src/main/res/authors.txt) (different to the one for icons).
 

--- a/CONTRIBUTING_A_NEW_QUEST.md
+++ b/CONTRIBUTING_A_NEW_QUEST.md
@@ -464,6 +464,8 @@ Each of these folders should hold the same image resized to a different resoluti
 
 The [rescaling script](https://github.com/matkoniecz/rescaling_for_android) may be useful, but you can also do this manually with Gimp or similar software.
 
+Please make sure that the images do not take too much disk space. On StretComplete images, JPEG quality of 60% usually looks exactly the same as 80% (or 90%) while being noticeably smaller, and sometimes reducing it down to even 20% will not degrade quality visibly! Play with settings to see which is the smallest size which does not degrade image quality visibly.
+
 After adding a photo, remember to update [the credits file](app/src/main/res/authors.txt) (different to the one for icons).
 
 ## Resurvey


### PR DESCRIPTION
In SCEE discussion it has been found out that image sizes can be reduced significantly (e.g. from `21k` down to `6.7k` [without noticeable loss of quality](https://github.com/Helium314/SCEE/pull/644#issuecomment-2341964292)!)

As the app size increases noticeably with time[^1], it has even been [suggested](https://github.com/Helium314/SCEE/pull/644#issuecomment-2341964292) to check whether the size of already existing images can be reduced (without visual quality loss) too?


[^1]:  e.g. `59.1` is 70 MB, while not so very far ago `38.2` just was 47 MB