### PR TITLE
parking - skip (few more) detailed vehicles types

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -27,7 +27,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
             !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and
             !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and
             !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water and
-            !school_bus !disabled and !4wd_only and !roadtrain and !lhv and !tank and
+            !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank and
             !motor_vehicle and !vehicle
         )
     """

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -26,8 +26,9 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
             !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated and
             !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and
             !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and
-            !hov and !carpool and !car_sharing and !emergency and !hazmat and !water and
-            !disabled and !4wd_only and !roadtrain and !lhv and !tank
+            !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water and
+            !school_bus !disabled and !4wd_only and !roadtrain and !lhv and !tank and
+            !motor_vehicle and !vehicle
         )
     """
     override val changesetComment = "Specify parking access"


### PR DESCRIPTION
Fixes https://github.com/streetcomplete/StreetComplete/issues/6215

We are already skipping the quest for majority of more detailed access tags in https://github.com/streetcomplete/StreetComplete/pull/4547 (as accepted in https://github.com/streetcomplete/StreetComplete/issues/4538#issuecomment-1288187859), but few were missing or incorrect.

This followup PR fixes that