### PR TITLE
Expand AddBusStopName to also ask for ferry terminal names

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -18,6 +18,7 @@ class AddBusStopName : OsmFilterQuestType<BusStopNameAnswer>(), AndroidQuest {
           public_transport = platform and bus = yes
           or highway = bus_stop and public_transport != stop_position
           or railway ~ halt|station|tram_stop
+          or amenity = ferry_terminal
         )
         and access !~ no|private
         and !name and noname != yes and name:signed != no


### PR DESCRIPTION
50.89% of Ferry terminals ([amenity](https://wiki.openstreetmap.org/wiki/Key:amenity)=[ferry_terminal](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dferry_terminal)) already have names. In my experience they generally all have.