### PR TITLE
reenable debug functionality in GitHub actions debug build

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -28,7 +28,7 @@ jobs:
         run: sed -i -e "s/versionName = \"\([^ ]*\).*\"/versionName = \"\1 (git $COMMIT_SHA)\"/"  app/build.gradle.kts
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug -Papp.streetcomplete.debug=true
 
       - name: Rename APK
         run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/StreetComplete-debug-$COMMIT_SHA.apk


### PR DESCRIPTION
regarding https://github.com/streetcomplete/StreetComplete/pull/6339#issuecomment-2960529311, this restores debug functionality when using GitHub Actions to build debug APK

Tested [here](https://github.com/mnalis/StreetComplete/actions/runs/15571775268), and seems to work fine.