### PR TITLE
ci(Android test): failed job doesn't cancel other matrix jobs

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -18,6 +18,7 @@ jobs:
           - 21
         arch:
           - x86_64
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This guarantees that all matrix jobs produce test results and thereby avoids newly introduced test errors in one matrix configuration not being detected when another matrix configuration has already been failing for some prior commits.