### PR TITLE
Add "no toilets" to AddBabyChangingTable Quest

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -6,11 +6,10 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddBabyChangingTable : OsmFilterQuestType<Boolean>(), AndroidQuest {
+class AddBabyChangingTable : OsmFilterQuestType<Boolean?>(), AndroidQuest {
 
     override val elementFilter = """
         nodes, ways with
@@ -33,9 +32,12 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean>(), AndroidQuest {
     override val achievements = listOf(CITIZEN)
     override val defaultDisabledMessage = Res.string.default_disabled_msg_go_inside
 
-    override fun createForm() = YesNoQuestForm()
+    override fun createForm() = AddBabyChangingTableForm()
 
-    override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        tags["changing_table"] = answer.toYesNo()
+    override fun applyAnswerTo(answer: Boolean?, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        if(answer == null)
+            tags["toilets"] = "no"
+        else
+            tags["changing_table"] = answer.toYesNo()
     }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -6,10 +6,11 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.baby_changing_table.BabyChangingTableAnswer.*
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddBabyChangingTable : OsmFilterQuestType<Boolean?>(), AndroidQuest {
+class AddBabyChangingTable : OsmFilterQuestType<BabyChangingTableAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         nodes, ways with
@@ -34,10 +35,11 @@ class AddBabyChangingTable : OsmFilterQuestType<Boolean?>(), AndroidQuest {
 
     override fun createForm() = AddBabyChangingTableForm()
 
-    override fun applyAnswerTo(answer: Boolean?, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        if(answer == null)
-            tags["toilets"] = "no"
-        else
-            tags["changing_table"] = answer.toYesNo()
+    override fun applyAnswerTo(answer: BabyChangingTableAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        when (answer) {
+            YES -> tags["changing_table"] = "yes"
+            NO -> tags["changing_table"] = "no"
+            NO_TOILET -> tags["toilets"] = "no"
+        }
     }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.quests.baby_changing_table
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
+import de.westnordost.streetcomplete.quests.AnswerItem
+
+class AddBabyChangingTableForm : AbstractOsmQuestForm<Boolean?>() {
+
+    override val buttonPanelAnswers = listOf(
+        AnswerItem(R.string.quest_generic_hasFeature_no) { applyAnswer(false) },
+        AnswerItem(R.string.quest_generic_hasFeature_yes) { applyAnswer(true) }
+    )
+
+    override val otherAnswers get() = listOf(
+        AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(null) }
+    )
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
@@ -3,15 +3,16 @@ package de.westnordost.streetcomplete.quests.baby_changing_table
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
+import de.westnordost.streetcomplete.quests.baby_changing_table.BabyChangingTableAnswer.*
 
-class AddBabyChangingTableForm : AbstractOsmQuestForm<Boolean?>() {
+class AddBabyChangingTableForm : AbstractOsmQuestForm<BabyChangingTableAnswer>() {
 
     override val buttonPanelAnswers = listOf(
-        AnswerItem(R.string.quest_generic_hasFeature_no) { applyAnswer(false) },
-        AnswerItem(R.string.quest_generic_hasFeature_yes) { applyAnswer(true) }
+        AnswerItem(R.string.quest_generic_hasFeature_no) { applyAnswer(NO) },
+        AnswerItem(R.string.quest_generic_hasFeature_yes) { applyAnswer(YES) }
     )
 
     override val otherAnswers get() = listOf(
-        AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(null) }
+        AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NO_TOILET) }
     )
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/BabyChangingTableAnswer.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/BabyChangingTableAnswer.kt
@@ -1,0 +1,3 @@
+package de.westnordost.streetcomplete.quests.baby_changing_table
+
+enum class BabyChangingTableAnswer { YES, NO, NO_TOILET }


### PR DESCRIPTION
In https://github.com/streetcomplete/StreetComplete/pull/6115 the baby changing table quest filter was modifed to no longer require toilets=yes.

However places without toilets exist, but are rare. This option can be used in such cases to mark them as `toilets=no`.

I implemented this with a null value, to avoid adding a new "answer" file, since it seemed overkill for this.
Also `null` seems like a good abstraction of what a place without a toilet entails.