### PR TITLE
fixed 'There are no toilets here*' for toilets

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
@@ -12,7 +12,10 @@ class AddBabyChangingTableForm : AbstractOsmQuestForm<BabyChangingTableAnswer>()
         AnswerItem(R.string.quest_generic_hasFeature_yes) { applyAnswer(YES) }
     )
 
-    override val otherAnswers get() = listOf(
-        AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NO_TOILET) }
-    )
+    override val otherAnswers get() = buildList {
+        val result = mutableListOf<AnswerItem>()
+        if (element.tags["amenity"] != "toilets") {
+            add(AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NO_TOILET) })
+        }
+    }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTableForm.kt
@@ -13,7 +13,6 @@ class AddBabyChangingTableForm : AbstractOsmQuestForm<BabyChangingTableAnswer>()
     )
 
     override val otherAnswers get() = buildList {
-        val result = mutableListOf<AnswerItem>()
         if (element.tags["amenity"] != "toilets") {
             add(AnswerItem(R.string.quest_wheelchairAccessPat_noToilet) { applyAnswer(NO_TOILET) })
         }


### PR DESCRIPTION
Since https://github.com/streetcomplete/StreetComplete/commit/41f02ca10d5fae72e5b4e0f69f694a07e787c052 users can answer "There are no toilets here" in the changing station quest. This makes sense for places that might have toilets, but not for amenity=toilets, which the quest matches:
https://github.com/paulklie/StreetComplete/blob/b5a3088432e886a9801a388503cdc0ca7440f611/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt#L18

A new user might use this button, incorrectly, to try to remove a toilet that no longer exists, instead of the "It does not exist" button. This would cause `amenity=toilets, toilets=no` to be tagged, which makes little sense.

This PR removes this new button for stand alone toilets.