### PR TITLE
Typo: unnecessary uppercase in "Bicycle boulevard"

### DIFF
--- a/app/src/androidMain/res/values/strings.xml
+++ b/app/src/androidMain/res/values/strings.xml
@@ -1802,7 +1802,7 @@ Partially means that a wheelchair can enter and use the restroom, but no handrai
     <string name="overlay_cycleway">Bike paths</string>
     <string name="bicycle_boulevard_is_a">It’s a %1$s</string>
     <string name="bicycle_boulevard_is_not_a">It’s not a %1$s</string>
-    <string name="bicycle_boulevard">Bicycle boulevard</string>
+    <string name="bicycle_boulevard">bicycle boulevard</string>
     <string name="pedestrian_zone_designated">Designated for cycling here</string>
     <string name="pedestrian_zone_allowed_sign">A sign allows cycling here</string>
     <string name="pedestrian_zone_no_sign">No explicit sign about cycling here</string>


### PR DESCRIPTION
I'd just like to fix this typo. Not sure whether I should also update the strings.xml in commonMain/ ?

<img width="1080" height="2190" alt="Screenshot_20260505-012551" src="https://github.com/user-attachments/assets/2c15f9ad-b65e-465a-8e23-cfe5f6fb5cfe" />
