### PR TITLE
Expanded AddPitchLit to outdoor fitness station

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -13,7 +13,7 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddPitchLit : OsmFilterQuestType<Boolean>(), AndroidQuest {
 
     override val elementFilter = """
-        ways with (leisure = pitch or leisure = track)
+        ways with (leisure ~ pitch|track|fitness_station)
         and (access !~ private|no)
         and indoor != yes and (!building or building = no)
         and (


### PR DESCRIPTION
Of the 120k [leisure](https://wiki.openstreetmap.org/wiki/Key:leisure)=[fitness_station](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dfitness_station)  238 have lit=yes while 163 have lit=no.
This PR expands the quest for pitches to also ask if outdoor fitness stations are lit.
The [leisure](https://wiki.openstreetmap.org/wiki/Key:leisure)=[fitness_station](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dfitness_station) tag is also often used for the individual machines, however since we only query for ways, these nodes will not be shown and only the underlying area.