### PR TITLE
Do not skip Halal quest on Vegan-only restaurants

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
@@ -18,7 +18,6 @@ class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
           amenity ~ restaurant|cafe|fast_food|ice_cream|food_court and food != no
           or shop ~ butcher|supermarket|ice_cream|convenience
         )
-        and diet:vegan != only
         and (
           !diet:halal
           or diet:halal != only and diet:halal older today -4 years


### PR DESCRIPTION
as noted in https://github.com/streetcomplete/StreetComplete/issues/6276#issuecomment-2889070800 and below, Halal quest should not  be skipped on Vegan-only restaurants, because:

- just because it is Vegan-only, does not mean it is automatically Halal
- while Halal restaurants may be having meat, they may be vegan (including vegan-only) too, and that distinction is worth noting

In short, being Halal and being Vegan are orthogonal things, and it does not make sense to make one depend on the other.

(PR not tested yet, but seems simple enough)