### PR TITLE
Prevent Surface Quest from immediately asking again when choosing paved or unpaved

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -25,7 +25,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<Surface>() {
           !cycleway:surface
           or cycleway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            cycleway:surface ~ paved|unpaved and cycleway:surface older today -6 years
+            cycleway:surface ~ paved|unpaved and cycleway:surface older today -6 months
             and !cycleway:surface:note
             and !check_date:cycleway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -25,7 +25,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<Surface>() {
           !cycleway:surface
           or cycleway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            cycleway:surface ~ paved|unpaved
+            cycleway:surface ~ paved|unpaved and surface older today -6 years
             and !cycleway:surface:note
             and !check_date:cycleway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -25,7 +25,7 @@ class AddCyclewayPartSurface : OsmFilterQuestType<Surface>() {
           !cycleway:surface
           or cycleway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            cycleway:surface ~ paved|unpaved and surface older today -6 years
+            cycleway:surface ~ paved|unpaved and cycleway:surface older today -6 years
             and !cycleway:surface:note
             and !check_date:cycleway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -26,7 +26,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<Surface>() {
           !footway:surface
           or footway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            footway:surface ~ paved|unpaved
+            footway:surface ~ paved|unpaved and surface older today -6 years
             and !footway:surface:note
             and !check_date:footway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -26,7 +26,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<Surface>() {
           !footway:surface
           or footway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            footway:surface ~ paved|unpaved and footway:surface older today -6 years
+            footway:surface ~ paved|unpaved and footway:surface older today -6 months
             and !footway:surface:note
             and !check_date:footway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -26,7 +26,7 @@ class AddFootwayPartSurface : OsmFilterQuestType<Surface>() {
           !footway:surface
           or footway:surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            footway:surface ~ paved|unpaved and surface older today -6 years
+            footway:surface ~ paved|unpaved and footway:surface older today -6 years
             and !footway:surface:note
             and !check_date:footway:surface
           )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -24,7 +24,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            surface ~ paved|unpaved and surface older today -6 years
+            surface ~ paved|unpaved and surface older today -6 months
             and !surface:note
             and !note:surface
             and !check_date:surface

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -24,7 +24,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>() {
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            surface ~ paved|unpaved
+            surface ~ paved|unpaved and surface older today -6 years
             and !surface:note
             and !note:surface
             and !check_date:surface

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -35,7 +35,7 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            surface ~ paved|unpaved
+            surface ~ paved|unpaved and surface older today -6 years
             and !surface:note
             and !note:surface
             and !check_date:surface

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -35,7 +35,7 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            surface ~ paved|unpaved and surface older today -6 years
+            surface ~ paved|unpaved and surface older today -6 months
             and !surface:note
             and !note:surface
             and !check_date:surface

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -27,7 +27,7 @@ class AddRoadSurface : OsmFilterQuestType<Surface>() {
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}
           or (
-            surface ~ paved|unpaved
+            surface ~ paved|unpaved and surface older today -6 years
             and !surface:note
             and !note:surface
             and !check_date:surface

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -32,7 +32,7 @@ class AddRoadSurface : OsmFilterQuestType<Surface>() {
             and !note:surface
             and !check_date:surface
           )
-          or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and surface older today -6 years
+          or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and surface older today -6 months
           or surface older today -12 years
           ${INVALID_SURFACES_FOR_TRACKTYPES.entries.joinToString("\n") { (tracktype, surfaces) ->
               "or tracktype = $tracktype and surface ~ ${surfaces.joinToString("|")}"


### PR DESCRIPTION
This PR is created to fix #6172 

Adds time constraint for surface = paved|unpaved  precondition.