### PR TITLE
test: update StringMapEntryAddTest method name to match test behavior

### DIFF
--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryAddTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/StringMapEntryAddTest.kt
@@ -11,7 +11,7 @@ class StringMapEntryAddTest {
         assertTrue(StringMapEntryAdd("a", "b").conflictsWith(mutableMapOf("a" to "c")))
     }
 
-    @Test fun `does not conflict if already added with different value`() {
+    @Test fun `does not conflict if already added with same value`() {
         assertFalse(StringMapEntryAdd("a", "b").conflictsWith(mutableMapOf("a" to "b")))
     }
 


### PR DESCRIPTION
Method name referenced "different value" but test used same value ("b"). Updated name to reflect actual test scenario.