### PR TITLE
Add fee quest for basic/backcountry camp sites

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -61,6 +61,7 @@ import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter
 import de.westnordost.streetcomplete.quests.camera_type.AddCameraType
 import de.westnordost.streetcomplete.quests.camping.AddCampDrinkingWater
 import de.westnordost.streetcomplete.quests.camping.AddCampPower
+import de.westnordost.streetcomplete.quests.camping.AddCampSiteFee
 import de.westnordost.streetcomplete.quests.camping.AddCampShower
 import de.westnordost.streetcomplete.quests.camping.AddTents
 import de.westnordost.streetcomplete.quests.camping.AddCabins
@@ -506,6 +507,7 @@ fun questTypeRegistry(
     115 to AddCampDrinkingWater(),
     116 to AddCampShower(),
     117 to AddCampPower(),
+    198 to AddCampSiteFee(),
     162 to AddSanitaryDumpStation(),
 
     192 to AddHotWater(),

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampSiteFee.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampSiteFee.kt
@@ -1,0 +1,41 @@
+package de.westnordost.streetcomplete.quests.camping
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.updateWithCheckDate
+import de.westnordost.streetcomplete.quests.YesNoQuestForm
+import de.westnordost.streetcomplete.resources.*
+import de.westnordost.streetcomplete.util.ktx.toYesNo
+
+class AddCampSiteFee : OsmFilterQuestType<Boolean>(), AndroidQuest {
+
+    /* Most camp sites are paid by default, so asking everywhere would be spammy. We only ask
+     * where free access is plausible: basic camp sites and backcountry sites. We only resurvey
+     * fee = yes and fee = no, as it might have more detailed values from other editors, and we
+     * don't want to damage them. */
+    override val elementFilter = """
+        nodes, ways with
+          tourism = camp_site
+          and (camp_site = basic or backcountry = yes)
+          and !fee:conditional
+          and (
+            !fee
+            or fee older today -4 years and fee ~ yes|no
+          )
+    """
+    override val changesetComment = "Specify whether you have to pay to camp here"
+    override val wikiLink = "Key:fee"
+    override val icon = R.drawable.quest_fee
+    override val title = Res.string.quest_camp_site_fee_title
+    override val achievements = listOf(OUTDOORS)
+
+    override fun createForm() = YesNoQuestForm()
+
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags.updateWithCheckDate("fee", answer.toYesNo())
+    }
+}

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampSiteFeeTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampSiteFeeTest.kt
@@ -1,0 +1,93 @@
+package de.westnordost.streetcomplete.quests.camping
+
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
+import de.westnordost.streetcomplete.osm.nowAsCheckDateString
+import de.westnordost.streetcomplete.quests.answerApplied
+import de.westnordost.streetcomplete.quests.answerAppliedTo
+import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddCampSiteFeeTest {
+    private val questType = AddCampSiteFee()
+
+    private val millisecondsForFiveYears = 5L * 365 * 24 * 60 * 60 * 1000
+
+    @Test fun `applicable to basic camp site without fee`() {
+        assertTrue(questType.isApplicableTo(node(tags = mapOf(
+            "tourism" to "camp_site",
+            "camp_site" to "basic"
+        ))))
+    }
+
+    @Test fun `applicable to backcountry camp site without fee`() {
+        assertTrue(questType.isApplicableTo(node(tags = mapOf(
+            "tourism" to "camp_site",
+            "backcountry" to "yes"
+        ))))
+    }
+
+    @Test fun `not applicable to plain camp site`() {
+        assertFalse(questType.isApplicableTo(node(tags = mapOf(
+            "tourism" to "camp_site"
+        ))))
+    }
+
+    @Test fun `not applicable to basic camp site that recently had a fee surveyed`() {
+        assertFalse(questType.isApplicableTo(node(
+            tags = mapOf(
+                "tourism" to "camp_site",
+                "camp_site" to "basic",
+                "fee" to "yes"
+            ),
+            timestamp = nowAsEpochMilliseconds()
+        )))
+    }
+
+    @Test fun `applicable to basic camp site whose fee survey is old enough`() {
+        assertTrue(questType.isApplicableTo(node(
+            tags = mapOf(
+                "tourism" to "camp_site",
+                "camp_site" to "basic",
+                "fee" to "yes"
+            ),
+            timestamp = nowAsEpochMilliseconds() - millisecondsForFiveYears
+        )))
+    }
+
+    @Test fun `not applicable to basic camp site with a conditional fee`() {
+        assertFalse(questType.isApplicableTo(node(tags = mapOf(
+            "tourism" to "camp_site",
+            "camp_site" to "basic",
+            "fee:conditional" to "no @ (Nov-Mar)"
+        ))))
+    }
+
+    @Test fun `apply yes answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("fee", "yes")),
+            questType.answerApplied(true)
+        )
+    }
+
+    @Test fun `apply no answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("fee", "no")),
+            questType.answerApplied(false)
+        )
+    }
+
+    @Test fun `apply same answer again refreshes check date`() {
+        assertEquals(
+            setOf(
+                StringMapEntryModify("fee", "yes", "yes"),
+                StringMapEntryAdd("check_date:fee", nowAsCheckDateString())
+            ),
+            questType.answerAppliedTo(true, mapOf("fee" to "yes"))
+        )
+    }
+}

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1049,6 +1049,7 @@ A level counts as a roof level when its windows are in the roof. Subsequently, r
     <string name="quest_camp_shower_title">Are there showers here?</string>
     <string name="quest_camp_power_supply_title">Are there any power outlets available for guests?</string>
     <string name="quest_camp_power_supply_hint">This could be outlets directly at the camp pitches, outlets in a service building accessible by guests, a dedicated charging station for phones, laptops, etc.</string>
+    <string name="quest_camp_site_fee_title">Do you have to pay to camp here?</string>
     <string name="quest_camp_tent_title">May you camp here in a tent?</string>
     <string name="quest_camp_cabin_title">Are there cabins that you may stay in here?</string>
     <string name="quest_camp_caravan_title">May you camp here in a motor home or travel trailer?</string>


### PR DESCRIPTION
## Summary
Adds a new `AddCampSiteFee` quest that asks `fee=*` on `tourism=camp_site`, addressing #6859. To avoid spamming the majority of camp sites that are paid by default, the quest only triggers where free access is plausible: `camp_site=basic` or `backcountry=yes` (the cases the issue discussion, including #4198, converged on). It reuses the existing `quest_fee` icon and the `OUTDOORS` achievement, and is registered in `QuestsModule` with stable id 198.

## Why this matters
Whether a camp site charges a fee is a basic, high-value attribute for anyone planning a trip, but most camp sites are paid, so a blanket fee quest would be noisy. Scoping it to basic and backcountry sites - where free camping is common - keeps the quest useful without flooding mappers with obvious answers. Sites with an existing `fee:conditional` are skipped so the quest does not overwrite richer conditional detail with a blanket `fee=yes/no`.

## Testing
Added `AddCampSiteFeeTest` covering:
- Applicability to `camp_site=basic` and `backcountry=yes` sites without a fee.
- Non-applicability to a plain `camp_site`, to sites with a recent `fee` survey, and to sites carrying `fee:conditional`.
- Re-applicability once an existing `fee` survey is older than 4 years.
- `applyAnswerTo` writing `fee=yes`/`fee=no`, and refreshing `check_date:fee` on an unchanged resurvey answer via `updateWithCheckDate`.

Fixes #6859
