### PR TITLE
added pastry shop to AddVegan quest

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -18,6 +18,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>(), AndroidQuest {
         nodes, ways with
         (
           amenity = ice_cream
+          or shop = pastry
           or diet:vegetarian ~ yes|only and
           (
             amenity ~ restaurant|cafe|fast_food|food_court and food != no


### PR DESCRIPTION
Many pastrys are not vegan due to containing eggs.

However all pastry shops I have been to had vegetarian options, so the vegetarian quest makes less sense to me.