### PR TITLE
More space for the label of the About section

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainMenuDialog.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainMenuDialog.kt
@@ -142,7 +142,7 @@ private fun BigMenuButton(
         modifier = modifier
             .width(160.dp)
             .clickable { onClick() }
-            .padding(16.dp),
+            .padding(10.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         icon()


### PR DESCRIPTION
Now the label is ugly split into two lines and only one character remains in the first line.

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>

<img width="1080" height="2400" alt="Screenshot_20260327_210746_StreetComplete Dev" src="https://github.com/user-attachments/assets/185b73d6-703f-4425-adaf-9488aa6b739e" />

 <td>

<img width="1080" height="2400" alt="Screenshot_20260327_210728_StreetComplete Dev" src="https://github.com/user-attachments/assets/b3f9e898-273f-493f-a9f5-c85868c4e85e" />

</table>