### PR TITLE
Enable fire hydrant refs quest in Germany

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_ref/AddFireHydrantRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_ref/AddFireHydrantRef.kt
@@ -20,7 +20,7 @@ class AddFireHydrantRef : OsmFilterQuestType<FireHydrantRefAnswer>() {
     override val achievements = listOf(EditTypeAchievement.LIFESAVER)
     override val isDeleteElementEnabled = true
     override val enabledInCountries = NoCountriesExcept(
-        "CH", "FR"
+        "CH", "DE", "FR"
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_genericRef_title


### PR DESCRIPTION
Reference codes for fire hydrants seem to be widely used all around Germany. I can confirm that for where I live. For all other federal states of Germany, I found many examples of hydrants with non-trivial reference codes in  [Overpass Turbo](https://overpass-turbo.eu/) with the following query:

```
node
  [emergency=fire_hydrant]
  [ref~"^[A-Z0-9]{3,}$"]
  ({{bbox}});
out;
```