### PR TITLE
extended quests to slaughterhouses, and scrapyards

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -64,6 +64,10 @@ mapOf(
         // a bank that might be just next door because the app does not tell the user what
         // kind of object this is about
     ),
+    "industrial" to arrayOf(
+        // name & opening hours
+        "scrap_yard"
+    ),
     "tourism" to arrayOf(
         // common
         "zoo", "aquarium", "theme_park", "gallery", "museum"

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -74,6 +74,12 @@ class AddPlaceName(
                 "kindergarten", "school", "college", "university", "research_institute", // education
                 "dojo",                                                                  // sport
             ),
+            "industrial" to arrayOf(
+                // name & opening hours
+                "scrap_yard",
+                // name only
+                "slaughterhouse"
+            ),
             "tourism" to arrayOf(
                 // common
                 "zoo", "aquarium", "theme_park", "gallery", "museum",

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
@@ -164,6 +164,10 @@ private val IS_PLACE_EXPRESSION by lazy {
             "mountain_rescue",
             "water_rescue",
         ),
+        "industrial" to listOf(
+            "scrap_yard",
+            "slaughterhouse",
+        ),
         "leisure" to listOf(
             "adult_gaming_centre",
             "amusement_arcade",


### PR DESCRIPTION
Tested.

Adds [slaughterhouses](https://wiki.openstreetmap.org/wiki/Tag:industrial%3Dslaughterhouse) and [scrap](https://wiki.openstreetmap.org/wiki/Tag:industrial%3Dscrap_yard) yards as "places" and extends the name quest to them. Additionally, adds scrap yards to opening hours quest.
3.5% of scap yards have opening hours tagged.
30% of scrap yards have names tagged.
