### PR TITLE
update dependencies and android target version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,7 +107,7 @@ repositories {
 }
 
 dependencies {
-    val mockitoVersion = "3.12.4"
+    val mockitoVersion = "5.14.2"
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         }
     }
 
-    compileSdk = 34
+    compileSdk = 35
     testOptions {
         unitTests {
             isReturnDefaultValues = true
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId = "de.westnordost.streetcomplete"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 6003
         versionName = "60.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -109,7 +109,7 @@ repositories {
 dependencies {
     val mockitoVersion = "3.12.4"
 
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 
     // tests
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
@@ -122,7 +122,7 @@ dependencies {
     androidTestImplementation(kotlin("test"))
 
     // dependency injection
-    implementation(platform("io.insert-koin:koin-bom:4.0.0"))
+    implementation(platform("io.insert-koin:koin-bom:4.0.1"))
     implementation("io.insert-koin:koin-core")
     implementation("io.insert-koin:koin-android")
     implementation("io.insert-koin:koin-androidx-workmanager")
@@ -130,57 +130,57 @@ dependencies {
 
     // Android stuff
     implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.annotation:annotation:1.9.1")
     implementation("androidx.fragment:fragment-ktx:1.8.5")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
-    implementation("androidx.viewpager:viewpager:1.0.0")
+    implementation("androidx.viewpager:viewpager:1.1.0")
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
 
     // Jetpack Compose
     val composeBom = platform("androidx.compose:compose-bom:2024.10.01")
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
+    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
     implementation("androidx.compose.material:material")
     implementation("androidx.activity:activity-compose")
     // Jetpack Compose Previews
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation("androidx.navigation:navigation-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.5")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
 
     // reorderable lists (raw Compose API is pretty complicated)
-    implementation("sh.calvin.reorderable:reorderable:2.4.0")
+    implementation("sh.calvin.reorderable:reorderable:2.4.2")
 
     // multiplatform webview (for login via OAuth)
-    implementation("io.github.kevinnzou:compose-webview-multiplatform-android:1.9.20")
+    implementation("io.github.kevinnzou:compose-webview-multiplatform-android:1.9.40")
 
     // photos
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 
     // settings
-    implementation("com.russhwolf:multiplatform-settings:1.2.0")
+    implementation("com.russhwolf:multiplatform-settings:1.3.0")
 
     // Kotlin
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.5.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.6.0")
 
     // Date/time
     api("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
 
     // scheduling background jobs
-    implementation("androidx.work:work-runtime-ktx:2.9.1")
+    implementation("androidx.work:work-runtime-ktx:2.10.0")
 
     // HTTP Client
-    implementation("io.ktor:ktor-client-core:2.3.13")
-    implementation("io.ktor:ktor-client-android:2.3.13")
-    testImplementation("io.ktor:ktor-client-mock:2.3.13")
+    implementation("io.ktor:ktor-client-core:3.0.3")
+    implementation("io.ktor:ktor-client-android:3.0.3")
+    testImplementation("io.ktor:ktor-client-mock:3.0.3")
     // TODO: as soon as both ktor-client and kotlinx-serialization have been refactored to be based
     //       on kotlinx-io, revisit sending and receiving xml/json payloads via APIs, currently it
     //       is all String-based, i.e. no KMP equivalent of InputStream/OutputStream involved
@@ -202,11 +202,11 @@ dependencies {
 
     // serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
-    implementation("com.charleskorn.kaml:kaml:0.66.0")
-    implementation("io.github.pdvrieze.xmlutil:core:0.90.2")
+    implementation("com.charleskorn.kaml:kaml:0.67.0")
+    implementation("io.github.pdvrieze.xmlutil:core:0.90.3")
 
     // map and location
-    implementation("org.maplibre.gl:android-sdk:11.6.1")
+    implementation("org.maplibre.gl:android-sdk:11.7.1")
 
     // opening hours parser
     implementation("de.westnordost:osm-opening-hours:0.1.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,8 +141,8 @@ dependencies {
 
     // Jetpack Compose
     val composeBom = platform("androidx.compose:compose-bom:2024.10.01")
-    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
     implementation("androidx.compose.material:material")
     implementation("androidx.activity:activity-compose")
     // Jetpack Compose Previews

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,14 +89,14 @@
         <activity
             android:name="de.westnordost.streetcomplete.screens.about.AboutActivity"
             android:label="@string/action_about2"
-            android:parentActivityName="de.westnordost.streetcomplete.screens.MainActivity"
+            android:parentActivityName="de.westnordost.streetcomplete.screens.main.MainActivity"
             android:configChanges="density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             />
         <activity
             android:name="de.westnordost.streetcomplete.screens.user.UserActivity"
             android:label="@string/user_profile"
             android:windowSoftInputMode="adjustResize"
-            android:parentActivityName="de.westnordost.streetcomplete.screens.MainActivity"
+            android:parentActivityName="de.westnordost.streetcomplete.screens.main.MainActivity"
             android:configChanges="density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             />
         <!-- For WorkManager -->

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -58,7 +58,7 @@ fun AboutScreen(
         )
         Column(modifier = Modifier
             .verticalScroll(rememberScrollState())
-            .windowInsetsPadding(WindowInsets.systemBars.only(
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             ))
         ) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/AboutScreen.kt
@@ -2,9 +2,15 @@ package de.westnordost.streetcomplete.screens.about
 
 import android.content.Context
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -47,9 +53,15 @@ fun AboutScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.action_about2)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
-        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        Column(modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .windowInsetsPadding(WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            ))
+        ) {
 
             PreferenceCategory(null) {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogScreen.kt
@@ -2,11 +2,18 @@ package de.westnordost.streetcomplete.screens.about
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -21,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ui.common.BackIcon
 import de.westnordost.streetcomplete.ui.common.HtmlText
+import de.westnordost.streetcomplete.ui.ktx.plus
 import de.westnordost.streetcomplete.ui.theme.titleLarge
 import de.westnordost.streetcomplete.util.html.HtmlNode
 
@@ -35,13 +43,18 @@ fun ChangelogScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.about_title_changelog)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
         changelog?.let { changelog ->
             SelectionContainer {
+                val insets = WindowInsets.systemBars.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                ).asPaddingValues()
                 ChangelogList(
                     changelog = changelog,
-                    paddingValues = PaddingValues(16.dp)
+                    paddingValues = insets + PaddingValues(16.dp),
+                    modifier = Modifier.consumeWindowInsets(insets)
                 )
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/ChangelogScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -48,7 +48,7 @@ fun ChangelogScreen(
         )
         changelog?.let { changelog ->
             SelectionContainer {
-                val insets = WindowInsets.systemBars.only(
+                val insets = WindowInsets.safeDrawing.only(
                     WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
                 ).asPaddingValues()
                 ChangelogList(
@@ -76,7 +76,10 @@ fun ChangelogList(
             key = { index, _ -> index }
         ) { index, (version, html) ->
             if (index > 0) Divider(modifier = Modifier.padding(vertical = 16.dp))
-            Text(text = version, style = MaterialTheme.typography.titleLarge)
+            Text(
+                text = version,
+                style = MaterialTheme.typography.titleLarge
+            )
             HtmlText(
                 html = html,
                 style = MaterialTheme.typography.body2,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/CreditsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/CreditsScreen.kt
@@ -3,13 +3,19 @@ package de.westnordost.streetcomplete.screens.about
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
@@ -42,6 +48,7 @@ fun CreditsScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.about_title_authors)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
         credits?.let { credits ->
@@ -51,6 +58,9 @@ fun CreditsScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .verticalScroll(rememberScrollState())
+                        .windowInsetsPadding(WindowInsets.systemBars.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                        ))
                         .padding(16.dp)
                 )
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/CreditsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/CreditsScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -58,7 +58,7 @@ fun CreditsScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .verticalScroll(rememberScrollState())
-                        .windowInsetsPadding(WindowInsets.systemBars.only(
+                        .windowInsetsPadding(WindowInsets.safeDrawing.only(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
                         ))
                         .padding(16.dp)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/PrivacyStatementScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/PrivacyStatementScreen.kt
@@ -1,12 +1,18 @@
 package de.westnordost.streetcomplete.screens.about
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -28,6 +34,7 @@ fun PrivacyStatementScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.about_title_privacy_statement)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
         SelectionContainer {
@@ -40,6 +47,9 @@ fun PrivacyStatementScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
+                    .windowInsetsPadding(WindowInsets.systemBars.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                    ))
                     .padding(16.dp),
                 style = MaterialTheme.typography.body2,
             )

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/PrivacyStatementScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/PrivacyStatementScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -47,7 +47,7 @@ fun PrivacyStatementScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
-                    .windowInsetsPadding(WindowInsets.systemBars.only(
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(
                         WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
                     ))
                     .padding(16.dp),

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/logs/LogsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/logs/LogsScreen.kt
@@ -5,13 +5,20 @@ import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -61,6 +68,7 @@ fun LogsScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.about_title_logs, logs.size)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
             actions = {
                 IconButton(onClick = { showFiltersDialog = true }) {
@@ -86,7 +94,14 @@ fun LogsScreen(
         if (logs.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
-            LazyColumn(state = listState) {
+            val insets = WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            ).asPaddingValues()
+            LazyColumn(
+                state = listState,
+                contentPadding = insets,
+                modifier = Modifier.consumeWindowInsets(insets)
+            ) {
                 itemsIndexed(logs) { index, item ->
                     if (index > 0) Divider()
                     LogsRow(item, modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/about/logs/LogsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/about/logs/LogsScreen.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -94,7 +94,7 @@ fun LogsScreen(
         if (logs.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
-            val insets = WindowInsets.systemBars.only(
+            val insets = WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             ).asPaddingValues()
             LazyColumn(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -201,8 +201,7 @@ class MainActivity :
     //region Lifecycle - Android Lifecycle Callbacks
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val systemBarStyle = SystemBarStyle.dark(Color.argb(0x80, 0x1b, 0x1b, 0x1b))
-        enableEdgeToEdge(systemBarStyle, systemBarStyle)
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         LocalBroadcastManager.getInstance(this).registerReceiver(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
@@ -217,7 +217,7 @@ fun MainScreen(
 
         Column(Modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .onGloballyPositioned { pointerPinRects["frame"] = it.boundsInRoot() }
         ) {
             Box(Modifier
@@ -286,7 +286,8 @@ fun MainScreen(
                         .align(Alignment.BottomEnd)
                         .padding(4.dp)
                         .onGloballyPositioned { pointerPinRects["bottom-end"] = it.boundsInRoot() },
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.End,
                 ) {
                     val isCompassVisible = abs(mapRotation) >= 1.0 || abs(mapTilt) >= 1.0
                     AnimatedVisibility(
@@ -323,6 +324,7 @@ fun MainScreen(
                         },
                         modifier = Modifier
                             .align(BiasAlignment(0.333f, 1f))
+                            .onGloballyPositioned { pointerPinRects["create-node"] = it.boundsInRoot() }
                             .padding(4.dp),
                         colors = ButtonDefaults.buttonColors(
                             backgroundColor = MaterialTheme.colors.secondaryVariant,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/EditHistorySidebar.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/edithistory/EditHistorySidebar.kt
@@ -6,15 +6,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -44,6 +47,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.edithistory.Edit
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.ui.ktx.isItemAtIndexFullyVisible
+import de.westnordost.streetcomplete.ui.ktx.plus
 import de.westnordost.streetcomplete.ui.theme.titleSmall
 import de.westnordost.streetcomplete.util.ktx.toast
 import kotlinx.coroutines.launch
@@ -67,9 +71,6 @@ fun EditHistorySidebar(
     val scope = rememberCoroutineScope()
 
     val context = LocalContext.current
-    val dir = LocalLayoutDirection.current
-
-    val insets = WindowInsets.safeDrawing.asPaddingValues()
 
     var showUndoDialog by remember { mutableStateOf(false) }
     var editElement by remember { mutableStateOf<Element?>(null) }
@@ -105,28 +106,25 @@ fun EditHistorySidebar(
         }
     }
 
-    // take care of insets:
-    // vertical offset as lazy column content padding, left padding as padding of the surface
     Surface(
         modifier = modifier
-            .padding(end = insets.calculateEndPadding(dir))
             .fillMaxHeight()
-            .consumeWindowInsets(insets)
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.End))
             .shadow(16.dp),
         // not using surface's elevation here because we don't want it to change its background
         // color to gray in dark mode
     ) {
+        val verticalInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Vertical)
         LazyColumn(
             modifier = Modifier
-                .padding(start = insets.calculateStartPadding(dir))
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Start))
+                .consumeWindowInsets(verticalInsets)
                 .width(80.dp),
             state = state,
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Bottom,
-            contentPadding = PaddingValues(
-                top = insets.calculateTopPadding(),
-                bottom = insets.calculateBottomPadding() + 24.dp // to align with undo button
-            )
+            // bottom 24 dp to align with undo button
+            contentPadding = verticalInsets.asPaddingValues() + PaddingValues(bottom = 24.dp)
         ) {
             items(
                 items = editItems,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -84,7 +84,7 @@ fun SettingsScreen(
         )
         Column(Modifier
             .verticalScroll(rememberScrollState())
-            .windowInsetsPadding(WindowInsets.systemBars.only(
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             ))
         ) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
@@ -3,9 +3,15 @@ package de.westnordost.streetcomplete.screens.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Switch
@@ -73,9 +79,15 @@ fun SettingsScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.action_settings)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
-        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        Column(Modifier
+            .verticalScroll(rememberScrollState())
+            .windowInsetsPadding(WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            ))
+        ) {
             PreferenceCategory(stringResource(R.string.pref_category_quests)) {
 
                 Preference(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
@@ -4,11 +4,18 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.AppBarDefaults
@@ -62,9 +69,14 @@ fun ShowQuestFormsScreen(
         if (filteredQuests.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
+            val insets = WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            ).asPaddingValues()
             QuestList(
                 items = filteredQuests,
-                onClickQuestType = onClickQuestType
+                onClickQuestType = onClickQuestType,
+                contentPadding = insets,
+                modifier = Modifier.consumeWindowInsets(insets)
             )
         }
     }
@@ -92,6 +104,7 @@ private fun ShowQuestFormsTopAppBar(
         Column {
             TopAppBar(
                 title = { Text("Show Quest Forms") },
+                windowInsets = AppBarDefaults.topAppBarWindowInsets,
                 navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
                 actions = { IconButton(onClick = { setShowSearch(!showSearch) }) { SearchIcon() } },
                 elevation = 0.dp
@@ -118,8 +131,12 @@ private fun QuestList(
     items: List<QuestType>,
     onClickQuestType: (QuestType) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
-    LazyColumn(modifier) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = contentPadding,
+    ) {
         itemsIndexed(items, key = { _, it -> it.name }) { index, item ->
             Column(Modifier.clickable { onClickQuestType(item) }) {
                 if (index > 0) Divider()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.AppBarDefaults
@@ -69,7 +69,7 @@ fun ShowQuestFormsScreen(
         if (filteredQuests.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
-            val insets = WindowInsets.systemBars.only(
+            val insets = WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             ).asPaddingValues()
             QuestList(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_presets/QuestPresetsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_presets/QuestPresetsScreen.kt
@@ -2,13 +2,22 @@ package de.westnordost.streetcomplete.screens.settings.quest_presets
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -42,13 +51,26 @@ import de.westnordost.streetcomplete.ui.theme.titleMedium
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.action_manage_presets)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
-        Box(Modifier.fillMaxHeight()) {
-            QuestPresetsList(viewModel)
+        val insets = WindowInsets.systemBars.only(
+            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+        ).asPaddingValues()
+        Box(Modifier
+            .fillMaxHeight()
+            .consumeWindowInsets(insets)
+        ) {
+            QuestPresetsList(
+                viewModel = viewModel,
+                contentPadding = insets,
+            )
             FloatingActionButton(
                 onClick = { showAddDialog = true },
-                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+                    .padding(insets)
             ) {
                 Icon(
                     painter = painterResource(R.drawable.ic_add_24dp),
@@ -69,12 +91,18 @@ import de.westnordost.streetcomplete.ui.theme.titleMedium
 }
 
 @Composable
-private fun QuestPresetsList(viewModel: QuestPresetsViewModel) {
+private fun QuestPresetsList(
+    viewModel: QuestPresetsViewModel,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp)
+) {
     val presets by viewModel.presets.collectAsState()
 
-    Column {
+    Column(modifier) {
         QuestPresetsHeader()
-        LazyColumn {
+        LazyColumn(
+            contentPadding = contentPadding,
+        ) {
             itemsIndexed(presets, key = { _, it -> it.id }) { index, item ->
                 Column {
                     if (index > 0) Divider()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_presets/QuestPresetsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_presets/QuestPresetsScreen.kt
@@ -7,14 +7,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.AppBarDefaults
@@ -33,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -54,7 +56,7 @@ import de.westnordost.streetcomplete.ui.theme.titleMedium
             windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
-        val insets = WindowInsets.systemBars.only(
+        val insets = WindowInsets.safeDrawing.only(
             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
         ).asPaddingValues()
         Box(Modifier
@@ -99,9 +101,18 @@ private fun QuestPresetsList(
     val presets by viewModel.presets.collectAsState()
 
     Column(modifier) {
-        QuestPresetsHeader()
+        val layoutDirection = LocalLayoutDirection.current
+        QuestPresetsHeader(Modifier.padding(
+            start = contentPadding.calculateStartPadding(layoutDirection),
+            top = contentPadding.calculateTopPadding(),
+            end = contentPadding.calculateEndPadding(layoutDirection)
+        ))
         LazyColumn(
-            contentPadding = contentPadding,
+            contentPadding = PaddingValues(
+                start = contentPadding.calculateStartPadding(layoutDirection),
+                end = contentPadding.calculateEndPadding(layoutDirection),
+                bottom = contentPadding.calculateBottomPadding()
+            ),
         ) {
             itemsIndexed(presets, key = { _, it -> it.id }) { index, item ->
                 Column {
@@ -122,8 +133,8 @@ private fun QuestPresetsList(
 }
 
 @Composable
-private fun QuestPresetsHeader() {
-    Column {
+private fun QuestPresetsHeader(modifier: Modifier = Modifier) {
+    Column(modifier) {
         Row(
             Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.screens.settings.quest_selection
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -40,6 +41,8 @@ fun QuestSelectionList(
     displayCountry: String,
     onSelectQuest: (questType: QuestType, selected: Boolean) -> Unit,
     onReorderQuest: (questType: QuestType, toAfter: QuestType) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     var showEnableQuestDialog by remember { mutableStateOf<QuestType?>(null) }
 
@@ -64,12 +67,15 @@ fun QuestSelectionList(
         dragItem = null
     }
 
-    Column {
+    Column(modifier) {
         QuestSelectionHeader()
         // TODO Compose: scrollbars would be nice here (not supported yet by compose)
         //      When they are available: Check other places too, don't want to add a todo in every
         //      single place that could have a scrollbar
-        LazyColumn(state = listState) {
+        LazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
             itemsIndexed(reorderableItems, key = { _, it -> it.questType.name }) { index, item ->
                 ReorderableItem(
                     state = dragDropState,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -21,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -68,13 +71,22 @@ fun QuestSelectionList(
     }
 
     Column(modifier) {
-        QuestSelectionHeader()
+        val layoutDirection = LocalLayoutDirection.current
+        QuestSelectionHeader(Modifier.padding(
+            start = contentPadding.calculateStartPadding(layoutDirection),
+            top = contentPadding.calculateTopPadding(),
+            end = contentPadding.calculateEndPadding(layoutDirection)
+        ))
         // TODO Compose: scrollbars would be nice here (not supported yet by compose)
         //      When they are available: Check other places too, don't want to add a todo in every
         //      single place that could have a scrollbar
         LazyColumn(
             state = listState,
-            contentPadding = contentPadding,
+            contentPadding = PaddingValues(
+                start = contentPadding.calculateStartPadding(layoutDirection),
+                end = contentPadding.calculateEndPadding(layoutDirection),
+                bottom = contentPadding.calculateBottomPadding()
+            ),
         ) {
             itemsIndexed(reorderableItems, key = { _, it -> it.questType.name }) { index, item ->
                 ReorderableItem(
@@ -127,8 +139,8 @@ fun QuestSelectionList(
 }
 
 @Composable
-private fun QuestSelectionHeader() {
-    Column {
+private fun QuestSelectionHeader(modifier: Modifier = Modifier) {
+    Column(modifier) {
         Row(
             Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
@@ -61,7 +61,7 @@ fun QuestSelectionScreen(
         if (filteredQuests.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
-            val insets = WindowInsets.systemBars.only(
+            val insets = WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             ).asPaddingValues()
             QuestSelectionList(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionScreen.kt
@@ -1,7 +1,13 @@
 package de.westnordost.streetcomplete.screens.settings.quest_selection
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
@@ -55,6 +61,9 @@ fun QuestSelectionScreen(
         if (filteredQuests.isEmpty()) {
             CenteredLargeTitleHint(stringResource(R.string.no_search_results))
         } else {
+            val insets = WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            ).asPaddingValues()
             QuestSelectionList(
                 items = filteredQuests,
                 displayCountry = displayCountry,
@@ -63,7 +72,9 @@ fun QuestSelectionScreen(
                 },
                 onReorderQuest = { questType, toAfter ->
                     viewModel.orderQuest(questType, toAfter)
-                }
+                },
+                modifier =  Modifier.consumeWindowInsets(insets),
+                contentPadding = insets,
             )
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionTopAppBar.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionTopAppBar.kt
@@ -57,6 +57,7 @@ import de.westnordost.streetcomplete.ui.common.dialogs.ConfirmationDialog
         Column {
             TopAppBar(
                 title = { QuestSelectionTitle(currentPresetName) },
+                windowInsets = AppBarDefaults.topAppBarWindowInsets,
                 navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
                 actions = {
                     QuestSelectionTopBarActions(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/tutorial/TutorialScreen.kt
@@ -10,11 +10,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -100,8 +105,7 @@ fun TutorialScreen(
                         )
                         .padding(bottom = 16.dp)
                 )
-            },
-            modifier = Modifier.safeDrawingPadding()
+            }
         )
     }
 }
@@ -130,7 +134,11 @@ private fun TutorialScreenLayout(
                     illustration()
                 }
                 Box(
-                    modifier = Modifier.weight(0.6f),
+                    modifier = Modifier
+                        .weight(0.6f)
+                        .windowInsetsPadding(WindowInsets.safeDrawing.only(
+                            WindowInsetsSides.End + WindowInsetsSides.Vertical
+                        )),
                     contentAlignment = Alignment.Center
                 ) {
                     pageContent()
@@ -156,14 +164,18 @@ private fun TutorialScreenLayout(
                         illustration()
                     }
                     Box(
-                        modifier = Modifier.weight(0.6f),
+                        modifier = Modifier
+                            .weight(0.6f)
+                            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
                         contentAlignment = Alignment.Center
                     ) {
                         pageContent()
                     }
                 }
                 Row(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Spacer(Modifier.weight(0.4f))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/tutorial/TutorialScreen.kt
@@ -10,16 +10,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -117,7 +112,7 @@ private fun TutorialScreenLayout(
     pageContent: @Composable () -> Unit,
     controls: @Composable () -> Unit,
 ) {
-    BoxWithConstraints(modifier) {
+    BoxWithConstraints(modifier.safeDrawingPadding()) {
         if (maxHeight > maxWidth) {
             Column(
                 modifier = Modifier.fillMaxSize(),
@@ -134,11 +129,7 @@ private fun TutorialScreenLayout(
                     illustration()
                 }
                 Box(
-                    modifier = Modifier
-                        .weight(0.6f)
-                        .windowInsetsPadding(WindowInsets.safeDrawing.only(
-                            WindowInsetsSides.End + WindowInsetsSides.Vertical
-                        )),
+                    modifier = Modifier.weight(0.6f),
                     contentAlignment = Alignment.Center
                 ) {
                     pageContent()
@@ -164,18 +155,14 @@ private fun TutorialScreenLayout(
                         illustration()
                     }
                     Box(
-                        modifier = Modifier
-                            .weight(0.6f)
-                            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
+                        modifier = Modifier.weight(0.6f),
                         contentAlignment = Alignment.Center
                     ) {
                         pageContent()
                     }
                 }
                 Row(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
+                    modifier = Modifier.fillMaxSize(),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Spacer(Modifier.weight(0.4f))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserScreen.kt
@@ -4,12 +4,10 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -101,7 +99,7 @@ private fun UserScreenTopAppBar(
                 TabRow(
                     selectedTabIndex = page,
                     modifier = Modifier.windowInsetsPadding(
-                        WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
                     )
                 ) {
                     for (tab in UserTab.entries) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/UserScreen.kt
@@ -2,8 +2,15 @@ package de.westnordost.streetcomplete.screens.user
 
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -82,6 +89,7 @@ private fun UserScreenTopAppBar(
         Column {
             TopAppBar(
                 title = { Text(stringResource(R.string.user_profile)) },
+                windowInsets = AppBarDefaults.topAppBarWindowInsets,
                 navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
                 elevation = 0.dp
             )
@@ -90,7 +98,12 @@ private fun UserScreenTopAppBar(
             val page = pagerState.targetPage
 
             BoxWithConstraints {
-                TabRow(selectedTabIndex = page) {
+                TabRow(
+                    selectedTabIndex = page,
+                    modifier = Modifier.windowInsetsPadding(
+                        WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
+                    )
+                ) {
                     for (tab in UserTab.entries) {
                         val icon = painterResource(tab.iconId)
                         val text = stringResource(tab.textId)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
@@ -1,7 +1,13 @@
 package de.westnordost.streetcomplete.screens.user.achievements
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -15,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
 import de.westnordost.streetcomplete.ui.common.CenteredLargeTitleHint
+import de.westnordost.streetcomplete.ui.ktx.plus
 
 /** Shows the icons for all achieved achievements and opens a dialog to show the details on click. */
 @Composable
@@ -25,13 +32,16 @@ fun AchievementsScreen(viewModel: AchievementsViewModel) {
     var showAchievement by remember { mutableStateOf<Pair<Achievement, Int>?>(null) }
 
     achievements?.let {
+        val insets = WindowInsets.systemBars.only(
+            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+        ).asPaddingValues()
         LazyAchievementsGrid(
             achievements = it,
             onClickAchievement = { achievement, level ->
                 showAchievement = achievement to level
             },
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp)
+            modifier = Modifier.fillMaxSize().consumeWindowInsets(insets),
+            contentPadding = insets + PaddingValues(16.dp)
         )
     }
     if (hasNoAchievements) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -32,7 +32,7 @@ fun AchievementsScreen(viewModel: AchievementsViewModel) {
     var showAchievement by remember { mutableStateOf<Pair<Achievement, Int>?>(null) }
 
     achievements?.let {
-        val insets = WindowInsets.systemBars.only(
+        val insets = WindowInsets.safeDrawing.only(
             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
         ).asPaddingValues()
         LazyAchievementsGrid(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/CountryStatisticsColumn.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/CountryStatisticsColumn.kt
@@ -26,6 +26,7 @@ fun CountryStatisticsColumn(
     flagAlignments: Map<String, FlagAlignment>,
     isCurrentWeek: Boolean,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     var showInfo by remember { mutableStateOf<CountryStatistics?>(null) }
 
@@ -38,7 +39,7 @@ fun CountryStatisticsColumn(
     val maxCount = statistics.firstOrNull()?.count ?: 0
     LazyColumn(
         modifier = modifier,
-        contentPadding = PaddingValues(top = 16.dp)
+        contentPadding = contentPadding
     ) {
         items(statistics) { item ->
             BarChartRow(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/EditStatisticsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/EditStatisticsScreen.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.screens.user.edits
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -9,15 +10,17 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.AppBarDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material.primarySurface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -64,25 +67,24 @@ fun EditStatisticsScreen(
                 val pagerState = rememberPagerState(pageCount = { EditStatisticsTab.entries.size })
                 val page = pagerState.targetPage
 
-                TabRow(
-                    selectedTabIndex = page,
-                    modifier = Modifier
-                        .windowInsetsPadding(
-                            WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
-                        )
-                        .shadow(AppBarDefaults.TopAppBarElevation)
-                ) {
-                    for (tab in EditStatisticsTab.entries) {
-                        val index = tab.ordinal
-                        Tab(
-                            selected = page == index,
-                            onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
-                            text = { Text(stringResource(tab.textId)) }
-                        )
+                Box(Modifier.background(MaterialTheme.colors.primarySurface)) {
+                    TabRow(
+                        selectedTabIndex = page,
+                        modifier = Modifier
+                            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
+                    ) {
+                        for (tab in EditStatisticsTab.entries) {
+                            val index = tab.ordinal
+                            Tab(
+                                selected = page == index,
+                                onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                                text = { Text(stringResource(tab.textId)) }
+                            )
+                        }
                     }
                 }
 
-                val insets = WindowInsets.systemBars.only(
+                val insets = WindowInsets.safeDrawing.only(
                     WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
                 ).asPaddingValues()
 
@@ -117,18 +119,6 @@ fun EditStatisticsScreen(
                     }
                 }
             }
-            OutlinedButton(
-                onClick = { isCurrentWeek = !isCurrentWeek },
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp)
-                    .windowInsetsPadding(WindowInsets.systemBars)
-            ) {
-                Text(stringResource(
-                    if (isCurrentWeek) R.string.user_profile_current_week_title
-                    else R.string.user_profile_all_time_title
-                ))
-            }
         } else {
             val isSynchronizingStatistics by viewModel.isSynchronizingStatistics.collectAsState()
             CenteredLargeTitleHint(
@@ -137,6 +127,18 @@ fun EditStatisticsScreen(
                     else R.string.quests_empty
                 )
             )
+        }
+        OutlinedButton(
+            onClick = { isCurrentWeek = !isCurrentWeek },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+        ) {
+            Text(stringResource(
+                if (isCurrentWeek) R.string.user_profile_current_week_title
+                else R.string.user_profile_all_time_title
+            ))
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/EditTypeStatisticsColumn.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/edits/EditTypeStatisticsColumn.kt
@@ -25,6 +25,7 @@ import de.westnordost.streetcomplete.ui.theme.GrassGreen
 fun EditTypeStatisticsColumn(
     statistics: List<EditTypeStatistics>,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     var showInfo by remember { mutableStateOf<EditTypeStatistics?>(null) }
 
@@ -37,7 +38,7 @@ fun EditTypeStatisticsColumn(
     val maxCount = statistics.firstOrNull()?.count ?: 0
     LazyColumn(
         modifier = modifier,
-        contentPadding = PaddingValues(top = 16.dp)
+        contentPadding = contentPadding,
     ) {
         items(statistics) { item ->
             BarChartRow(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/links/LinksScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/links/LinksScreen.kt
@@ -1,7 +1,13 @@
 package de.westnordost.streetcomplete.screens.user.links
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -12,6 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ui.common.CenteredLargeTitleHint
+import de.westnordost.streetcomplete.ui.ktx.plus
 
 /** Shows the user's unlocked links */
 @Composable
@@ -20,10 +27,13 @@ fun LinksScreen(viewModel: LinksViewModel) {
     val hasNoLinks by remember { derivedStateOf { links?.isNotEmpty() != true } }
 
     links?.let {
+        val insets = WindowInsets.systemBars.only(
+            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+        ).asPaddingValues()
         LazyGroupedLinksColumn(
             allLinks = it,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp)
+            modifier = Modifier.fillMaxSize().consumeWindowInsets(insets),
+            contentPadding = insets + PaddingValues(16.dp)
         )
     }
     if (hasNoLinks) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/links/LinksScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/links/LinksScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -27,7 +27,7 @@ fun LinksScreen(viewModel: LinksViewModel) {
     val hasNoLinks by remember { derivedStateOf { links?.isNotEmpty() != true } }
 
     links?.let {
-        val insets = WindowInsets.systemBars.only(
+        val insets = WindowInsets.safeDrawing.only(
             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
         ).asPaddingValues()
         LazyGroupedLinksColumn(

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
@@ -128,7 +128,7 @@ fun LoginScreen(
 
             Box(Modifier
                 .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.systemBars.only(
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(
                     WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
                 ))
             ) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/login/LoginScreen.kt
@@ -4,9 +4,15 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.IconButton
@@ -74,6 +80,7 @@ fun LoginScreen(
     Column(Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(stringResource(R.string.user_login)) },
+            windowInsets = AppBarDefaults.topAppBarWindowInsets,
             navigationIcon = { IconButton(onClick = onClickBack) { BackIcon() } },
         )
 
@@ -119,7 +126,12 @@ fun LoginScreen(
                 }
             }
 
-            Box(Modifier.fillMaxSize()) {
+            Box(Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.systemBars.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                ))
+            ) {
                 if (webViewState.loadingState is LoadingState.Loading) {
                     LinearProgressIndicator(Modifier.fillMaxWidth())
                 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
@@ -9,10 +9,15 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -67,7 +72,10 @@ fun ProfileScreen(viewModel: ProfileViewModel) {
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
-            .padding(16.dp),
+            .padding(16.dp)
+            .windowInsetsPadding(WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+            )),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Basic user info

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -73,7 +73,7 @@ fun ProfileScreen(viewModel: ProfileViewModel) {
         modifier = Modifier
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
-            .windowInsetsPadding(WindowInsets.systemBars.only(
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             )),
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/de/westnordost/streetcomplete/ui/ktx/PaddingValues.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ui/ktx/PaddingValues.kt
@@ -1,0 +1,11 @@
+package de.westnordost.streetcomplete.ui.ktx
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.LayoutDirection.Ltr
+
+operator fun PaddingValues.plus(other: PaddingValues): PaddingValues = PaddingValues.Absolute(
+    left = calculateLeftPadding(Ltr) + other.calculateLeftPadding(Ltr),
+    top = calculateTopPadding() + other.calculateTopPadding(),
+    right = calculateRightPadding(Ltr) + other.calculateRightPadding(Ltr),
+    bottom = calculateBottomPadding() + other.calculateBottomPadding(),
+)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,9 @@ dependencies {
     implementation("com.beust:klaxon:5.6")
     implementation("de.westnordost:countryboundaries:2.1")
     implementation("com.esotericsoftware.yamlbeans:yamlbeans:1.17")
-    implementation("org.jsoup:jsoup:1.18.1")
+    implementation("org.jsoup:jsoup:1.18.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
-    implementation("com.charleskorn.kaml:kaml:0.61.0")
+    implementation("com.charleskorn.kaml:kaml:0.67.0")
     implementation("org.jetbrains:markdown:0.7.3")
 }
 


### PR DESCRIPTION
most of the changes are because when targeting Android SDK level 35, all screens are edge-to-edge by default. so one needs to specify the insets manually.

It's quite complex to test this, as it may appear different for any combination of:
- portrait or landscape mode (navigation is on the left or right side, but only if it is button navigation)
- with display cutout (needs additional padding, can be located anywhere depending on display rotation)
- right-to-left layout (expected location of the display cutout within the layout differs)
- using gesture navigation vs using button-navigation (background of the navigation changes)
- dark mode or light mode (color of the status bar icons changes)

E.g. when rotated to landscape mode, the display cutout will be on the left (or right) side, so there also needs to be a padding there.

But I think I tested it all. All screens are affected.

The visible changes are:
- top bar has no background anymore (seems to be standard now in Android)
- nav bar uses the default color now (background color almost-opaque when using navigation buttons, otherwise transparent)
- main screen regards necessary padding for the display cutout (😕 which may look odd, sometimes, but we don't want that a button is below the display cutout)
- you see some content below the navigation bar on scrollable screens (e.g. settings screen)
- all the other screens other than the main screen also add a padding for the display cutout