### PR TITLE
AddAcceptsCash: limit further tourism values to fee=yes.

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -24,11 +24,11 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>(), AndroidQuest {
             "internet_cafe", "car_wash", "fuel", "pharmacy", "telephone", "vending_machine"
         )
         val tourismsWithImpliedFees = listOf(
-            "zoo", "aquarium", "theme_park", "hotel", "hostel", "motel", "guest_house",
+            "theme_park", "hotel", "hostel", "motel", "guest_house",
             "apartment", "camp_site"
         )
         val tourismsWithoutImpliedFees = listOf(
-            "attraction", "museum", "gallery"
+            "attraction", "museum", "gallery", "zoo", "aquarium", "wilderness_hut"
         )
         val leisures = listOf(
             "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game", "miniature_golf",

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -28,7 +28,7 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>(), AndroidQuest {
             "apartment", "camp_site"
         )
         val tourismsWithoutImpliedFees = listOf(
-            "attraction", "museum", "gallery", "zoo", "aquarium", "wilderness_hut"
+            "attraction", "museum", "gallery", "zoo", "aquarium"
         )
         val leisures = listOf(
             "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game", "miniature_golf",


### PR DESCRIPTION
Since we now ask for fee of zoo and aquarium(https://github.com/streetcomplete/StreetComplete/issues/6350), we can limit this quest for places that have such a fee=yes.
Additionally I added wilderness_hut since we now also ask for its fee.
