### PR TITLE
Ask fee of bicycle_wash

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -25,7 +25,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>(), AndroidQuest {
            )
            or tourism ~ museum|gallery|caravan_site|zoo|aquarium|wilderness_hut
            or leisure ~ beach_resort|disc_golf_course
-           or amenity ~ sanitary_dump_station|shower|water_point|public_bath
+           or amenity ~ sanitary_dump_station|shower|water_point|public_bath|bicycle_wash
            or natural = cave_entrance and access=yes
          )
          and access !~ private|no


### PR DESCRIPTION
Of the only 303 [amenity](https://wiki.openstreetmap.org/wiki/Key:amenity?uselang=en) =[bicycle_wash](https://wiki.openstreetmap.org/wiki/Tag:amenity=bicycle%20wash?uselang=en), 77 have fee=yes while 70 have fee=no.
Its not common, but very usefull to know if it has a fee.