### PR TITLE
fix: correct Vector3d division and subtraction operations

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/math/Vector3d.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/math/Vector3d.kt
@@ -23,10 +23,10 @@ class Vector3d(val x: Double, val y: Double, val z: Double) {
     operator fun unaryMinus() = Vector3d(-x, -y, -z)
 
     operator fun times(v: Double) = Vector3d(x * v, y * v, z * v)
-    operator fun div(v: Double) = Vector3d(x / v, x / v, x / v)
+    operator fun div(v: Double) = Vector3d(x / v, y / v, z / v)
 
     operator fun plus(o: Vector3d) = Vector3d(x + o.x, y + o.y, z + o.z)
-    operator fun minus(o: Vector3d) = Vector3d(x - o.x, y - o.y, z - o.y)
+    operator fun minus(o: Vector3d) = Vector3d(x - o.x, y - o.y, z - o.z)
 
     /** dot (scalar) product with [o] */
     operator fun times(o: Vector3d) = x * o.x + y * o.y + z * o.z

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/math/Vector3dTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/math/Vector3dTest.kt
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.util.math
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Vector3dTest {
+    @Test fun `minus subtracts components`() {
+        val a = Vector3d(4.0, 3.0, 2.0)
+        val b = Vector3d(1.0, 1.5, 0.5)
+        assertEquals(Vector3d(3.0, 1.5, 1.5), a - b)
+    }
+
+    @Test fun `division divides components`() {
+        val v = Vector3d(4.0, 2.0, 1.0)
+        assertEquals(Vector3d(2.0, 1.0, 0.5), v / 2.0)
+    }
+}


### PR DESCRIPTION
- Fix div operator to divide each component (x/v, y/v, z/v) instead of (x/v, x/v, x/v)
- Fix minus operator to use o.z for z component instead of o.y
- Add Vector3dTest to verify corrected operations