### PR TITLE
Align highlighted elements for board type quests

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -30,7 +30,7 @@ class AddBoardType : OsmFilterQuestType<BoardTypeAnswer>(), AndroidQuest {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_board_type_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().filter("nodes with tourism = information and information = board")
+        getMapData().filter("nodes with tourism = information")
 
     override fun createForm() = AddBoardTypeForm()
 


### PR DESCRIPTION
## Summary

I noticed that the set of highlighted elements for the two board type quests (name and type) was different, which could be confusing when the quests trigger on the same (or nearby) elements. This PR aligns both by expanding the set of highlighted elements for the board type quest. This is a follow-up on #6418.

## Screenshot

https://www.openstreetmap.org/node/9199014037#map=19/50.705403/10.695204

<img width="360" alt="board type highlight" src="https://github.com/user-attachments/assets/7397c6bd-5ac5-432b-bd91-d9997afc21fb" />

