### PR TITLE
be more aggressive in removing keys associated with surface when surface is added or changed

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreator.kt
@@ -1,7 +1,6 @@
 package de.westnordost.streetcomplete.osm.surface
 
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.removeCheckDatesForKey
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 /** Apply the surface and note to the given [tags], with optional [prefix], e.g. "footway" for
@@ -16,15 +15,9 @@ fun SurfaceAndNote.applyTo(tags: Tags, prefix: String? = null, updateCheckDate: 
     val key = "${pre}surface"
     val previousOsmValue = tags[key]
 
-    val shouldRemoveTracktype = prefix == null && isSurfaceAndTracktypeConflicting(osmValue, tags["tracktype"])
-    if (shouldRemoveTracktype) {
-        tags.remove("tracktype")
-        tags.removeCheckDatesForKey("tracktype")
-    }
-
-    // remove smoothness (etc) tags if surface was changed
-    // or surface can be treated as outdated
-    if ((previousOsmValue != null && previousOsmValue != osmValue) || shouldRemoveTracktype) {
+    // remove smoothness, tracktype (etc), i.e. tags that are (potentially) associated with a given
+    // surface type, as they can potentially be incorrect now that the surface changed (see #5951)
+    if (previousOsmValue != osmValue) {
         getKeysAssociatedWithSurface(pre).forEach { tags.remove(it) }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/surface/SurfaceUtils.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/surface/SurfaceUtils.kt
@@ -109,6 +109,8 @@ fun getKeysAssociatedWithSurface(prefix: String = ""): Set<String> =
         "${prefix}smoothness",
         "${prefix}smoothness:date",
         "source:${prefix}smoothness",
+        "${prefix}tracktype", // it's at least *potentially* associated, see #5951
+        "source:${prefix}tracktype",
         "${prefix}paving_stones:shape",
         "${prefix}paving_stones:pattern",
         "${prefix}paving_stones:length",

--- a/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/osm/surface/SurfaceCreatorKtTest.kt
@@ -45,42 +45,6 @@ class SurfaceCreatorKtTest {
         )
     }
 
-    @Test fun `remove mismatching tracktype`() {
-        assertEquals(
-            setOf(
-                StringMapEntryAdd("surface", "asphalt"),
-                StringMapEntryDelete("tracktype", "grade5"),
-                StringMapEntryDelete("check_date:tracktype", "2011-11-11"),
-            ),
-            SurfaceAndNote(Surface.ASPHALT).appliedTo(mapOf(
-                "tracktype" to "grade5",
-                "check_date:tracktype" to "2011-11-11"
-            ))
-        )
-    }
-
-    @Test fun `remove mismatching tracktype not done with prefix`() {
-        assertEquals(
-            setOf(StringMapEntryAdd("footway:surface", "asphalt")),
-            SurfaceAndNote(Surface.ASPHALT).appliedTo(mapOf(
-                "tracktype" to "grade5",
-                "check_date:tracktype" to "2011-11-11"
-            ), "footway")
-        )
-    }
-
-    @Test fun `keep matching tracktype`() {
-        assertEquals(
-            setOf(
-                StringMapEntryAdd("surface", "asphalt")
-            ),
-            SurfaceAndNote(Surface.ASPHALT).appliedTo(mapOf(
-                "highway" to "residential",
-                "tracktype" to "grade1"
-            ))
-        )
-    }
-
     @Test fun `remove associated tags when surface changed`() {
         assertEquals(
             setOf(


### PR DESCRIPTION
fixes #5951

Whenever `surface` is changed or added, keys potentially associated with `surface` are removed, e.g. `smoothness` or `tracktype`.

- Before, `tracktype` was only removed when it conflicted with the newly set `surface` value.
- Before, keys were only removed if the `surface` was **changed**, now they are also removed if the `surface` was **added** (e.g. road with `tracktype=grade3` is removed when `surface=dirt` is added)

Reasons for the change in behavior was stated in #5951, in a nutshell:

When answering the smoothness quest, one can answer that the displayed surface is incorrect. This removes the `surface` tag.
The surface quest will pop up and ask about the surface. Now, when specifying any surface, a previously set `tracktype` will not be removed because 1. `surface` is now "new" and 2. `tracktype` is only removed if it conflicts with the new `surface`, regardless of the `smoothness` value.