### PR TITLE
util: handle empty lists in List.firstAndLast()

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/ktx/Collections.kt
@@ -1,7 +1,11 @@
 package de.westnordost.streetcomplete.util.ktx
 
 /** Return the first and last element of this list. If it contains only one element, just that one */
-fun <E> List<E>.firstAndLast() = if (size == 1) listOf(first()) else listOf(first(), last())
+fun <E> List<E>.firstAndLast() = when (size) {
+    0 -> listOf()
+    1 -> listOf(first())
+    else -> listOf(first(), last())
+}
 
 /** Return all except the first and last element of this list. If it contains less than two elements,
  *  it returns an empty list */

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/util/ktx/CollectionsTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class CollectionsTest {
 
@@ -93,4 +94,17 @@ class CollectionsTest {
         assertEquals(2, listOf(3, 4, 8).indexOfMaxBy { it })
         assertEquals(0, listOf(4, 0, -1).indexOfMaxBy { it })
     }
+
+    @Test fun `firstAndLast of empty list returns empty list`() {
+        assertTrue(listOf<Int>().firstAndLast().isEmpty())
+    }
+
+    @Test fun `firstAndLast of single element list`() {
+        assertEquals(listOf(1), listOf(1).firstAndLast())
+    }
+
+    @Test fun `firstAndLast of multi element list`() {
+        assertEquals(listOf(1, 3), listOf(1, 2, 3).firstAndLast())
+    }
+
 }


### PR DESCRIPTION
Return empty list if given empty list, to avoid potential NoSuchElementException from first() call.

---

Not sure if that could be triggered by the codebase atm, but to avoid potential crashes this makes more sense I think.