### PR TITLE
include highway=elevator in osm/Things

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -145,6 +145,7 @@ private val IS_THING_EXPRESSION by lazy {
         "highway" to listOf(
             // "bus_stop", handled in filter below to skip some common bad tagging
             "cyclist_waiting_aid",
+            "elevator",
             "emergency_access_point",
             "hitchhiking",
             "milestone",


### PR DESCRIPTION
In our local mapping community, we just had someone from the local government request for lifts/elevators to be better mapped, and it reminded me of an annoyance that I can't contribute this via SC.

This change is not yet tested, but from what I can see this would allow lift/elevator nodes to be placed as Things.

This is useful for wayfinding, especially those less mobile who might not be able to use stairs.

Given lifts could also be mapped as an area (representing the lift/elevator shaft) we should ensure those already mapped as an area still appear on the map as features to avoid duplicate nodes being added.

PS. it would be awesome if we had a GitHub CI which could build an APK from the PR that I could then load up to test.