### PR TITLE
Highlight `tourism=information` in board title quest

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
@@ -2,6 +2,9 @@ package de.westnordost.streetcomplete.quests.board_name
 
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
@@ -26,6 +29,9 @@ class AddBoardName : OsmFilterQuestType<BoardNameAnswer>(), AndroidQuest {
     override val achievements = listOf(OUTDOORS)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_board_name_title
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("nodes, ways, relations with tourism = information")
 
     override fun createForm() = AddBoardNameForm()
 


### PR DESCRIPTION
## Summary

Highlight other `tourism=information` elements when answering the board title quest to give context when there are other information boards nearby.

The element selection could be made more targeted to only display `information=board` and/or `information=map`, for instance. Currently, all `tourism=information` elements are highlighted. As of writing, [almost all of those have a `information=*`](https://taginfo.openstreetmap.org/tags/tourism=information#combinations) key (96.9%) of which [most are guideposts, information boards or maps (~87%)](https://taginfo.openstreetmap.org/keys/information#values), which should be the most relevant elements surrounding information boards.

## Screenshots

https://www.openstreetmap.org/node/2821098604#map=19/51.643955/12.427073:
<img width="400" alt="many boards" src="https://github.com/user-attachments/assets/df514aa2-4103-4e9a-8e0b-3bf0d3235dc9" />

https://www.openstreetmap.org/node/3187276262#map=19/51.788534/10.961767:
<img width="400" alt="hl maps and guideposts" src="https://github.com/user-attachments/assets/5824b036-d9b8-4372-ad26-84ac2f97ae00" />