### PR TITLE
Added toilet types to "Things"

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -248,6 +248,7 @@ private val IS_THING_EXPRESSION by lazy {
         or amenity = recycling and recycling_type = container
         or attraction
         or boundary = marker
+        or fitness_station
         or leisure = pitch and sport ~ chess|table_soccer|table_tennis|teqball
         or playground
         or public_transport = platform and (

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -249,6 +249,7 @@ private val IS_THING_EXPRESSION by lazy {
         or attraction
         or boundary = marker
         or fitness_station
+        or toilets:disposal
         or leisure = pitch and sport ~ chess|table_soccer|table_tennis|teqball
         or playground
         or public_transport = platform and (


### PR DESCRIPTION
This acts as a alternative fix to #6380
This way the user can better specify which type of toilet they wish to add: portable, flush or pitlatrine: https://github.com/openstreetmap/id-tagging-schema/tree/ff66003e33074b241b2ecaba240b5a128c1dce26/data/presets/amenity/toilets
The existing "toilets" stays available so if a user is unsure they can simply fall back to this option.