### PR TITLE
Added quests to leisure=sauna

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -73,7 +73,7 @@ class AddOpeningHours(
             "leisure" to arrayOf(
                 // common
                 "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
+                "amusement_arcade", "adult_gaming_centre", "tanning_salon", "sauna",
 
                 // not sports_centre, dance etc because these are often sports clubs which have no
                 // walk-in opening hours but training times

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -82,7 +82,7 @@ class AddPlaceName(
             "leisure" to arrayOf(
                 // common
                 "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
+                "amusement_arcade", "adult_gaming_centre", "tanning_salon", "sauna",
 
                 // name & wheelchair
                 "sports_centre", "stadium",

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -72,7 +72,7 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>(), Andr
             "leisure" to arrayOf(
                 // common
                 "fitness_centre", "golf_course", "water_park", "miniature_golf", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon",
+                "amusement_arcade", "adult_gaming_centre", "tanning_salon", "sauna",
 
                 // name & wheelchair
                 "sports_centre", "stadium"


### PR DESCRIPTION
Currently there are around 14k non private saunas.
This PR expands the AddOpeningHours, AddWheelchairAcessBuisness and AddPlaceName Quests to them.

182 of saunas have wheelchair = no while 92 have yes.
56% have names.

I have tested and verified its functionality.