### PR TITLE
osm: remove redundant else in ElementGeometryCreator when expression

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryCreator.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryCreator.kt
@@ -38,7 +38,6 @@ class ElementGeometryCreator {
                 val positionsByWayId = mapData.getWaysNodePositions(element, allowIncomplete) ?: return null
                 return create(element, positionsByWayId)
             }
-            else -> return null
         }
     }
 


### PR DESCRIPTION
Element is a sealed type exhaustively handled by existing branches, making else clause unnecessary.

Fixes compiler warning:

```
w: app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/geometry/ElementGeometryCreator.kt:41:13 'when' is exhaustive so 'else' is redundant here.
```  