### PR TITLE
Allow Sidewalk overlay on wider range of highways (like a Cycleway overlay)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
@@ -35,7 +35,7 @@ class SidewalkOverlay : Overlay {
         // roads
         mapData.filter("""
             ways with
-              highway ~ motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
+              highway ~ ${ALL_ROADS.joinToString("|")}
               and area != yes
         """).map { it to getSidewalkStyle(it) } +
         // footways etc, just to highlight e.g. separately mapped sidewalks. However, it is also

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
@@ -100,7 +100,7 @@ private fun getStreetStrokeStyle(tags: Map<String, String>): StrokeStyle? =
 
 private val sidewalkTaggingNotExpectedFilter by lazy { """
     ways with
-      highway ~ living_street|pedestrian|service|motorway_link|busway
+      highway ~ track|living_street|pedestrian|service|motorway_link|motorway|busway
       or motorroad = yes
       or expressway = yes
       or maxspeed <= 10


### PR DESCRIPTION
For consistency, as suggested in: https://github.com/streetcomplete/StreetComplete/issues/6176#issuecomment-2741214062

This PR extends Sidewalk overlay to allow (but not color as missing!) editing unexpected `highway` types like `track` etc., just like we already do in Cycleway Overlay.

[Builds](https://github.com/mnalis/StreetComplete/actions/runs/14050508346) and seems to work for me (i.e. I can select `track` in Sidewalk as well as in Cycleway overlay, when previously only Cycleway worked. And it doesn't color it), but more eyes are always welcome. 