### PR TITLE
New quest: In what direction can bicycles ride on this sidewalk?

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -124,6 +124,7 @@ import de.westnordost.streetcomplete.quests.moped.AddMopedAccess
 import de.westnordost.streetcomplete.quests.motorcycle_parking_capacity.AddMotorcycleParkingCapacity
 import de.westnordost.streetcomplete.quests.motorcycle_parking_cover.AddMotorcycleParkingCover
 import de.westnordost.streetcomplete.quests.note_discussion.OsmNoteQuestType
+import de.westnordost.streetcomplete.quests.oneway.AddCyclewayDirection
 import de.westnordost.streetcomplete.quests.oneway.AddOneway
 import de.westnordost.streetcomplete.quests.oneway.AddOnewayAerialway
 import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
@@ -554,6 +555,7 @@ fun questTypeRegistry(
     // footways
     143 to AddPathSurface(), // used by OSM Carto, BRouter, OsmAnd, OSRM, graphhopper...
     144 to AddCyclewaySegregation(), // Cyclosm, Valhalla, Bike Citizens Bicycle Navigation...
+    198 to AddCyclewayDirection(),
     145 to AddFootwayPartSurface(),
     146 to AddCyclewayPartSurface(),
     147 to AddSidewalkSurface(),

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
@@ -38,7 +38,7 @@ class AddCyclewayDirection : OsmFilterQuestType<OnewayAnswer>(), AndroidQuest {
     override val hasMarkersAtEnds = true
     override val achievements = listOf(BICYCLIST)
     override val hint = Res.string.quest_arrow_tutorial
-    override val defaultDisabledMessage = Res.string.default_disabled_msg_maxspeed
+    override val defaultDisabledMessage = Res.string.default_disabled_msg_visible_sign_bicycle_sidewalk_access
     override val enabledInCountries = NoCountriesExcept("DE")
 
     override fun createForm() = AddCyclewayDirectionForm()

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
@@ -39,7 +39,7 @@ class AddCyclewayDirection : OsmFilterQuestType<OnewayAnswer>(), AndroidQuest {
     override val achievements = listOf(BICYCLIST)
     override val hint = Res.string.quest_arrow_tutorial
     override val defaultDisabledMessage = Res.string.default_disabled_msg_visible_sign_bicycle_sidewalk_access
-    override val enabledInCountries = NoCountriesExcept("DE")
+    override val enabledInCountries = NoCountriesExcept("DE", "AT", "DK", "NL", "FI", "NO")
 
     override fun createForm() = AddCyclewayDirectionForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
@@ -20,12 +20,9 @@ class AddCyclewayDirection : OsmFilterQuestType<OnewayAnswer>(), AndroidQuest {
     override val elementFilter = """
         ways with
           (
-            highway = cycleway
-            or (
-              highway ~ path|footway
+              (highway ~ path|footway) or (highway = cycleway)
               and (footway = sidewalk or is_sidepath = yes)
               and bicycle ~ yes|designated
-            )
           )
           and !oneway
           and !oneway:bicycle

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
@@ -1,0 +1,70 @@
+package de.westnordost.streetcomplete.quests.oneway
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.BACKWARD
+import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.FORWARD
+import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.NO_ONEWAY
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.default_disabled_msg_maxspeed
+import de.westnordost.streetcomplete.resources.quest_arrow_tutorial
+import de.westnordost.streetcomplete.resources.quest_cycleway_direction_title
+
+class AddCyclewayDirection : OsmFilterQuestType<OnewayAnswer>(), AndroidQuest {
+
+    override val elementFilter = """
+        ways with
+          (
+            highway = cycleway
+            or (
+              highway ~ path|footway
+              and (footway = sidewalk or is_sidepath = yes)
+              and bicycle ~ yes|designated
+            )
+          )
+          and !oneway
+          and !oneway:bicycle
+          and area != yes
+          and junction != roundabout
+          and access !~ private|no
+    """
+
+    override val changesetComment = "Specify in which direction cyclists may ride this path"
+    override val wikiLink = "Key:oneway:bicycle"
+    override val icon = R.drawable.quest_bicycleway_oneway
+    override val title = Res.string.quest_cycleway_direction_title
+    override val hasMarkersAtEnds = true
+    override val achievements = listOf(BICYCLIST)
+    override val hint = Res.string.quest_arrow_tutorial
+    override val defaultDisabledMessage = Res.string.default_disabled_msg_maxspeed
+    override val enabledInCountries = NoCountriesExcept("DE")
+
+    override fun createForm() = AddCyclewayDirectionForm()
+
+    override fun applyAnswerTo(
+        answer: OnewayAnswer,
+        tags: Tags,
+        geometry: ElementGeometry,
+        timestampEdited: Long,
+    ) {
+        val key = if (tags["highway"] == "cycleway" &&
+            tags["foot"] !in setOf("yes", "designated") &&
+            tags["segregated"] != "yes"
+        ) {
+            "oneway"
+        } else {
+            "oneway:bicycle"
+        }
+
+        tags[key] = when (answer) {
+            FORWARD -> "yes"
+            BACKWARD -> "-1"
+            NO_ONEWAY -> "no"
+        }
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirection.kt
@@ -19,11 +19,9 @@ class AddCyclewayDirection : OsmFilterQuestType<OnewayAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-          (
-              (highway ~ path|footway) or (highway = cycleway)
-              and (footway = sidewalk or is_sidepath = yes)
-              and bicycle ~ yes|designated
-          )
+          highway ~ path|footway|cycleway
+          and (footway = sidewalk or is_sidepath = yes)
+          and bicycle ~ yes|designated
           and !oneway
           and !oneway:bicycle
           and area != yes

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirectionForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddCyclewayDirectionForm.kt
@@ -1,0 +1,39 @@
+package de.westnordost.streetcomplete.quests.oneway
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import de.westnordost.streetcomplete.quests.AItemSelectQuestForm
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.quest_cycleway_direction_dir
+import de.westnordost.streetcomplete.resources.quest_cycleway_direction_no_oneway
+import de.westnordost.streetcomplete.ui.common.item_select.ImageWithLabel
+import de.westnordost.streetcomplete.ui.util.ClipCirclePainter
+import kotlinx.serialization.serializer
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+class AddCyclewayDirectionForm : AItemSelectQuestForm<OnewayAnswer, OnewayAnswer>() {
+
+    override val items = OnewayAnswer.entries
+    override val itemsPerRow = 3
+    override val serializer = serializer<OnewayAnswer>()
+
+    @Composable override fun ItemContent(item: OnewayAnswer) {
+        val painter = painterResource(item.icon)
+        ImageWithLabel(
+            painter = remember(painter) { ClipCirclePainter(painter) },
+            label = stringResource(item.cyclewayDirectionTitle),
+            imageRotation = geometryRotation.floatValue - mapRotation.floatValue,
+        )
+    }
+
+    override fun onClickOk(selectedItem: OnewayAnswer) {
+        applyAnswer(selectedItem)
+    }
+}
+
+private val OnewayAnswer.cyclewayDirectionTitle: StringResource get() = when (this) {
+    OnewayAnswer.FORWARD, OnewayAnswer.BACKWARD -> Res.string.quest_cycleway_direction_dir
+    OnewayAnswer.NO_ONEWAY -> Res.string.quest_cycleway_direction_no_oneway
+}

--- a/app/src/commonMain/composeResources/values-de/strings.xml
+++ b/app/src/commonMain/composeResources/values-de/strings.xml
@@ -699,8 +699,8 @@ Erfolge</string>
     <string name="quest_oneway2_title">Ist dies eine Einbahnstraße? In welche Richtung?</string>
     <string name="quest_oneway2_dir">Einbahn­straße in diese Richtung</string>
     <string name="quest_oneway2_no_oneway">Keine Einbahn­straße</string>
-    <string name="quest_cycleway_direction_title">In welche Richtung darf man hier mit dem Fahrrad fahren?</string>
-    <string name="quest_cycleway_direction_dir">Nur in die Richtung</string>
+    <string name="quest_cycleway_direction_title">In welche Richtung darf man mit dem Fahrrad auf diesem Bürgersteig fahren?</string>
+    <string name="quest_cycleway_direction_dir">Nur in diese Richtung</string>
     <string name="quest_cycleway_direction_no_oneway">In beide Richtungen</string>
     <string name="default_disabled_msg_visible_sign_bicycle_sidewalk_access">Dieser Aufgabentyp ist standardmäßig deaktiviert, da der Zugang für für Fahrräder auf dem Bürgersteig nur durch bestimmte Schilder am Anfang/Ende einer Straße gekennzeichnet ist.</string>
     <string name="quest_steps_incline_title">Welche Richtung führt hier nach oben?</string>

--- a/app/src/commonMain/composeResources/values-de/strings.xml
+++ b/app/src/commonMain/composeResources/values-de/strings.xml
@@ -702,6 +702,7 @@ Erfolge</string>
     <string name="quest_cycleway_direction_title">In welche Richtung darf man hier mit dem Fahrrad fahren?</string>
     <string name="quest_cycleway_direction_dir">Nur in die Richtung</string>
     <string name="quest_cycleway_direction_no_oneway">In beide Richtungen</string>
+    <string name="default_disabled_msg_visible_sign_bicycle_sidewalk_access">Dieser Aufgabentyp ist standardmäßig deaktiviert, da der Zugang für für Fahrräder auf dem Bürgersteig nur durch bestimmte Schilder am Anfang/Ende einer Straße gekennzeichnet ist.</string>
     <string name="quest_steps_incline_title">Welche Richtung führt hier nach oben?</string>
     <string name="quest_steps_incline_up">Hier nach oben</string>
     <string name="quest_step_count_title">Wie viele Stufen gibt es hier?</string>

--- a/app/src/commonMain/composeResources/values-de/strings.xml
+++ b/app/src/commonMain/composeResources/values-de/strings.xml
@@ -699,6 +699,9 @@ Erfolge</string>
     <string name="quest_oneway2_title">Ist dies eine Einbahnstraße? In welche Richtung?</string>
     <string name="quest_oneway2_dir">Einbahn­straße in diese Richtung</string>
     <string name="quest_oneway2_no_oneway">Keine Einbahn­straße</string>
+    <string name="quest_cycleway_direction_title">In welche Richtung darf man hier mit dem Fahrrad fahren?</string>
+    <string name="quest_cycleway_direction_dir">Nur in die Richtung</string>
+    <string name="quest_cycleway_direction_no_oneway">In beide Richtungen</string>
     <string name="quest_steps_incline_title">Welche Richtung führt hier nach oben?</string>
     <string name="quest_steps_incline_up">Hier nach oben</string>
     <string name="quest_step_count_title">Wie viele Stufen gibt es hier?</string>

--- a/app/src/commonMain/composeResources/values-en/strings.xml
+++ b/app/src/commonMain/composeResources/values-en/strings.xml
@@ -1313,6 +1313,9 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_oneway2_title">Is this a one-way street? In which direction?</string>
     <string name="quest_oneway2_dir">Oneway in this direction</string>
     <string name="quest_oneway2_no_oneway">Not a oneway</string>
+    <string name="quest_cycleway_direction_title">In what direction are you allowed to ride this path?</string>
+    <string name="quest_cycleway_direction_dir">Only this way</string>
+    <string name="quest_cycleway_direction_no_oneway">In both directions</string>
 
     <string name="quest_openingHours_title">What are the opening hours here?</string>
     <string name="quest_openingHours_signed_title">Are the opening hours here signed?</string>

--- a/app/src/commonMain/composeResources/values-en/strings.xml
+++ b/app/src/commonMain/composeResources/values-en/strings.xml
@@ -1316,6 +1316,9 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_cycleway_direction_title">In what direction are you allowed to ride this path?</string>
     <string name="quest_cycleway_direction_dir">Only this way</string>
     <string name="quest_cycleway_direction_no_oneway">In both directions</string>
+    
+    <string name="default_disabled_msg_visible_sign_bicycle_sidewalk_access">This quest type is disabled by default because bicycle access on sidewalks is only indicated by specific signs at start/end of a sidewalk.</string>
+
 
     <string name="quest_openingHours_title">What are the opening hours here?</string>
     <string name="quest_openingHours_signed_title">Are the opening hours here signed?</string>

--- a/app/src/commonMain/composeResources/values-en/strings.xml
+++ b/app/src/commonMain/composeResources/values-en/strings.xml
@@ -1313,7 +1313,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_oneway2_title">Is this a one-way street? In which direction?</string>
     <string name="quest_oneway2_dir">Oneway in this direction</string>
     <string name="quest_oneway2_no_oneway">Not a oneway</string>
-    <string name="quest_cycleway_direction_title">In what direction are you allowed to ride this path?</string>
+    <string name="quest_cycleway_direction_title">In what direction are you allowed to cycle on this sidewalk?</string>
     <string name="quest_cycleway_direction_dir">Only this way</string>
     <string name="quest_cycleway_direction_no_oneway">In both directions</string>
     

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1315,7 +1315,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_oneway2_title">Is this a one-way street? In which direction?</string>
     <string name="quest_oneway2_dir">Oneway in this direction</string>
     <string name="quest_oneway2_no_oneway">Not a oneway</string>
-    <string name="quest_cycleway_direction_title">In what direction are you allowed to ride this path?</string>
+    <string name="quest_cycleway_direction_title">In what direction are you allowed to cycle on this sidewalk?</string>
     <string name="quest_cycleway_direction_dir">Only this way</string>
     <string name="quest_cycleway_direction_no_oneway">In both directions</string>
 

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1319,6 +1319,8 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_cycleway_direction_dir">Only this way</string>
     <string name="quest_cycleway_direction_no_oneway">In both directions</string>
 
+    <string name="default_disabled_msg_visible_sign_bicycle_sidewalk_access">This quest type is disabled by default because bicycle access on sidewalks is only indicated by specific signs at start/end of a sidewalk.</string>
+
     <string name="quest_openingHours_title">What are the opening hours here?</string>
     <string name="quest_openingHours_signed_title">Are the opening hours here signed?</string>
     <string name="quest_openingHours_resurvey_title">Are these opening hours still correct?</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1315,6 +1315,9 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_oneway2_title">Is this a one-way street? In which direction?</string>
     <string name="quest_oneway2_dir">Oneway in this direction</string>
     <string name="quest_oneway2_no_oneway">Not a oneway</string>
+    <string name="quest_cycleway_direction_title">In what direction are you allowed to ride this path?</string>
+    <string name="quest_cycleway_direction_dir">Only this way</string>
+    <string name="quest_cycleway_direction_no_oneway">In both directions</string>
 
     <string name="quest_openingHours_title">What are the opening hours here?</string>
     <string name="quest_openingHours_signed_title">Are the opening hours here signed?</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1316,7 +1316,7 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_oneway2_dir">Oneway in this direction</string>
     <string name="quest_oneway2_no_oneway">Not a oneway</string>
     <string name="quest_cycleway_direction_title">In what direction are you allowed to cycle on this sidewalk?</string>
-    <string name="quest_cycleway_direction_dir">Only this way</string>
+    <string name="quest_cycleway_direction_dir">Only this direction</string>
     <string name="quest_cycleway_direction_no_oneway">In both directions</string>
 
     <string name="default_disabled_msg_visible_sign_bicycle_sidewalk_access">This quest type is disabled by default because bicycle access on sidewalks is only indicated by specific signs at start/end of a sidewalk.</string>


### PR DESCRIPTION
This PR adds a quest "In what direction are bicycles allowed to travel here?" that is asked for sidewalk-like ways. Background is the problem that (at least in germany) cycling on sidewalks (if allowed) is usually only allowed in one direction (the direction of traffic on this side), but it is possible in StreetComplete to convert a sidewalk into a sidewalk with a cycleway or where cycling is allowed, but currently no way to enter the direction of allowed travel for bicycles.
Implemented based on [AddOnewayBicycle](https://github.com/Helium314/SCEE/pull/881/) in SCEE by @mcliquid.

<img height="1280" alt="photo_2026-04-16_06-51-42" src="https://github.com/user-attachments/assets/3361a0f9-6f20-41e2-829e-173fd4865782" />


Potentially closes #4827

Things that are still to-do/to-sort-out:
- Quest icon: Do we want to use the one from SCEE? (Currently implemented like that)
- Direction icons: There was discussion if they are enough to show what is beeing entered, or if other icons should be used (Currently the oneway ones are implemented)
    - Answer wording: Is the current wording under the icons okay to communicate what is asked or should it be different?
- Enabled countries: Currently only enabled in Germany, Austria, Denkmark, Nederlands, Finland, Norway but other countries could be added if the need arises.
- Regarding seperate sidewalk quest: I do not think there is the explicit _need_ for such a quest before this one can be greenlit. But if such a functionality is wanted, my idea would be to intregrate it into the sidewalk-overlay. Paths could be clickable and instead of all foot-paths beeing blue only those that are sidewalk-like could be blue, all others black and when tapping such a path a combobox or checkbox "This is a sidewalk" could pop up, but there should be separate discussion for that.
