### PR TITLE
ignore private features for bus-stop related quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -18,6 +18,7 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
           or (highway = bus_stop and public_transport != stop_position)
         )
         and physically_present != no and naptan:BusStopType != HAR
+        and access !~ no|private
         and (!bench or bench older today -4 years)
     """
     override val changesetComment = "Specify whether public transport stops have benches"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -18,6 +18,7 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
           or (highway = bus_stop and public_transport != stop_position)
         )
         and physically_present != no and naptan:BusStopType != HAR
+        and access !~ no|private
         and (!bin or bin older today -4 years)
     """
     override val changesetComment = "Specify whether public transport stops have bins"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -18,6 +18,7 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
           or (highway = bus_stop and public_transport != stop_position)
         )
         and physically_present != no and naptan:BusStopType != HAR
+        and access !~ no|private
         and location !~ underground|indoor
         and indoor != yes
         and (!level or level >= 0)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -18,6 +18,7 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>() {
           or highway = bus_stop and public_transport != stop_position
           or railway ~ halt|station|tram_stop
         )
+        and access !~ no|private
         and !name and noname != yes and name:signed != no
     """
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -16,6 +16,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
           or
           (highway = bus_stop and public_transport != stop_position)
         )
+        and access !~ no|private
         and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
     override val enabledInCountries = NoCountriesExcept(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -19,6 +19,7 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
           or (highway = bus_stop and public_transport != stop_position)
         )
         and physically_present != no and naptan:BusStopType != HAR
+        and access !~ no|private
         and !covered
         and location !~ underground|indoor
         and indoor != yes


### PR DESCRIPTION
similar to [many other quests](https://grep.app/search?f.repo=streetcomplete/StreetComplete&q=access+!~+private|no), it would be good if the bus-stop quests ignored private features. 

For example, bus stops within a gated business-park, factory, or school, all of which are inaccessible to the public. 