### PR TITLE
remove incorrect comment

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -109,7 +109,6 @@ abstract class AbstractOverlayForm :
             return localizedContext.resources
         }
 
-    // only used for testing / only used for ShowQuestFormsScreen! Found no better way to do this
     var addElementEditsController: AddElementEditsController = elementEditsController
 
     // view / state


### PR DESCRIPTION
accoding to my testing it is used in regular operations in overlay editing, at least in Things, Places and Buildings overlays

BTW, maybe I got blind but I cannot find ShowQuestFormsScreen anymore in debug builds