### PR TITLE
fix code comments for String.toRgb() / toHexString()

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/color/Rgb.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/color/Rgb.kt
@@ -26,13 +26,19 @@ data class Rgb(val red: UByte, val green: UByte, val blue: UByte) {
         )
     }
 
-    /** return color as hexadecimal string "#rrggbb" */
+    /**
+     * Return color as hexadecimal string in the form "#rrggbb". The alpha
+     * channel is not included because this class stores only RGB values.
+     */
     @OptIn(ExperimentalStdlibApi::class)
     fun toHexString(): String =
         "#" + red.toHexString() + green.toHexString() + blue.toHexString()
 }
 
-/** Creates RGB from string in the form "#rrggbb" */
+/**
+ * Creates RGB from a hexadecimal color string in the form "#rrggbb" or
+ * "#rrggbbaa". If an alpha value is present it will be ignored.
+ */
 @OptIn(ExperimentalStdlibApi::class, ExperimentalUnsignedTypes::class)
 fun String.toRgb(): Rgb {
     require(length == 7 || length == 9)


### PR DESCRIPTION
Code comment mentions an alpha channel, but the code (currently) only uses RGB. Modified code comments to reflect that.

--- 

More detailed code comments, revising #6319