### PR TITLE
add luggage locker to payment quests

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -17,7 +17,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>(), AndroidQuest {
 
     override val elementFilter = """
         nodes, ways with (
-          amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar
+          amenity ~ restaurant|cafe|fast_food|ice_cream|pub|bar|luggage_locker
           or (shop and shop !~ no|vacant|mall)
           or tourism = alpine_hut
         )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -21,7 +21,7 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>(), AndroidQuest {
         val amenities = listOf(
             "bar", "cafe", "fast_food", "ice_cream", "pub", "biergarten", "restaurant", "fuel",
             "cinema", "nightclub", "planetarium", "theatre", "internet_cafe", "car_wash",
-            "pharmacy", "telephone", "vending_machine"
+            "pharmacy", "telephone", "vending_machine", "luggage_locker"
         )
         val tourismsWithImpliedFees = listOf(
             "theme_park", "hotel", "hostel", "motel", "guest_house",


### PR DESCRIPTION
I also removed food court as discussed here: https://github.com/streetcomplete/StreetComplete/pull/6519

Luggage lockers are very usefull to know about since they are for tourists who might in a place where they dont have local currency like airports or train stations.