### PR TITLE
ignore files generated on building APK through Android Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 quest-list.csv
 /keystore.properties
 /projectFilesBackup*/
+app/release
 *.iml
 .kotlin
 .gradle


### PR DESCRIPTION
I think this can be safely ignored, right?

I somehow got

```
app/release/app-release.apk
app/release/baselineProfiles/0/app-release.dm
app/release/baselineProfiles/1/app-release.dm
app/release/output-metadata.json
```

when trying to build .apk that would be accepted by my phone.