### PR TITLE
OsmNoteQuestController: surveyme override and regex test update

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -256,7 +256,7 @@ private fun Note.containsSurveyRequiredMarker(): Boolean =
     comments.any { it.containsSurveyRequiredMarker() }
 
 private fun NoteComment.containsSurveyRequiredMarker(): Boolean =
-    text?.matches(".*#surveyme.*".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))) == true
+    text?.contains("#surveyme", ignoreCase = true) == true
 
 private fun Note.probablyCreatedByUserInThisApp(userId: Long): Boolean {
     val firstComment = comments.first()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -196,15 +196,21 @@ private fun Note.shouldShowAsQuest(
     // don't show notes hidden by user
     if (id in blockedNoteIds) return false
 
-    // don't show notes where user replied last unless he wrote a survey required marker
-    if (comments.last().isReplyFromUser(userId)
+    /*
+        We usually don't show notes where either the user is the last responder, or the
+        note was created with the app and has no replies.
+        If the most recent comment contains "#surveyme", we want to show the note regardless.
+        See https://github.com/streetcomplete/StreetComplete/issues/6052#issuecomment-2567163451
+     */
+    if (
+        (
+            comments.last().isReplyFromUser(userId) ||
+            (probablyCreatedByUserInThisApp(userId) && !hasReplies)
+        )
         && !comments.last().containsSurveyRequiredMarker()
     ) {
         return false
     }
-
-    // newly created notes by user should not be shown if it was both created in this app and has no replies yet
-    if (probablyCreatedByUserInThisApp(userId) && !hasReplies) return false
 
     /*
         many notes are created to report problems on the map that cannot be resolved
@@ -250,7 +256,7 @@ private fun Note.containsSurveyRequiredMarker(): Boolean =
     comments.any { it.containsSurveyRequiredMarker() }
 
 private fun NoteComment.containsSurveyRequiredMarker(): Boolean =
-    text?.matches(".*#surveyme.*".toRegex()) == true
+    text?.matches(".*#surveyme.*".toRegex(RegexOption.DOT_MATCHES_ALL)) == true
 
 private fun Note.probablyCreatedByUserInThisApp(userId: Long): Boolean {
     val firstComment = comments.first()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -256,7 +256,7 @@ private fun Note.containsSurveyRequiredMarker(): Boolean =
     comments.any { it.containsSurveyRequiredMarker() }
 
 private fun NoteComment.containsSurveyRequiredMarker(): Boolean =
-    text?.matches(".*#surveyme.*".toRegex(RegexOption.DOT_MATCHES_ALL)) == true
+    text?.matches(".*#surveyme.*".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))) == true
 
 private fun Note.probablyCreatedByUserInThisApp(userId: Long): Boolean {
     val firstComment = comments.first()

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
@@ -175,6 +175,33 @@ class OsmNoteQuestControllerTest {
         assertNotNull(ctrl.getVisible(1))
     }
 
+    @Test fun `get note quest created in app without comments and without survey required marker returns null`() {
+        on(noteSource.get(1)).thenReturn(note(comments = listOf(
+            comment(text = "this is a non-question test note\n\nCreated via StreetComplete 60.1", user = User(id = 100, "Blaubär")),
+        )))
+        on(userDataSource.userId).thenReturn(1)
+
+        assertNull(ctrl.getVisible(1))
+    }
+
+    @Test fun `get note quest created in app without comments and with survey required marker returns non-null`() {
+        on(noteSource.get(1)).thenReturn(note(comments = listOf(
+            comment(text = "this is a non-question test note #surveyme\n\nCreated via StreetComplete 60.1", user = User(id = 100, "Blaubär")),
+        )))
+        on(userDataSource.userId).thenReturn(1)
+
+        assertNotNull(ctrl.getVisible(1))
+    }
+
+    @Test fun `get note quest created in app without comments and with survey required marker (ignore case) returns non-null`() {
+        on(noteSource.get(1)).thenReturn(note(comments = listOf(
+            comment(text = "this is a non-question test note #SurVEyMe\n\nCreated via StreetComplete 60.1", user = User(id = 100, "Blaubär")),
+        )))
+        on(userDataSource.userId).thenReturn(1)
+
+        assertNotNull(ctrl.getVisible(1))
+    }
+
     @Test fun `get quest not phrased as question returns null`() {
         on(noteSource.get(1)).thenReturn(note(comments = listOf(
             comment(text = "test")


### PR DESCRIPTION
Resolves #6052.

* Restructured exclusion of notes that get overridden by #surveyme
* Added RegexOption.DOT_MATCHES_ALL to function NoteComment.containsSurveyRequiredMarker: #surveyme wasn't found at the end of the text added by the user, because SC add "\n\nvia StreetComplete <x.y>" to the text