### PR TITLE
expanded quests to clubs

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -132,6 +132,7 @@ mapOf(
                     or railway = station
                     or aeroway = terminal
                     or man_made = observatory
+                    or club
                 )
             )
             or (


### PR DESCRIPTION
Extends the opening_hours quest to clubs.

I added it to the update section, where places are only quested if they already have `opening_hours` set.

Thus clubs without walk in times, will not be quested.

Tested