### PR TITLE
make app license unambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Also, if you like StreetComplete, **spread the word**! ❤️
 
 ## License
 
-This software is released under the terms of the [GNU General Public License](http://www.gnu.org/licenses/gpl-3.0.html).
+This software is released under the terms of the [GNU General Public License v3.0 only](http://www.gnu.org/licenses/gpl-3.0.html).
 
 ## Sponsors
 


### PR DESCRIPTION
* this makes license unambiguous
* github/gitlab license templates does not distinguish between only or later versions. ex, version 3 only OR version 3 or later.
* feel free to outright reject or accept as it is, however, make time to explicitly declare or educate your choosen license without any ambiguity for your code !
* License: GPL-3.0-only https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/de.westnordost.streetcomplete.yml
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html