### PR TITLE
Demote baby changing table and wheelchair access toilets

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -473,8 +473,6 @@ fun questTypeRegistry(
     // toilets
     118 to AddToiletAvailability(), // shown in OsmAnd descriptions
     119 to AddToiletsFee(), // used by OsmAnd in the object description
-    120 to AddBabyChangingTable(), // used by OsmAnd in the object description
-    121 to AddWheelchairAccessToiletsPart(),
     122 to AddWheelchairAccessToilets(), // used by wheelmap, OsmAnd, Organic Maps
 
     // shop
@@ -489,6 +487,10 @@ fun questTypeRegistry(
     130 to AddInternetAccess(), // used by OsmAnd
     131 to AddAcceptsCards(), // this will often involve going inside and near the till
     132 to AddAcceptsCash(),
+
+    // shop and others, but have to go inside
+    120 to AddBabyChangingTable(), // used by OsmAnd in the object description, have to go inside
+    121 to AddWheelchairAccessToiletsPart(), // have to go inside
 
     133 to AddFuelSelfService(),
     156 to CheckShopExistence(getFeature), // after opening hours and similar so they will be preferred if enabled


### PR DESCRIPTION
Now they are asked for things like restaurants and cafes too, but you generally have to go inside them to answer (and likely use the toilets), compared to say dietary quests where a menu is often posted outside, or sometimes vegetarian/vegan/halal/GF may be an advertised selling point too.

Also below shop payment quests as everyone who uses an amenity will pay (hopefully!) but only some people will use the toilet.