### PR TITLE
expanded summit register quest to norway

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/summit/AddSummitRegister.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/summit/AddSummitRegister.kt
@@ -46,6 +46,7 @@ class AddSummitRegister : OsmElementQuestType<Boolean>, AndroidQuest {
         "IS", // https://github.com/streetcomplete/StreetComplete/issues/6897
         "IT", // https://it.wikipedia.org/wiki/Libro_di_vetta
         // not "NL": https://nl.wikipedia.org/wiki/Gipfelbuch is about "foreign" summit registers e.g. in the Alps
+        "NO", // https://github.com/streetcomplete/StreetComplete/pull/6902
         // not "PL": https://github.com/westnordost/StreetComplete/issues/561#issuecomment-325504455
         "RO", // https://es.wikipedia.org/wiki/Cruz_de_la_cumbre#Ejemplos
         "SI", // https://it.wikipedia.org/wiki/Libro_di_vetta#Alcuni_esempi_di_libri_di_vetta


### PR DESCRIPTION
Expands the summit register quest to norway. Tested.

I have seen atleast one of these, and confirmed with a norwegen friend that they are somwhat common, though less than in the alps. In some places they are also being replaced by digital solutions.

Examples: https://www.stordront.no/2023/06/19/ny-gjestebok-i-kjomda/
<img width="443" height="590" alt="image" src="https://github.com/user-attachments/assets/7a8ae4f1-046b-4bfb-b447-40578731e99d" />
