### PR TITLE
OsmNoteQuestController: Also accept inverted question mark as sole sign of a question

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -231,6 +231,7 @@ private fun Note.probablyContainsQuestion(): Boolean {
      */
     val questionMarksAroundTheWorld = listOf(
         "?", // Latin question mark
+        "¿", // Spanish question mark in case the closing latin one was omitted
         ";", // Greek question mark (a different character than semicolon, though same appearance)
         ";", // semicolon (often used instead of proper greek question mark)
         "؟", // mirrored question mark (used in script written from right to left, like Arabic)


### PR DESCRIPTION
Notes can become quests ("Can you contribute anything to this note?") when they contain any of the `questionMarksAroundTheWorld` in `OsmNoteQuestController`.

This PR adds the inverted question mark (¿) to that list, so that questions that do _not_ have a latin question mark (?) at the end, contrary to the normal use of the inverted question mark, also get displayed when the "Show all notes" settings toggle is set to "Ignoring notes not phrased as questions".

For a list of affected Notes, see #6058

In action (https://www.openstreetmap.org/note/4299211):
![image](https://github.com/user-attachments/assets/f9724251-1305-4675-a978-b5d43746df67)
