### PR TITLE
added exersize station equipments to things

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -248,6 +248,7 @@ private val IS_THING_EXPRESSION by lazy {
         or amenity = recycling and recycling_type = container
         or attraction
         or boundary = marker
+        or fitness_station
         or leisure = pitch and sport ~ chess|table_soccer|table_tennis|teqball
         or playground
         or public_transport = platform and (


### PR DESCRIPTION
This allows these 10 exersize station equipments to be added via the "things" menu: https://github.com/openstreetmap/id-tagging-schema/tree/ff66003e33074b241b2ecaba240b5a128c1dce26/data/presets/leisure/fitness_station

see the corresponding wiki here: https://wiki.openstreetmap.org/wiki/Key:fitness_station
These things mostly use the "fitness station" icon, only the exercise rings, horizontal bar, balance beam and parallel bars have unique icons.