### PR TITLE
expanded addAcceptsCards to alpine huts

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -19,6 +19,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>(), AndroidQuest {
         nodes, ways with (
           amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar
           or (shop and shop !~ no|vacant|mall)
+          or tourism = alpine_hut
         )
         and !payment:credit_cards and !payment:debit_cards and payment:others != no
         and !brand and !wikipedia:brand and !wikidata:brand


### PR DESCRIPTION
Alpine huts are commonly in places where internet access is not available, thus it is especially useful to know beforehand if card payment is possible.
Tested.