### PR TITLE
remove not only $key, but also source:$key and check_date:$key

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -249,7 +249,7 @@ fun StringMapChangesBuilder.replacePlace(tags: Map<String, String>) {
     removeCheckDates()
 
     for (key in keys) {
-        if (KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.any { it.matches(key) }) {
+        if (KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.any { it.matches(key) || it.matches("source:" + key) }) {
             remove(key)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -248,9 +248,9 @@ val POPULAR_PLACE_FEATURE_IDS = listOf(
 fun StringMapChangesBuilder.replacePlace(tags: Map<String, String>) {
     removeCheckDates()
 
-    private val REMOVABLE_KEYS = KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED +
-                                 KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "source:$it" } +
-                                 KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "check_date:$it" }
+    val REMOVABLE_KEYS = KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED +
+                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "source:$it" } +
+                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "check_date:$it" }
 
     for (key in keys) {
         if (REMOVABLE_KEYS.any { it.matches(key) }) {

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -248,8 +248,12 @@ val POPULAR_PLACE_FEATURE_IDS = listOf(
 fun StringMapChangesBuilder.replacePlace(tags: Map<String, String>) {
     removeCheckDates()
 
+    private val REMOVABLE_KEYS = KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED +
+                                 KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "source:$it" } +
+                                 KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "check_date:$it" }
+
     for (key in keys) {
-        if (KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.any { it.matches(key) || it.matches("source:" + key) }) {
+        if (REMOVABLE_KEYS.any { it.matches(key) }) {
             remove(key)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/osm/Place.kt
@@ -249,8 +249,8 @@ fun StringMapChangesBuilder.replacePlace(tags: Map<String, String>) {
     removeCheckDates()
 
     val REMOVABLE_KEYS = KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED +
-                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "source:$it" } +
-                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "check_date:$it" }
+                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "source:$it".toRegex() } +
+                         KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED.map { "check_date:$it".toRegex() }
 
     for (key in keys) {
         if (REMOVABLE_KEYS.any { it.matches(key) }) {


### PR DESCRIPTION
when trimming keys in `KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED`, remove not only every `$key` that matches, but also every `source:$key` and `check_date:$key` that matches too. 

Rationale being that if we are removing no longer relevant key, we should remove its metadata too (e.g. from where it initially came, and when it was last verified).

- Fixes https://github.com/streetcomplete/StreetComplete/issues/6057
- Fixes https://github.com/mnalis/StreetComplete-taginfo-categorize/issues/30

Tested with [debug apk ](https://github.com/mnalis/StreetComplete/actions/runs/12554714035) on e.g. https://www.openstreetmap.org/node/832042729 which has `source:opening_hours` and which regular SC does not remove...

(it also adds `--info` to `gradlew test` invocation in GitHub action, to report reason in case of test failure - which I needed and think is useful all around when we run tests)