### PR TITLE
Yolo decimal

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightForm.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.intl.Locale
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.databinding.ComposeViewBinding
@@ -52,7 +53,7 @@ class AddMaxHeightForm : AbstractOsmQuestForm<MaxHeightAnswer>() {
                     height.value = it
                     checkIsFormComplete()
                 },
-                countryCode = countryInfo.countryCode,
+                locale = countryInfo.languageTag?.let { Locale(it) } ?: Locale.current,
                 modifier = Modifier.fillMaxWidth()
             )
         } }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeightForm.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.text.intl.Locale
 import androidx.lifecycle.lifecycleScope
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.ComposeViewBinding
@@ -40,7 +41,7 @@ class AddMaxWeightForm : AbstractOsmQuestForm<List<MaxWeight>>() {
         binding.composeViewBase.content { Surface {
             MaxWeightForm(
                 signs = signs,
-                countryCode = countryInfo.countryCode,
+                locale = countryInfo.languageTag?.let { Locale(it) } ?: Locale.current,
                 selectableUnits = weightLimitUnits,
                 onSignAdded = { maxweight ->
                     signs.add(maxweight)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightForm.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.data.meta.LengthUnit
 import de.westnordost.streetcomplete.osm.Length
@@ -28,13 +29,13 @@ import androidx.compose.ui.tooling.preview.Preview
 
 /** Displays a form to input the max height, as specified on the sign. For clarity and fun, the
  *  input fields are shown on a sign background that resembles a maxheight sign in the given
- *  [countryCode] */
+ *  [locale] */
 @Composable
 fun MaxHeightForm(
     length: Length?,
     onChange: (Length?) -> Unit,
     selectableUnits: List<LengthUnit>,
-    countryCode: String?,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
     var selectedUnit by rememberSerializable { mutableStateOf(length?.unit ?: selectableUnits[0]) }
@@ -47,7 +48,7 @@ fun MaxHeightForm(
         modifier = modifier,
     ) {
         MaxHeightSign(
-            countryCode = countryCode,
+            countryCode = locale.region,
             modifier = Modifier.align(Alignment.Center)
         ) {
             when (selectedUnit) {
@@ -57,6 +58,7 @@ fun MaxHeightForm(
                             length = length as? Length.Meters,
                             onChange = onChange,
                             maxMeterDigits = Pair(3, 2),
+                            locale = locale,
                         )
                     }
                 }
@@ -97,7 +99,7 @@ fun MaxHeightFormPreview() {
             length = length,
             onChange = { length = it },
             selectableUnits = listOf(LengthUnit.FOOT_AND_INCH, LengthUnit.METER),
-            countryCode = "US",
+            locale = Locale("en-US"),
         )
         Text(length?.toOsmValue().orEmpty(), Modifier.padding(16.dp))
     }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/MaxWeightForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/MaxWeightForm.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import com.cheonjaeung.compose.grid.SimpleGridCells
 import de.westnordost.streetcomplete.data.meta.WeightMeasurementUnit
@@ -31,11 +32,13 @@ fun MaxWeightForm(
     onSignAdded: (MaxWeight) -> Unit,
     onSignRemoved: (index: Int) -> Unit,
     onSignChanged: (index: Int, MaxWeight) -> Unit,
-    countryCode: String,
+    locale: Locale,
     selectableUnits: List<WeightMeasurementUnit>,
     modifier: Modifier = Modifier,
 ) {
     var showSelectionDialog by remember { mutableStateOf(false) }
+
+    val countryCode = locale.region
 
     val selectableMaxWeightTypes = MaxWeightType.entries.filter { type ->
         type !in signs.map { it.type } &&
@@ -56,7 +59,7 @@ fun MaxWeightForm(
                     type = sign.type,
                     weight = sign.weight,
                     onWeightChange = { onSignChanged(index, signs[index].copy(weight = it)) },
-                    countryCode = countryCode,
+                    locale = locale,
                     selectableUnits = selectableUnits,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/MaxWeightSignForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/MaxWeightSignForm.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.data.meta.WeightMeasurementUnit
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightType.*
@@ -25,14 +26,14 @@ import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 
 /** A form to input the [weight] for a single max weight sign [type]. The signs shown
- *  should look similar to how the signs actually look in the country with the given [countryCode]
+ *  should look similar to how the signs actually look in the country with the given [locale]
  */
 @Composable
 fun MaxWeightSignForm(
     type: MaxWeightType,
     weight: Weight?,
     onWeightChange: (Weight?) -> Unit,
-    countryCode: String,
+    locale: Locale,
     selectableUnits: List<WeightMeasurementUnit>,
     modifier: Modifier = Modifier,
 ) {
@@ -53,51 +54,58 @@ fun MaxWeightSignForm(
         onWeightChange(value?.let { Weight(it, newUnit) })
     }
 
+    val countryCode = locale.region
+
     val color =
         if (countryCode in listOf("FI", "IS", "SE")) TrafficSignColor.Yellow
         else TrafficSignColor.White
 
     val unitTextStyle = MaterialTheme.typography.largeInput
 
+    val weightInput: @Composable () -> Unit = {
+        WeightInput(
+            value = value,
+            onValueChange = onValueChange,
+            locale = locale
+        )
+    }
+
+    val weightInputMutcd: @Composable () -> Unit = {
+        WeightInputMutcd(
+            value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle,
+            locale = locale
+        )
+    }
+
     Box(modifier) {
         when (type) {
             MAX_WEIGHT -> when (countryCode) {
                 "AU", "CA", "US" ->
-                    MaxWeightSignMutcd("WEIGHT LIMIT") {
-                        WeightInputMutcd(value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle)
-                    }
+                    MaxWeightSignMutcd("WEIGHT LIMIT") { weightInputMutcd() }
                 else ->
-                    MaxWeightSign(color = color) {
-                        WeightInput(value, onValueChange)
-                    }
+                    MaxWeightSign(color = color) { weightInput() }
             }
             MAX_WEIGHT_RATING -> when (countryCode) {
                 "AU", "CA", "US" ->
-                    MaxWeightSignMutcd("GVWR LIMIT") {
-                        WeightInputMutcd(value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle)
-                    }
+                    MaxWeightSignMutcd("GVWR LIMIT") { weightInputMutcd() }
                 "DE" ->
                     MaxWeightSignExtra(
                         color = color,
                         signContent = {},
-                        extraContent = { WeightInput(value, onValueChange) },
+                        extraContent = { weightInput() },
                     )
                 "GB" ->
                     MaxWeightSign(color = color) {
-                        WeightInput(value, onValueChange)
+                        weightInput()
                         Text("m g w")
                     }
                 // French max weight sign is actually a max weight rating sign
                 "FR" ->
-                    MaxWeightSign(color = color) {
-                        WeightInput(value, onValueChange)
-                    }
+                    MaxWeightSign(color = color) { weightInput() }
             }
             MAX_WEIGHT_RATING_HGV -> when (countryCode) {
                 "AU", "CA", "US" ->
-                    MaxWeightSignMutcd("TRUCK GVWR LIMIT") {
-                        WeightInputMutcd(value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle)
-                    }
+                    MaxWeightSignMutcd("TRUCK GVWR LIMIT") { weightInputMutcd() }
                 "DE" ->
                     MaxWeightSignExtra(
                         color = color,
@@ -108,33 +116,29 @@ fun MaxWeightSignForm(
                                 modifier = Modifier.fillMaxSize().padding(16.dp)
                             )
                         },
-                        extraContent = { WeightInput(value, onValueChange) },
+                        extraContent = { weightInput() },
                     )
                 else ->
                     MaxWeightSign(color = color) {
                         Icon(painterResource(Res.drawable.maxweight_hgv), null)
-                        WeightInput(value, onValueChange)
+                        weightInput()
                     }
             }
             MAX_AXLE_LOAD -> when (countryCode) {
                 "AU", "CA", "US" ->
-                    MaxWeightSignMutcd("AXLE WEIGHT LIMIT") {
-                        WeightInputMutcd(value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle)
-                    }
+                    MaxWeightSignMutcd("AXLE WEIGHT LIMIT") { weightInputMutcd() }
                 else ->
                     MaxWeightSign(color = color) {
-                        WeightInput(value, onValueChange)
+                        weightInput()
                         Icon(painterResource(Res.drawable.maxweight_axleload), null)
                     }
             }
             MAX_TANDEM_AXLE_LOAD -> when (countryCode) {
                 "AU", "CA", "US" ->
-                    MaxWeightSignMutcd("TANDEM AXLE WEIGHT LIMIT") {
-                        WeightInputMutcd(value, unit, onValueChange, onUnitChange, selectableUnits, unitTextStyle)
-                    }
+                    MaxWeightSignMutcd("TANDEM AXLE WEIGHT LIMIT") { weightInputMutcd() }
                 else ->
                     MaxWeightSign(color = color) {
-                        WeightInput(value, onValueChange)
+                        weightInput()
                         Icon(painterResource(Res.drawable.maxweight_bogieweight), null)
                     }
             }
@@ -169,7 +173,7 @@ private fun MaxWeightSignFormPreview() {
             type = maxWeightType,
             weight = weight,
             onWeightChange = { weight = it },
-            countryCode = country,
+            locale = Locale("${Locale.current.language}-$country"),
             selectableUnits = WeightMeasurementUnit.entries,
         )
     }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/WeightInput.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/WeightInput.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.data.meta.WeightMeasurementUnit
 import de.westnordost.streetcomplete.ui.common.AutoFitTextFieldFontSize
@@ -27,7 +28,8 @@ fun WeightInputMutcd(
     onUnitChange: (WeightMeasurementUnit) -> Unit,
     selectableUnits: List<WeightMeasurementUnit>,
     unitTextStyle: TextStyle,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    locale: Locale = Locale.current
 ) {
     Column(
         modifier = modifier,
@@ -40,6 +42,7 @@ fun WeightInputMutcd(
                 onValueChange = onValueChange,
                 maxIntegerDigits = 6,
                 maxFractionDigits = 1,
+                locale = locale,
                 isUnsigned = true,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -71,7 +74,8 @@ fun WeightInputMutcd(
 fun WeightInput(
     value: Double?,
     onValueChange: (Double?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    locale: Locale = Locale.current,
 ) {
     Row(
         modifier = modifier,
@@ -88,6 +92,7 @@ fun WeightInput(
                 onValueChange = onValueChange,
                 maxIntegerDigits = 3,
                 maxFractionDigits = 1,
+                locale = locale,
                 isUnsigned = true,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/LengthMetersInput.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/LengthMetersInput.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.osm.Length
 import de.westnordost.streetcomplete.ui.common.input.DecimalInput
@@ -24,6 +25,7 @@ fun LengthMetersInput(
     onChange: (Length.Meters?) -> Unit,
     maxMeterDigits: Pair<Int, Int>,
     modifier: Modifier = Modifier,
+    locale: Locale = Locale.current,
     style: TextFieldStyle = TextFieldStyle.Filled,
 ) {
     Row(
@@ -43,6 +45,7 @@ fun LengthMetersInput(
                 modifier = Modifier.fillMaxWidth(),
                 maxIntegerDigits = maxMeterDigits.first,
                 maxFractionDigits = maxMeterDigits.second,
+                locale = locale,
                 isUnsigned = true,
                 style = style,
             )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/input/DecimalInput.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/input/DecimalInput.kt
@@ -46,6 +46,7 @@ fun DecimalInput(
     maxIntegerDigits: Int = Int.MAX_VALUE,
     maxFractionDigits: Int = Int.MAX_VALUE,
     isUnsigned: Boolean = false,
+    locale: Locale = Locale.current,
     style: TextFieldStyle = TextFieldStyle.Filled,
     enabled: Boolean = true,
     readOnly: Boolean = false,
@@ -63,12 +64,13 @@ fun DecimalInput(
     colors: TextFieldColors = style.colors,
     contentPadding: PaddingValues = style.getContentPadding(label != null),
 ) {
-    val locale = Locale.current
+    val acceptedDecimalSeparators = remember { setOf('.', ',', '٫') }
     val formatter = remember(locale, maxIntegerDigits, maxFractionDigits) {
         NumberFormatter(
             locale = locale,
             maxIntegerDigits = maxIntegerDigits,
-            maxFractionDigits = maxFractionDigits
+            maxFractionDigits = maxFractionDigits,
+            useGrouping = false
         )
     }
     // number value as text
@@ -99,6 +101,11 @@ fun DecimalInput(
     TextField2(
         value = textFieldValueState,
         onValueChange = { newTextFieldValueState ->
+            // replace all decimal separators to the localized decimal separator
+            val newTextFieldValueState = newTextFieldValueState.copy(
+                text = newTextFieldValueState.text.replace(acceptedDecimalSeparators, formatter.decimalSeparator)
+            )
+
             // cleared input -> value now null
             if (newTextFieldValueState.text.isEmpty() && lastValue != null) {
                 textFieldValueState = newTextFieldValueState
@@ -142,6 +149,9 @@ fun DecimalInput(
         contentPadding = contentPadding,
     )
 }
+
+private fun String.replace(chars: Set<Char>, replacement: Char): String =
+    map { if (it in chars) replacement else it }.joinToString("")
 
 /** Checks if string has at most one decimal separator, otherwise only consists of digits and has
  *  at most the given number of digits */


### PR DESCRIPTION
fixes #6864

The `DecimalInput` now allows input of *any* decimal separators, but will always format it in the given locale. E.g. locale is `en-GB` and one inputs "3,0", it will display as "3.0".

Also, for the max height and max weight form that already show the localized signs, always use the country locale rather than the user's locale to format the numbers.