### PR TITLE
build: extract helper methods in DownloadBrandLogosTask to reduce complexity

### DIFF
--- a/buildSrc/src/main/java/DownloadBrandLogosTask.kt
+++ b/buildSrc/src/main/java/DownloadBrandLogosTask.kt
@@ -26,51 +26,46 @@ open class DownloadBrandLogosTask : DefaultTask() {
         /* NSI uses (atm) a slightly different format than the normal presets: The presets are in
            a sub-object called "presets" */
         val presets = nsiPresetsJson.obj("presets")!!
-        for (entry in presets.entries) {
-            val id = entry.key
-            val presetJson = entry.value as JsonObject
-            val imageURL = presetJson["imageURL"] as String?
-            if (imageURL != null) {
-                val smallImageUrl = when {
-                    imageURL.contains("graph.facebook.com") && imageURL.endsWith("large") -> {
-                        // small is about 50x50px. large would be 200x200px
-                        imageURL.replaceRange(imageURL.length - 5, imageURL.length, "small")
-                    }
-                    imageURL.contains("commons.wikimedia.org") && imageURL.endsWith("width=100") -> {
-                        imageURL.replaceRange(imageURL.length - 3, imageURL.length, "50")
-                    }
-                    imageURL.contains("pbs.twimg.com/profile_images") -> {
-                        // normal is 48x48px, bigger is about 128x128px
-                        imageURL.replace("_bigger.", "_normal.")
-                    }
-                    else -> {
-                        imageURL
-                    }
-                }
-                try {
-                    val conn = URL(smallImageUrl)
-                    val suffix = when (conn.openConnection().contentType) {
-                        "image/jpeg" -> "jpg"
-                        "image/png" -> "png"
-                        "image/webp" -> "webp"
-                        else -> throw UnsupportedFormatException("only png, jpg, webp are supported")
-                    }
+        for ((id, value) in presets.entries) {
+            val imageURL = (value as JsonObject)["imageURL"] as String?
+            if (imageURL != null) downloadLogo(id, imageURL, targetDir)
+        }
+    }
 
-                    val targetFile = File("$targetDir/$id.$suffix")
-                    targetFile.parentFile.mkdirs()
+    private fun downloadLogo(id: String, imageURL: String, targetDir: String) {
+        val smallImageUrl = computeSmallImageUrl(imageURL)
+        try {
+            val conn = URL(smallImageUrl)
+            val suffix = when (conn.openConnection().contentType) {
+                "image/jpeg" -> "jpg"
+                "image/png" -> "png"
+                "image/webp" -> "webp"
+                else -> throw UnsupportedFormatException("only png, jpg, webp are supported")
+            }
 
-                    conn.openStream().use { input ->
-                        FileOutputStream(targetFile).use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                } catch (e: FileNotFoundException) {
-                    println("$id: $imageURL not found")
-                } catch (e: UnsupportedFormatException) {
-                    println("$id: $imageURL unsupported format")
+            val targetFile = File("$targetDir/$id.$suffix")
+            targetFile.parentFile.mkdirs()
+
+            conn.openStream().use { input ->
+                FileOutputStream(targetFile).use { output ->
+                    input.copyTo(output)
                 }
             }
+        } catch (e: FileNotFoundException) {
+            println("$id: $imageURL not found")
+        } catch (e: UnsupportedFormatException) {
+            println("$id: $imageURL unsupported format")
         }
+    }
+
+    private fun computeSmallImageUrl(imageURL: String): String = when {
+        imageURL.contains("graph.facebook.com") && imageURL.endsWith("large") ->
+            imageURL.replaceRange(imageURL.length - 5, imageURL.length, "small") // small ~50x50px
+        imageURL.contains("commons.wikimedia.org") && imageURL.endsWith("width=100") ->
+            imageURL.replaceRange(imageURL.length - 3, imageURL.length, "50")
+        imageURL.contains("pbs.twimg.com/profile_images") ->
+            imageURL.replace("_bigger.", "_normal.") // normal ~48x48px
+        else -> imageURL
     }
 }
 


### PR DESCRIPTION
Split run() method into downloadLogo() and computeSmallImageUrl() to improve readability and maintainability.

Fixes two detekt complains:

```
buildSrc/src/main/java/DownloadBrandLogosTask.kt:20:21: The function run appears to be too complex based on Cyclomatic Complexity (complexity: 19). Defined complexity threshold for methods is set to '15' [CyclomaticComplexMethod]

buildSrc/src/main/java/DownloadBrandLogosTask.kt:20:21: Function run is nested too deeply. [NestedBlockDepth]
``` 