### PR TITLE
Encode git revision in debug .apk

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -21,18 +21,21 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Set env
+        run: echo "COMMIT_SHA=$(git log -n 1 --format='%h')" >> $GITHUB_ENV
+
       - name: Encode git revision
-        run: sed -i -e "s/versionName = \"\([^ ]*\).*\"/versionName = \"\1 (git $(git log -n 1 --format='%h'))\"/"  app/build.gradle.kts
+        run: sed -i -e "s/versionName = \"\([^ ]*\).*\"/versionName = \"\1 (git $COMMIT_SHA)\"/"  app/build.gradle.kts
 
       - name: Build with Gradle
         run: ./gradlew assembleDebug
 
       - name: Rename APK
-        run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$(git log -n 1 --format='%h').apk
+        run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$COMMIT_SHA.apk
 
       - name: Archive APK
         uses: actions/upload-artifact@v4
         with:
-          name: debug-apk
+          name: StreetComplete-debug-apk-${{ env.COMMIT_SHA }}
           path: app/build/outputs/apk/debug/*.apk
           retention-days: 30

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Encode git revision
+        run: sed -i -e "s/versionName = \"\([^ ]*\).*\"/versionName = \"\1 (git $(git log -n 1 --format='%h'))\"/"  app/build.gradle.kts
+
       - name: Build with Gradle
         run: ./gradlew assembleDebug
 


### PR DESCRIPTION
When using GitHub actions to build debug `.apk`, encode actual git revision built into its `versionName`. 

It helps using About window to identify exact git revision being tested, among other things. Especially helpful when testing several different branches at the same time.

tested (and example debug `.apk`) at https://github.com/mnalis/StreetComplete/actions/runs/12996593370