### PR TITLE
util: fix no-op bug in String.withNonBreakingSpaces()

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/NameAndLocationLabel.kt
@@ -204,4 +204,4 @@ fun getShortHouseNumber(map: Map<String, String>): String? {
 private fun String.inBold(): String = "<b>${replaceHtmlEntities()}</b>"
 private fun String.inItalics(): String = "<i>${replaceHtmlEntities()}</i>"
 
-private fun String.withNonBreakingSpaces(): String = replace(' ', ' ')
+private fun String.withNonBreakingSpaces(): String = replace(' ', '\u00A0')


### PR DESCRIPTION
Replace(' ', ' ') was replacing regular spaces with regular spaces.
Changed to replace(' ', '\u00A0') so it exchanges spaces to correct non-breaking space character.