### PR TITLE
expanded quests to ranger stations

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -45,7 +45,8 @@ mapOf(
         "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten",         // eat & drink
         "food_court", "nightclub", "hookah_lounge",
         "cinema", "planetarium", "casino",                                                  // amenities
-        "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library", // civic
+        "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",
+        "ranger_station",                                                                   // civic
         "driving_school", "music_school", "prep_school", "language_school", "dive_centre",  // learning
         "dancing_school", "ski_school", "flight_school", "surf_school", "sailing_school",
         "cooking_school",

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -41,7 +41,8 @@ class AddPlaceName(
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten",         // eat & drink
                 "food_court", "nightclub", "hookah_lounge",
                 "cinema", "planetarium", "casino",                                                  // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library", // civic
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",
+                "ranger_station",                                                                   // civic
                 "driving_school", "music_school", "prep_school", "language_school", "dive_centre",  // learning
                 "dancing_school", "ski_school", "flight_school", "surf_school", "sailing_school",
                 "cooking_school",
@@ -59,7 +60,7 @@ class AddPlaceName(
                 // name & wheelchair
                 "theatre",                                        // culture
                 "conference_centre", "arts_centre",               // events
-                "police", "ranger_station",                       // civic
+                "police",                                         // civic
                 "ferry_terminal",                                 // transport
                 "place_of_worship",                               // religious
                 "hospital",                                       // health care

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -21,6 +21,7 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>(), AndroidQuest {
           or highway ~ services|rest_area
           or tourism ~ camp_site|caravan_site|wilderness_hut
           or leisure = bathing_place
+          or amenity = ranger_station
         )
         and !toilets
     """

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -37,7 +37,8 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>(), Andr
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten",         // eat & drink
                 "food_court", "nightclub", "hookah_lounge",
                 "cinema", "planetarium", "casino",                                                  // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library", // civic
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",
+                "ranger_station",                                                                   // civic
                 "driving_school", "music_school", "prep_school", "language_school", "dive_centre",  // learning
                 "dancing_school", "ski_school", "flight_school", "surf_school", "sailing_school",
                 "cooking_school",
@@ -51,7 +52,7 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>(), Andr
                 // name & wheelchair
                 "theatre",                                        // culture
                 "conference_centre", "arts_centre",               // events
-                "police", "ranger_station",                       // civic
+                "police",                                         // civic
                 "ferry_terminal",                                 // transport
                 "place_of_worship",                               // religious
                 "hospital",                                       // health care


### PR DESCRIPTION
Expands quests to [ranger_stations](https://wiki.openstreetmap.org/wiki/Tag%3Aamenity%3Dranger_station):

- AddToilets, currently only around 0.5% of ranger stations have this tag
- AddOpeningHours: currently 3.6% of ranger_stations have this tag.

In my experience (mostly Europe) most ranger stations have regular opening hours and often toilets.

The wiki defines them as

> The location of an official park visitor facility building (one directly associated with a park or natural area). Such buildings typically offer a variety of services such as police services, visitor information, permits, exhibits, lost & found, etc. A ranger station is generally the first and primary spot for visitors. 
