### PR TITLE
avoid integer math in StreetParkingDrawable

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/street_parking/StreetParkingDrawable.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/street_parking/StreetParkingDrawable.kt
@@ -55,11 +55,11 @@ class StreetParkingDrawable(
         if (!isVisible) return
 
         if (isUpsideDown) {
-            val pivotY = bounds.height() / ceil(height / width / 2f)
+            val pivotY = bounds.height() / ceil(height.toFloat() / width / 2f)
             canvas.scale(1f, -1f, bounds.width() / 2f, pivotY)
         }
 
-        val height = bounds.height().toFloat() / (height / width) * 2f
+        val height = bounds.height().toFloat() / (height.toFloat() / width) * 2f
         val width = bounds.width()
 
         val omittedCarIndices = getOmittedCarIndices(parkingOrientation, parkingPosition)


### PR DESCRIPTION
With the current images "ic_car*" this is not causing any harm, however if the image is turned 90° the integer math can lead to 0 as result for height/width. Leading to Infinity as results.

To avoid issues after exchanging/adding the images in the future, implicit floating point operations are required.