### PR TITLE
handle 410 error code for now gone elements

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
@@ -64,7 +64,9 @@ class MapDataApiClient(
                 HttpStatusCode.Conflict,
                 // an element referred to by another element does not exist (anymore) or was redacted
                 HttpStatusCode.PreconditionFailed,
-                // some elements do not exist (anymore)
+                // some elements do not exist anymore as it was deleted
+                HttpStatusCode.Gone,
+                // some elements do not exist and never existed
                 HttpStatusCode.NotFound -> {
                     throw ConflictException(e.message, e)
                 }


### PR DESCRIPTION
fixes #6060

note: if wiki documentation is to be believed, HttpStatusCode.NotFound should never ever be triggered by SC

should we handle it this way?

Note: this code is untested