### PR TITLE
implemented isRelationIgnored, which does not ignore ferry routes

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -88,7 +88,7 @@ object ApplicationConstants {
      *  complete as possible. Some relations are extremely large, which would require to pull
      *  a lot of elements from db into memory.
      */
-    fun isRelationIgnored(tags: Map<String, String>): Boolean {
+    fun ignoreRelation(tags: Map<String, String>): Boolean {
         val type = tags["type"] ?: return false
         return when (type) {
             // ignore non ferry relations since these are sometimes/often very very large

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -86,19 +86,26 @@ object ApplicationConstants {
     /** Which relation types to drop already during download, before persisting. This is a
      *  performance improvement. Working properly with relations means we have to have it as
      *  complete as possible. Some relations are extremely large, which would require to pull
-     *  a lot of elements from db into memory. */
-    val IGNORED_RELATION_TYPES = setOf(
-        // could be useful, but sometimes/often very very large
-        "route", "route_master", "superroute", "network", "disused:route",
-        // very large, not useful for SC
-        "boundary",
-        // can easily span very large areas, not useful for SC
-        "water", "waterway", "watershed", "collection",
-        // questionable relation type: members could easily span multiple continents
-        "person",
-        // no wiki entry, sounds like it could span large areas
-        "power", "pipeline", "railway"
-    )
+     *  a lot of elements from db into memory.
+     */
+    fun isRelationIgnored(tags: Map<String, String>): Boolean {
+        val type = tags["type"] ?: return false
+        return when (type) {
+            // could be useful, but sometimes/often very very large
+            "route" -> tags["route"] != "ferry"
+            "route_master", "superroute", "network", "disused:route" -> true
+
+            // very large, not useful for SC
+            "boundary" -> true
+            // can easily span very large areas, not useful for SC
+            "water", "waterway", "watershed", "collection" -> true
+            // questionable relation type: members could easily span multiple continents
+            "person" -> true
+            // no wiki entry, sounds like it could span large areas
+            "power", "pipeline", "railway" -> true
+            else -> false
+        }
+    }
 
     val EDIT_ACTIONS_NOT_ALLOWED_TO_USE_LOCAL_CHANGES = setOf(
         /* because this action may edit route relations but route relations are not persisted

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -91,7 +91,7 @@ object ApplicationConstants {
     fun isRelationIgnored(tags: Map<String, String>): Boolean {
         val type = tags["type"] ?: return false
         return when (type) {
-            // could be useful, but sometimes/often very very large
+            // ignore non ferry relations since these are sometimes/often very very large
             "route" -> tags["route"] != "ferry"
             "route_master", "superroute", "network", "disused:route" -> true
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
@@ -87,6 +87,6 @@ class ElementEditUploader(
         } else {
             changesetManager.getOrCreateChangeset(edit.type, edit.source, edit.position, edit.isNearUserLocation)
         }
-        return mapDataApi.uploadChanges(changesetId, changes, ApplicationConstants::isRelationIgnored)
+        return mapDataApi.uploadChanges(changesetId, changes, ApplicationConstants::ignoreRelation)
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditUploader.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.osm.edits.upload
 
+import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.ApplicationConstants.EDIT_ACTIONS_NOT_ALLOWED_TO_USE_LOCAL_CHANGES
-import de.westnordost.streetcomplete.ApplicationConstants.IGNORED_RELATION_TYPES
 import de.westnordost.streetcomplete.data.ConflictException
 import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
@@ -87,6 +87,6 @@ class ElementEditUploader(
         } else {
             changesetManager.getOrCreateChangeset(edit.type, edit.source, edit.position, edit.isNearUserLocation)
         }
-        return mapDataApi.uploadChanges(changesetId, changes, IGNORED_RELATION_TYPES)
+        return mapDataApi.uploadChanges(changesetId, changes, ApplicationConstants::isRelationIgnored)
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
@@ -33,9 +33,10 @@ class MapDataApiClient(
      *
      * @param changesetId id of the changeset to upload changes into
      * @param changes changes to upload.
-     * @param ignoreRelation omit any updates to relations of the given types from the result.
-     *                            Such relations can still be referred to as relation members,
-     *                            though, the relations themselves are just not included
+```suggestion
+     * @param ignoreRelation omit any relations for which the given function returns true.
+     *                       Such relations can still be referred to as relation members,
+     *                       though, the relations themselves are just not included
      *
      * @throws ConflictException if the changeset has already been closed, there is a conflict for
      *                           the elements being uploaded or the user who created the changeset
@@ -88,9 +89,9 @@ class MapDataApiClient(
      *
      * @param bounds rectangle in which to query map data. May not cross the 180th meridian. This is
      * usually limited at 0.25 square degrees. Check the server capabilities.
-     * @param ignoreRelation omit any relations of the given types from the result.
-     *                            Such relations can still be referred to as relation members,
-     *                            though, the relations themselves are just not included
+     * @param ignoreRelation omit any relations for which the given function returns true.
+     *                       Such relations can still be referred to as relation members,
+     *                       though, the relations themselves are just not included
      *
      * @throws QueryTooBigException if the bounds area is too large or too many elements would be returned
      * @throws IllegalArgumentException if the bounds cross the 180th meridian.

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClient.kt
@@ -51,7 +51,7 @@ class MapDataApiClient(
     suspend fun uploadChanges(
         changesetId: Long,
         changes: MapDataChanges,
-        ignoreRelationTypes: Set<String?> = emptySet()
+        ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
     ): MapDataUpdates = wrapApiClientExceptions {
         try {
             val response = httpClient.post(baseUrl + "changeset/$changesetId/upload") {
@@ -100,7 +100,7 @@ class MapDataApiClient(
      */
     suspend fun getMap(
         bounds: BoundingBox,
-        ignoreRelationTypes: Set<String?> = emptySet()
+        ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
     ): MutableMapData = wrapApiClientExceptions {
         if (bounds.crosses180thMeridian) {
             throw IllegalArgumentException("Bounding box crosses 180th meridian")
@@ -199,7 +199,7 @@ class MapDataApiClient(
         try {
             val response = httpClient.get(baseUrl + query) { expectSuccess = true }
             val source = response.bodyAsChannel().asSource().buffered()
-            return parser.parseMapData(source, emptySet())
+            return parser.parseMapData(source) { false }
         } catch (e: ClientRequestException) {
             when (e.response.status) {
                 HttpStatusCode.Gone, HttpStatusCode.NotFound -> return null

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParser.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParser.kt
@@ -14,15 +14,15 @@ import nl.adaptivity.xmlutil.xmlStreaming
 class MapDataApiParser {
     fun parseMapData(
         source: Source,
-        ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
+        ignoreRelation: (tags: Map<String, String>) -> Boolean = { false }
     ): MutableMapData =
-        xmlStreaming.newReader(source).parseMapData(ignoreRelationTypes)
+        xmlStreaming.newReader(source).parseMapData(ignoreRelation)
 
     fun parseElementUpdates(source: Source): Map<ElementKey, ElementUpdate> =
         xmlStreaming.newReader(source).parseElementUpdates()
 }
 
-private fun XmlReader.parseMapData(ignoreRelationTypes: (tags: Map<String, String>) -> Boolean): MutableMapData = try {
+private fun XmlReader.parseMapData(ignoreRelation: (tags: Map<String, String>) -> Boolean): MutableMapData = try {
     val result = MutableMapData()
     var tags: MutableMap<String, String>? = null
     var nodes: MutableList<Long> = ArrayList()
@@ -67,7 +67,7 @@ private fun XmlReader.parseMapData(ignoreRelationTypes: (tags: Map<String, Strin
         END_ELEMENT -> when (localName) {
             "node" -> result.add(Node(id!!, position!!, tags.orEmpty(), version!!, timestamp!!))
             "way" -> result.add(Way(id!!, nodes, tags.orEmpty(), version!!, timestamp!!))
-            "relation" -> if (!ignoreRelationTypes(tags.orEmpty())) {
+            "relation" -> if (!ignoreRelation(tags.orEmpty())) {
                 result.add(Relation(id!!, members, tags.orEmpty(), version!!, timestamp!!))
             }
         }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParser.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParser.kt
@@ -12,14 +12,17 @@ import nl.adaptivity.xmlutil.core.kxio.newReader
 import nl.adaptivity.xmlutil.xmlStreaming
 
 class MapDataApiParser {
-    fun parseMapData(source: Source, ignoreRelationTypes: Set<String?>): MutableMapData =
+    fun parseMapData(
+        source: Source,
+        ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
+    ): MutableMapData =
         xmlStreaming.newReader(source).parseMapData(ignoreRelationTypes)
 
     fun parseElementUpdates(source: Source): Map<ElementKey, ElementUpdate> =
         xmlStreaming.newReader(source).parseElementUpdates()
 }
 
-private fun XmlReader.parseMapData(ignoreRelationTypes: Set<String?>): MutableMapData = try {
+private fun XmlReader.parseMapData(ignoreRelationTypes: (tags: Map<String, String>) -> Boolean): MutableMapData = try {
     val result = MutableMapData()
     var tags: MutableMap<String, String>? = null
     var nodes: MutableList<Long> = ArrayList()
@@ -64,7 +67,7 @@ private fun XmlReader.parseMapData(ignoreRelationTypes: Set<String?>): MutableMa
         END_ELEMENT -> when (localName) {
             "node" -> result.add(Node(id!!, position!!, tags.orEmpty(), version!!, timestamp!!))
             "way" -> result.add(Way(id!!, nodes, tags.orEmpty(), version!!, timestamp!!))
-            "relation" -> if (tags.orEmpty()["type"] !in ignoreRelationTypes) {
+            "relation" -> if (!ignoreRelationTypes(tags.orEmpty())) {
                 result.add(Relation(id!!, members, tags.orEmpty(), version!!, timestamp!!))
             }
         }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataDownloader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataDownloader.kt
@@ -32,7 +32,7 @@ class MapDataDownloader(
 
     private suspend fun getMapAndHandleTooBigQuery(bounds: BoundingBox): MutableMapData {
         try {
-            return mapDataApi.getMap(bounds, ApplicationConstants.IGNORED_RELATION_TYPES)
+            return mapDataApi.getMap(bounds, ApplicationConstants::isRelationIgnored)
         } catch (e: QueryTooBigException) {
             val mapData = MutableMapData()
             for (subBounds in bounds.splitIntoFour()) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataDownloader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataDownloader.kt
@@ -32,7 +32,7 @@ class MapDataDownloader(
 
     private suspend fun getMapAndHandleTooBigQuery(bounds: BoundingBox): MutableMapData {
         try {
-            return mapDataApi.getMap(bounds, ApplicationConstants::isRelationIgnored)
+            return mapDataApi.getMap(bounds, ApplicationConstants::ignoreRelation)
         } catch (e: QueryTooBigException) {
             val mapData = MutableMapData()
             for (subBounds in bounds.splitIntoFour()) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataUpdates.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataUpdates.kt
@@ -17,14 +17,14 @@ data class ElementIdUpdate(
 fun createMapDataUpdates(
     elements: Collection<Element>,
     updates: Map<ElementKey, ElementUpdate>,
-    ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
+    ignoreRelation: (tags: Map<String, String>) -> Boolean = { false }
 ): MapDataUpdates {
     val updatedElements = mutableListOf<Element>()
     val deletedElementKeys = mutableListOf<ElementKey>()
     val idUpdates = mutableListOf<ElementIdUpdate>()
 
     for (element in elements) {
-        if (element is Relation && ignoreRelationTypes(element.tags)) continue
+        if (element is Relation && ignoreRelation(element.tags)) continue
 
         val newElement = element.update(updates)
         if (newElement == null) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataUpdates.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataUpdates.kt
@@ -17,14 +17,14 @@ data class ElementIdUpdate(
 fun createMapDataUpdates(
     elements: Collection<Element>,
     updates: Map<ElementKey, ElementUpdate>,
-    ignoreRelationTypes: Set<String?> = emptySet()
+    ignoreRelationTypes: (tags: Map<String, String>) -> Boolean = { false }
 ): MapDataUpdates {
     val updatedElements = mutableListOf<Element>()
     val deletedElementKeys = mutableListOf<ElementKey>()
     val idUpdates = mutableListOf<ElementIdUpdate>()
 
     for (element in elements) {
-        if (element is Relation && element.tags["type"] in ignoreRelationTypes) continue
+        if (element is Relation && ignoreRelationTypes(element.tags)) continue
 
         val newElement = element.update(updates)
         if (newElement == null) {

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/MapDataUpdatesTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/MapDataUpdatesTest.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.edits.upload
 
+import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementIdUpdate
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.NODE
@@ -163,7 +164,7 @@ class MapDataUpdatesTest {
                 rel(2, listOf(member(NODE, 1), member(NODE, 2), member(NODE, 1))), // contains it multiple times
                 rel(3, listOf(member(WAY, 1), member(RELATION, 1), member(NODE, 2))) // contains it not
             ),
-            updates = mapOf(ElementKey(NODE, 1) to ElementUpdate.Delete)
+            updates = mapOf(ElementKey(NODE, 1) to ElementUpdate.Delete),
         )
         assertTrue(updates.idUpdates.isEmpty())
         assertEquals(listOf(ElementKey(NODE, 1)), updates.deleted)
@@ -180,7 +181,7 @@ class MapDataUpdatesTest {
                 rel(-4, tags = mapOf("type" to "route"))
             ),
             updates = mapOf(ElementKey(RELATION, -4) to ElementUpdate.Update(4, 1)),
-            ignoreRelationTypes = setOf("route")
+            ApplicationConstants::isRelationIgnored
         )
         assertTrue(updates.idUpdates.isEmpty())
         assertTrue(updates.updated.isEmpty())
@@ -194,7 +195,7 @@ class MapDataUpdatesTest {
                 rel(-4, tags = mapOf("type" to "route"))
             ),
             updates = mapOf(ElementKey(RELATION, -4) to ElementUpdate.Update(4, 1)),
-            ignoreRelationTypes = setOf("route")
+            ApplicationConstants::isRelationIgnored
         )
         assertTrue(updates.idUpdates.isEmpty())
         assertEquals(

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/MapDataUpdatesTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/MapDataUpdatesTest.kt
@@ -181,7 +181,7 @@ class MapDataUpdatesTest {
                 rel(-4, tags = mapOf("type" to "route"))
             ),
             updates = mapOf(ElementKey(RELATION, -4) to ElementUpdate.Update(4, 1)),
-            ApplicationConstants::isRelationIgnored
+            ApplicationConstants::ignoreRelation
         )
         assertTrue(updates.idUpdates.isEmpty())
         assertTrue(updates.updated.isEmpty())
@@ -195,7 +195,7 @@ class MapDataUpdatesTest {
                 rel(-4, tags = mapOf("type" to "route"))
             ),
             updates = mapOf(ElementKey(RELATION, -4) to ElementUpdate.Update(4, 1)),
-            ApplicationConstants::isRelationIgnored
+            ApplicationConstants::ignoreRelation
         )
         assertTrue(updates.idUpdates.isEmpty())
         assertEquals(

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClientTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClientTest.kt
@@ -83,7 +83,7 @@ class MapDataApiClientTest {
     }
 
     @Test fun `getMap does not return relations of ignored type`(): Unit = runBlocking {
-        val hamburg = liveClient.getMap(AREA_NEAR_BUS_STATION, ApplicationConstants::isRelationIgnored)
+        val hamburg = liveClient.getMap(AREA_NEAR_BUS_STATION, ApplicationConstants::ignoreRelation)
         assertTrue(hamburg.relations.none { it.tags["type"] == "route" })
     }
 

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClientTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiClientTest.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.mapdata
 
+import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.AuthorizationException
 import de.westnordost.streetcomplete.data.ConflictException
 import de.westnordost.streetcomplete.data.QueryTooBigException
@@ -82,7 +83,7 @@ class MapDataApiClientTest {
     }
 
     @Test fun `getMap does not return relations of ignored type`(): Unit = runBlocking {
-        val hamburg = liveClient.getMap(AREA_NEAR_BUS_STATION, setOf("route"))
+        val hamburg = liveClient.getMap(AREA_NEAR_BUS_STATION, ApplicationConstants::isRelationIgnored)
         assertTrue(hamburg.relations.none { it.tags["type"] == "route" })
     }
 

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParserTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParserTest.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.data.osm.mapdata
 
+import de.westnordost.streetcomplete.ApplicationConstants
 import kotlinx.io.Buffer
 import kotlinx.io.writeString
 import kotlin.test.Test
@@ -11,7 +12,7 @@ class MapDataApiParserTest {
     @Test fun `parseMapData minimum`() {
         val buffer = Buffer()
         buffer.writeString("<osm></osm>")
-        val empty = MapDataApiParser().parseMapData(buffer, emptySet())
+        val empty = MapDataApiParser().parseMapData(buffer)
         assertEquals(0, empty.size)
         assertNull(empty.boundingBox)
     }
@@ -27,7 +28,7 @@ class MapDataApiParserTest {
             </osm>
         """)
 
-        val data = MapDataApiParser().parseMapData(buffer, emptySet())
+        val data = MapDataApiParser().parseMapData(buffer)
         assertEquals(nodesList.toSet(), data.nodes.toSet())
         assertEquals(waysList.toSet(), data.ways.toSet())
         assertEquals(relationsList.toSet(), data.relations.toSet())
@@ -44,7 +45,7 @@ class MapDataApiParserTest {
             </osm>
         """)
 
-        val empty = MapDataApiParser().parseMapData(buffer, setOf("route"))
+        val empty = MapDataApiParser().parseMapData(buffer, ApplicationConstants::isRelationIgnored)
         assertEquals(0, empty.size)
     }
 

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParserTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/MapDataApiParserTest.kt
@@ -45,7 +45,7 @@ class MapDataApiParserTest {
             </osm>
         """)
 
-        val empty = MapDataApiParser().parseMapData(buffer, ApplicationConstants::isRelationIgnored)
+        val empty = MapDataApiParser().parseMapData(buffer, ApplicationConstants::ignoreRelation)
         assertEquals(0, empty.size)
     }
 


### PR DESCRIPTION
As suggested in #6375 this function replaces the simple relationship filter and allows ferry routes to be processed while all other routes are still ignored.