### PR TITLE
util: handle duplicate elements in Collection.containsExactlyInAnyOrder()

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
@@ -74,5 +74,10 @@ inline fun <T, R : Comparable<R>> Iterable<T>.indexOfMaxBy(selector: (T) -> R): 
 }
 
 // TODO clean: for tests, rather use assertEquals with sets for better errors on failure
-fun <T> Collection<T>.containsExactlyInAnyOrder(other: Collection<T>): Boolean =
-    other.size == size && containsAll(other)
+fun <T> Collection<T>.containsExactlyInAnyOrder(other: Collection<T>): Boolean {
+    if (size != other.size) return false
+    if (this === other) return true
+
+    fun Collection<T>.toCountMap() = groupingBy { it }.eachCount()
+    return toCountMap() == other.toCountMap()
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
@@ -77,7 +77,7 @@ inline fun <T, R : Comparable<R>> Iterable<T>.indexOfMaxBy(selector: (T) -> R): 
 fun <T> Collection<T>.containsExactlyInAnyOrder(other: Collection<T>): Boolean {
     if (size != other.size) return false
     if (this === other) return true
-
-    fun Collection<T>.toCountMap() = groupingBy { it }.eachCount()
     return toCountMap() == other.toCountMap()
 }
+
+private fun <T>  Collection<T>.toCountMap() = groupingBy { it }.eachCount()

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class CollectionsTest {
 
@@ -92,5 +93,17 @@ class CollectionsTest {
     @Test fun `indexOfMaxBy with some elements`() {
         assertEquals(2, listOf(3, 4, 8).indexOfMaxBy { it })
         assertEquals(0, listOf(4, 0, -1).indexOfMaxBy { it })
+    }
+
+    @Test fun `containsExactlyInAnyOrder ignores order`() {
+        assertTrue(listOf(1, 2, 3).containsExactlyInAnyOrder(listOf(3, 2, 1)))
+    }
+
+    @Test fun `containsExactlyInAnyOrder checks duplicate counts`() {
+        assertFalse(listOf(1, 1, 2).containsExactlyInAnyOrder(listOf(1, 2, 2)))
+    }
+
+    @Test fun `containsExactlyInAnyOrder with duplicates`() {
+        assertTrue(listOf(1, 1, 2).containsExactlyInAnyOrder(listOf(1, 2, 1)))
     }
 }


### PR DESCRIPTION
containsAll() only checked for unique element presence, not frequencies. Changed to use count maps for duplicate element comparison.

The original implementation would incorrectly return true for collections 
like [1, 2, 2, 3] and [1, 2, 3, 3] because:
- Both have the same size (4)
- Both contain the elements 1, 2, and 3

The new implementation uses groupingBy().eachCount() to create frequency maps ({1=1, 2=2, 3=1} vs {1=1, 2=1, 3=2}), which correctly identifies these collections as different due to varying element frequencies.

This ensures the function behaves as its name suggests - checking for exact content equality regardless of order.