### PR TITLE
extended place names to beach_resort and summer_camp

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -102,7 +102,7 @@ class AddPlaceName(
 
                 // name only
                 "dance", "nature_reserve", "marina", "horse_riding",
-                "bathing_place", "escape_game",
+                "bathing_place", "escape_game", "beach_resort", "summer_camp"
             ),
             "landuse" to arrayOf(
                 "cemetery", "allotments"


### PR DESCRIPTION
Extends the AddPlaceName quest to [summer_camp](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dsummer_camp)  and [beach_resort](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dbeach_resort).

The latter was made possible due to https://github.com/openstreetmap/id-tagging-schema/pull/2000

I was also thinking of adding summer_camp as a place. What do you think?

Tested