### PR TITLE
Allow developers to use Test-API

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -84,6 +84,9 @@ object ApplicationConstants {
     During development it might be better to work against the Test-API, rather than the
     Live-API. Developers are reminded that they need a separate login for the Test-API and
     can register/logon via https://master.apis.dev.openstreetmap.org/
+    Note that test actions not applied to the database do not require test API (test edits that are reverted
+    locally before an upload etc) and that test API has a separate database that is mostly empty
+    (test data needs to be created there).
      */
     const val USE_TEST_API = false
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -79,4 +79,11 @@ object ApplicationConstants {
            locally for performance reasons */
         SplitWayAction::class
     )
+
+    /*
+    During development it might be better to work against the Test-API, rather than the
+    Live-API. Developers are reminded that they need a separate login for the Test-API and
+    can register/logon via https://master.apis.dev.openstreetmap.org/
+     */
+    const val USE_TEST_API = false
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
@@ -16,13 +16,13 @@ import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
-private var OSM_API_URL = "https://api.openstreetmap.org/api/0.6/"
+private const val OSM_API_URL_LIVE = "https://api.openstreetmap.org/api/0.6/"
+private const val OSM_API_URL_TEST = "https://master.apis.dev.openstreetmap.org/api/0.6/"
+
+val OSM_API_URL =
+    if (USE_TEST_API) OSM_API_URL_TEST else OSM_API_URL_LIVE
 
 val osmApiModule = module {
-
-    if (USE_TEST_API) {
-        OSM_API_URL = "https://master.apis.dev.openstreetmap.org/api/0.6/"
-    }
 
     factory { Cleaner(get(), get(), get(), get(), get(), get()) }
     factory { CacheTrimmer(get(), get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data
 
+import de.westnordost.streetcomplete.ApplicationConstants.USE_TEST_API
 import de.westnordost.streetcomplete.data.osm.edits.upload.changesets.ChangesetApiClient
 import de.westnordost.streetcomplete.data.osm.edits.upload.changesets.ChangesetApiSerializer
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApiClient
@@ -15,9 +16,14 @@ import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
-private const val OSM_API_URL = "https://api.openstreetmap.org/api/0.6/"
+private var OSM_API_URL = "https://api.openstreetmap.org/api/0.6/"
 
 val osmApiModule = module {
+
+    if (USE_TEST_API) {
+        OSM_API_URL = "https://master.apis.dev.openstreetmap.org/api/0.6/"
+    }
+
     factory { Cleaner(get(), get(), get(), get(), get(), get()) }
     factory { CacheTrimmer(get(), get()) }
     factory { MapDataApiClient(get(), OSM_API_URL, get(), get(), get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
@@ -4,10 +4,18 @@ import de.westnordost.streetcomplete.ApplicationConstants.USE_TEST_API
 import de.westnordost.streetcomplete.data.user.oauth.OAuthApiClient
 import org.koin.dsl.module
 
-var OAUTH2_TOKEN_URL = "https://www.openstreetmap.org/oauth2/token"
-var OAUTH2_AUTHORIZATION_URL = "https://www.openstreetmap.org/oauth2/authorize"
+private const val OAUTH2_HOST_LIVE = "https://www.openstreetmap.org/"
+private const val OAUTH2_HOST_TEST = "https://master.apis.dev.openstreetmap.org/"
 
-var OAUTH2_CLIENT_ID = "Yyk4PmTopczrr3BWZYvLK_M-KBloCQwXgPGEzqUYTc8"
+private const val OAUTH2_CLIENT_ID_LIVE = "Yyk4PmTopczrr3BWZYvLK_M-KBloCQwXgPGEzqUYTc8"
+private const val OAUTH2_CLIENT_ID_TEST = "ObZ7yPf4lfs4XJ3NWysI3ukJMN0SHey1oPnNQnLmvw8"
+
+val OAUTH2_TOKEN_URL =
+    (if (USE_TEST_API) OAUTH2_HOST_TEST else OAUTH2_HOST_LIVE) + "oauth2/token"
+val OAUTH2_AUTHORIZATION_URL =
+    (if (USE_TEST_API) OAUTH2_HOST_TEST else OAUTH2_HOST_LIVE) + "oauth2/authorize"
+val OAUTH2_CLIENT_ID =
+    if (USE_TEST_API) OAUTH2_CLIENT_ID_TEST else OAUTH2_CLIENT_ID_LIVE
 
 const val OAUTH2_CALLBACK_SCHEME = "streetcomplete"
 const val OAUTH2_CALLBACK_HOST = "oauth"
@@ -36,13 +44,6 @@ val OAUTH2_REQUIRED_SCOPES = listOf(
 )
 
 val userModule = module {
-
-    if (USE_TEST_API) {
-        OAUTH2_TOKEN_URL = "https://master.apis.dev.openstreetmap.org/oauth2/token"
-        OAUTH2_AUTHORIZATION_URL = "https://master.apis.dev.openstreetmap.org/oauth2/authorize"
-        OAUTH2_CLIENT_ID = "ObZ7yPf4lfs4XJ3NWysI3ukJMN0SHey1oPnNQnLmvw8"
-    }
-
     single<UserDataSource> { get<UserDataController>() }
     single { UserDataController(get()) }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
@@ -1,12 +1,13 @@
 package de.westnordost.streetcomplete.data.user
 
+import de.westnordost.streetcomplete.ApplicationConstants.USE_TEST_API
 import de.westnordost.streetcomplete.data.user.oauth.OAuthApiClient
 import org.koin.dsl.module
 
-const val OAUTH2_TOKEN_URL = "https://www.openstreetmap.org/oauth2/token"
-const val OAUTH2_AUTHORIZATION_URL = "https://www.openstreetmap.org/oauth2/authorize"
+var OAUTH2_TOKEN_URL = "https://www.openstreetmap.org/oauth2/token"
+var OAUTH2_AUTHORIZATION_URL = "https://www.openstreetmap.org/oauth2/authorize"
 
-const val OAUTH2_CLIENT_ID = "Yyk4PmTopczrr3BWZYvLK_M-KBloCQwXgPGEzqUYTc8"
+var OAUTH2_CLIENT_ID = "Yyk4PmTopczrr3BWZYvLK_M-KBloCQwXgPGEzqUYTc8"
 
 const val OAUTH2_CALLBACK_SCHEME = "streetcomplete"
 const val OAUTH2_CALLBACK_HOST = "oauth"
@@ -35,6 +36,12 @@ val OAUTH2_REQUIRED_SCOPES = listOf(
 )
 
 val userModule = module {
+
+    if (USE_TEST_API) {
+        OAUTH2_TOKEN_URL = "https://master.apis.dev.openstreetmap.org/oauth2/token"
+        OAUTH2_AUTHORIZATION_URL = "https://master.apis.dev.openstreetmap.org/oauth2/authorize"
+        OAUTH2_CLIENT_ID = "ObZ7yPf4lfs4XJ3NWysI3ukJMN0SHey1oPnNQnLmvw8"
+    }
 
     single<UserDataSource> { get<UserDataController>() }
     single { UserDataController(get()) }


### PR DESCRIPTION
When developing SC where multiple changes to objects might be neccessary, it might be helpful to not do this sort of updates to an object in the Live Database but rather the Development/Testing one.

This PR creates a boolean application variable which will switch the API the software is working against.

`OAUTH2_CLIENT_ID` is an application registered to my dev-user, this could be changed to anything in @westnordost 's domain.