### PR TITLE
ui: ensure updateOkButtonEnablement() runs after buttons exist in ShopGoneDialog

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/ShopGoneDialog.kt
@@ -83,6 +83,7 @@ class ShopGoneDialog(
 
     override fun show() {
         super.show()
+        updateOkButtonEnablement()
         // to override the default OK=dismiss() behavior
         getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
             when (selectedRadioButtonId) {


### PR DESCRIPTION
updateOkButtonEnablement() was called during init when getButton(BUTTON_POSITIVE) may return null. Move to show() after super.show() to ensure button state update actually executes, addressing potential timing issue.

---

UI is not my can of worms, but I think I found a bug here. 

During the init() `updateOkButtonEnablement()` is called, but since the button does not exist yet `getButton()` will return NULL here, which is masked by `?.`.

This can lead to the button not being disabled, despite the user not yet having selected an element from the list.