### PR TITLE
No silent link unlocks

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDaoTest.kt
@@ -13,13 +13,18 @@ class UserAchievementsDaoTest : ApplicationDbTestCase() {
     }
 
     @Test fun putGetAll() {
-        dao.put(ONE, 1)
-        dao.put(ONE, 4)
-        dao.put(TWO, 2)
+        dao.putAll(listOf(ONE to 1))
+        dao.putAll(listOf(ONE to 4, TWO to 2))
         assertEquals(mapOf(
             ONE to 4,
             TWO to 2
         ), dao.getAll())
+    }
+
+    @Test fun putSingle() {
+        dao.put(ONE, 1)
+        dao.put(ONE, 4)
+        assertEquals(mapOf(ONE to 4), dao.getAll())
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/messages/Message.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/messages/Message.kt
@@ -1,11 +1,16 @@
 package de.westnordost.streetcomplete.data.messages
 
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
+import de.westnordost.streetcomplete.data.user.achievements.Link
 import de.westnordost.streetcomplete.util.html.HtmlNode
 
 sealed interface Message
 
 data class OsmUnreadMessagesMessage(val unreadMessages: Int) : Message
-data class NewAchievementMessage(val achievement: Achievement, val level: Int) : Message
+data class NewAchievementMessage(
+    val achievement: Achievement,
+    val level: Int,
+    val unlockedLinks: List<Link>
+) : Message
 data class NewVersionMessage(val changelog: Map<String, List<HtmlNode>>) : Message
 data object QuestSelectionHintMessage : Message

--- a/app/src/main/java/de/westnordost/streetcomplete/data/messages/MessagesSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/messages/MessagesSource.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.data.user.UserDataController
 import de.westnordost.streetcomplete.data.user.UserDataSource
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
 import de.westnordost.streetcomplete.data.user.achievements.AchievementsSource
+import de.westnordost.streetcomplete.data.user.achievements.Link
 import de.westnordost.streetcomplete.util.Listeners
 
 /** This class is to access user messages, which are basically dialogs that pop up when
@@ -36,7 +37,7 @@ class MessagesSource(
 
     /** Achievement levels unlocked since application start. I.e. when restarting the app, the
      *  messages about new achievements unlocked are lost, this is deliberate */
-    private val newAchievements = ArrayList<Pair<Achievement, Int>>()
+    private val newAchievements = ArrayList<NewAchievementMessage>()
 
     init {
         userDataController.addListener(object : UserDataSource.Listener {
@@ -45,8 +46,8 @@ class MessagesSource(
             }
         })
         achievementsSource.addListener(object : AchievementsSource.Listener {
-            override fun onAchievementUnlocked(achievement: Achievement, level: Int) {
-                newAchievements.add(achievement to level)
+            override fun onAchievementUnlocked(achievement: Achievement, level: Int, unlockedLinks: List<Link>) {
+                newAchievements.add(NewAchievementMessage(achievement, level, unlockedLinks))
                 onNumberOfMessagesUpdated()
             }
 
@@ -114,7 +115,7 @@ class MessagesSource(
         val newAchievement = newAchievements.removeFirstOrNull()
         if (newAchievement != null) {
             onNumberOfMessagesUpdated()
-            return NewAchievementMessage(newAchievement.first, newAchievement.second)
+            return newAchievement
         }
 
         val unreadOsmMessages = userDataController.unreadMessagesCount

--- a/app/src/main/java/de/westnordost/streetcomplete/data/preferences/Preferences.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/preferences/Preferences.kt
@@ -181,6 +181,9 @@ class Preferences(private val prefs: ObservableSettings) {
 
     // default true because if it is not set yet, the first thing that is done is to synchronize it
     var isSynchronizingStatistics: Boolean by prefs.boolean(IS_SYNCHRONIZING_STATISTICS, true)
+    // default true because it is set to false on login, so that for old users for which the value
+    // is not set yet it is also true
+    var statisticsSynchronizedOnce: Boolean by prefs.boolean(STATISTICS_SYNCED_ONCE, true)
 
     fun clearUserStatistics() {
         prefs.remove(USER_DAYS_ACTIVE)
@@ -189,6 +192,7 @@ class Preferences(private val prefs: ObservableSettings) {
         prefs.remove(USER_GLOBAL_RANK)
         prefs.remove(USER_GLOBAL_RANK_CURRENT_WEEK)
         prefs.remove(USER_LAST_TIMESTAMP_ACTIVE)
+        prefs.remove(STATISTICS_SYNCED_ONCE)
     }
 
     companion object {
@@ -254,5 +258,6 @@ class Preferences(private val prefs: ObservableSettings) {
         private const val USER_LAST_TIMESTAMP_ACTIVE = "last_timestamp_active"
         private const val ACTIVE_DATES_RANGE = "active_days_range"
         private const val IS_SYNCHRONIZING_STATISTICS = "is_synchronizing_statistics"
+        private const val STATISTICS_SYNCED_ONCE = "statistics_synced_once"
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserDataController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserDataController.kt
@@ -4,7 +4,15 @@ import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.Listeners
 
 /** Controller that handles user login, logout, auth and updated data */
-class UserDataController(private val prefs: Preferences) : UserDataSource {
+class UserDataController(
+    private val prefs: Preferences,
+    private val userLoginSource: UserLoginSource,
+) : UserDataSource {
+
+    private val userLoginListener = object : UserLoginSource.Listener {
+        override fun onLoggedIn() {}
+        override fun onLoggedOut() { clear() }
+    }
 
     private val listeners = Listeners<UserDataSource.Listener>()
 
@@ -18,6 +26,10 @@ class UserDataController(private val prefs: Preferences) : UserDataSource {
             listeners.forEach { it.onUpdated() }
         }
 
+    init {
+        userLoginSource.addListener(userLoginListener)
+    }
+
     fun setDetails(userDetails: UserInfo) {
         prefs.userId = userDetails.id
         prefs.userName = userDetails.displayName
@@ -25,7 +37,7 @@ class UserDataController(private val prefs: Preferences) : UserDataSource {
         listeners.forEach { it.onUpdated() }
     }
 
-    fun clear() {
+    private fun clear() {
         prefs.clearUserData()
         listeners.forEach { it.onUpdated() }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserModule.kt
@@ -45,7 +45,7 @@ val OAUTH2_REQUIRED_SCOPES = listOf(
 
 val userModule = module {
     single<UserDataSource> { get<UserDataController>() }
-    single { UserDataController(get()) }
+    single { UserDataController(get(), get()) }
 
     single<UserLoginSource> { get<UserLoginController>() }
     single { UserLoginController(get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserUpdater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserUpdater.kt
@@ -24,9 +24,7 @@ class UserUpdater(
         override fun onLoggedIn() {
             update()
         }
-        override fun onLoggedOut() {
-            clear()
-        }
+        override fun onLoggedOut() {}
     }
 
     interface Listener {
@@ -52,11 +50,6 @@ class UserUpdater(
         } catch (e: Exception) {
             Log.w(TAG, "Unable to download user details", e)
         }
-    }
-
-    fun clear() {
-        userDataController.clear()
-        statisticsController.clear()
     }
 
     private fun updateAvatar(userId: Long, imageUrl: String) = coroutineScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsSource.kt
@@ -2,8 +2,10 @@ package de.westnordost.streetcomplete.data.user.achievements
 
 interface AchievementsSource {
     interface Listener {
-        /** Called when a single achievement level has been unlocked */
-        fun onAchievementUnlocked(achievement: Achievement, level: Int)
+        /** Called when a new achievement level has been reached. When the user unlocked several
+         *  levels at once, this is only called once with the highest achieved level, the
+         *  [unlockedLinks] contain all links not unlocked yet */
+        fun onAchievementUnlocked(achievement: Achievement, level: Int, unlockedLinks: List<Link>)
         /** Called when all achievements have been updated (after sync with server) */
         fun onAllAchievementsUpdated()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/achievements/UserAchievementsDao.kt
@@ -21,4 +21,12 @@ class UserAchievementsDao(private val db: Database) {
             LEVEL to level
         ))
     }
+
+    fun putAll(achievements: Collection<Pair<String, Int>>) {
+        db.replaceMany(
+            table = NAME,
+            columnNames = arrayOf(ACHIEVEMENT, LEVEL),
+            valuesList = achievements.map { arrayOf(it.first, it.second) }
+        )
+    }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsModule.kt
@@ -26,5 +26,6 @@ val statisticsModule = module {
         activeDatesDao = get(),
         countryBoundaries = get(named("CountryBoundariesLazy")),
         prefs = get(),
+        userLoginSource = get(),
     ) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsSource.kt
@@ -11,7 +11,7 @@ interface StatisticsSource {
         fun onSubtractedOne(type: String)
         /** Called when all the statistics have been replaced by a new set of statistics. E.g. when
          *  the updated statistics have been downloaded from the server */
-        fun onUpdatedAll()
+        fun onUpdatedAll(isFirstUpdate: Boolean)
         /** Called when the statistics have been cleared. E.g. on logout. */
         fun onCleared()
         /** Called when the days the user has been active changed */

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
@@ -312,7 +312,7 @@ class MainViewModelImpl(
         val listener = object : StatisticsSource.Listener {
             override fun onAddedOne(type: String) { trySend(++count) }
             override fun onSubtractedOne(type: String) { trySend(--count) }
-            override fun onUpdatedAll() { update() }
+            override fun onUpdatedAll(isFirstUpdate: Boolean) { update() }
             override fun onCleared() { update() }
             override fun onUpdatedDaysActive() {}
         }
@@ -332,7 +332,7 @@ class MainViewModelImpl(
         val listener = object : StatisticsSource.Listener {
             override fun onAddedOne(type: String) { trySend(++count) }
             override fun onSubtractedOne(type: String) { trySend(--count) }
-            override fun onUpdatedAll() { update() }
+            override fun onUpdatedAll(isFirstUpdate: Boolean) { update() }
             override fun onCleared() { update() }
             override fun onUpdatedDaysActive() {}
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/messages/MessageDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/messages/MessageDialog.kt
@@ -23,6 +23,7 @@ fun MessageDialog(
             AchievementDialog(
                 achievement = message.achievement,
                 level = message.level,
+                unlockedLinks = message.unlockedLinks,
                 onDismissRequest = onDismissRequest
             )
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
+import de.westnordost.streetcomplete.data.user.achievements.Link
 import de.westnordost.streetcomplete.data.user.achievements.achievements
 import de.westnordost.streetcomplete.screens.user.DialogContentWithIconLayout
 import de.westnordost.streetcomplete.screens.user.links.LazyLinksColumn
@@ -32,6 +33,7 @@ import de.westnordost.streetcomplete.ui.theme.titleMedium
 fun AchievementDialog(
     achievement: Achievement,
     level: Int,
+    unlockedLinks: List<Link>,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     isNew: Boolean = true,
@@ -57,9 +59,8 @@ fun AchievementDialog(
                 },
                 content = { isLandscape ->
                     AchievementDetails(
-                        achievement, level,
-                        isLandscape = isLandscape,
-                        showLinks = isNew
+                        achievement, level, unlockedLinks,
+                        isLandscape = isLandscape
                     )
                 },
                 modifier = modifier.padding(16.dp)
@@ -72,9 +73,9 @@ fun AchievementDialog(
 private fun AchievementDetails(
     achievement: Achievement,
     level: Int,
+    unlockedLinks: List<Link>,
     modifier: Modifier = Modifier,
     isLandscape: Boolean,
-    showLinks: Boolean,
 ) {
     Column(
         modifier = modifier,
@@ -95,8 +96,7 @@ private fun AchievementDetails(
                 style = MaterialTheme.typography.body2
             )
         }
-        val unlockedLinks = achievement.unlockedLinks[level].orEmpty()
-        if (unlockedLinks.isNotEmpty() && showLinks) {
+        if (unlockedLinks.isNotEmpty()) {
             val unlockedLinksText = stringResource(
                 if (unlockedLinks.size == 1) R.string.achievements_unlocked_link
                 else R.string.achievements_unlocked_links
@@ -119,9 +119,11 @@ private fun AchievementDetails(
 @Composable
 private fun PreviewAchievementDetailsDialog() {
     AppTheme {
+        val regularAchievement = achievements.associateBy { it.id }["regular"]!!
         AchievementDialog(
-            achievement = achievements.associateBy { it.id }["regular"]!!,
+            achievement = regularAchievement,
             level = 7,
+            unlockedLinks = regularAchievement.unlockedLinks[7].orEmpty(),
             onDismissRequest = {}
         )
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/achievements/AchievementsScreen.kt
@@ -55,6 +55,7 @@ fun AchievementsScreen(viewModel: AchievementsViewModel) {
     showAchievement?.let { (achievement, level) ->
         AchievementDialog(
             achievement, level,
+            unlockedLinks = emptyList(),
             onDismissRequest = { showAchievement = null },
             isNew = false
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileViewModel.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileViewModel.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.user.UserLoginController
 import de.westnordost.streetcomplete.data.user.UserUpdater
 import de.westnordost.streetcomplete.data.user.achievements.Achievement
 import de.westnordost.streetcomplete.data.user.achievements.AchievementsSource
+import de.westnordost.streetcomplete.data.user.achievements.Link
 import de.westnordost.streetcomplete.data.user.statistics.CountryStatistics
 import de.westnordost.streetcomplete.data.user.statistics.StatisticsSource
 import de.westnordost.streetcomplete.util.ktx.launch
@@ -89,12 +90,16 @@ class ProfileViewModelImpl(
             editCount.update { it - 1 }
             editCountCurrentWeek.update { it - 1 }
         }
-        override fun onUpdatedAll() { updateStatistics() }
+        override fun onUpdatedAll(isFirstUpdate: Boolean) { updateStatistics() }
         override fun onCleared() { updateStatistics() }
         override fun onUpdatedDaysActive() { updateDatesActive() }
     }
     private val achievementsListener = object : AchievementsSource.Listener {
-        override fun onAchievementUnlocked(achievement: Achievement, level: Int) { updateAchievementLevels() }
+        override fun onAchievementUnlocked(
+            achievement: Achievement,
+            level: Int,
+            unlockedLinks: List<Link>
+        ) { updateAchievementLevels() }
         override fun onAllAchievementsUpdated() { updateAchievementLevels() }
     }
     private val userListener = object : UserDataSource.Listener {


### PR DESCRIPTION
Don't unlock new links added to achievements silently for old users, add them to the next achievement level they unlock instead.

Also, when a user unlocked several levels of the same achievement, only show the highest achieved level and display all the unlocked links in that one dialog.