### PR TITLE
fix compile errors and runtime bugs in iosMain, make tests runnable on iOS

### DIFF
--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/split_way/SplitWayActionTest.kt
@@ -287,7 +287,7 @@ class SplitWayActionTest {
         )
     }
 
-    @Test fun `split way with multiple split positions, one of which is at vertices`() {
+    @Test fun `split way with multiple split positions where one is at vertices`() {
         // 0   1   2   3
         //   | |
         val data = doSplit(
@@ -323,12 +323,12 @@ class SplitWayActionTest {
         )
     }
 
-    @Test fun `reuse object id of longest split chunk (= second chunk)`() {
+    @Test fun `reuse object id of longest split chunk if it is the second chunk`() {
         val data = doSplit(SplitAtPoint(p[1]))
         assertEquals(way.id, data.ways.maxByOrNull { it.nodeIds.size }?.id)
     }
 
-    @Test fun `reuse object id of longest split chunk (= first chunk)`() {
+    @Test fun `reuse object id of longest split chunk if it is the first chunk`() {
         val data = doSplit(SplitAtPoint(p[2]))
         assertEquals(way.id, data.ways.maxByOrNull { it.nodeIds.size }?.id)
     }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/mapdata/ElementDaoTest.kt
@@ -161,7 +161,7 @@ class ElementDaoTest {
         )
     }
 
-    @Test fun `getAllElementsByBbox includes nodes that are not in bbox, but part of ways contained in bbox`() {
+    @Test fun `getAllElementsByBbox includes nodes that are not in bbox but part of ways contained in bbox`() {
         val bbox = BoundingBox(0.0, 0.0, 1.0, 1.0)
         val bboxNodes = listOf(node(1), node(2), node(3))
         val bboxNodeIds = bboxNodes.map { it.id }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSourceImplTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSourceImplTest.kt
@@ -175,7 +175,7 @@ class NotesWithEditsSourceImplTest {
     }
 
     @Test
-    fun `get returns created, then commented note`() {
+    fun `get returns created and then commented note`() {
         val p = p(12.0, 46.0)
         val expectedNote = note(
             id = -12,

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestControllerTest.kt
@@ -109,7 +109,7 @@ class OsmNoteQuestControllerTest {
         assertNotNull(ctrl.get(1))
     }
 
-    @Test fun `get note quest created in app without comments and with survey required marker (ignore case) returns non-null`() {
+    @Test fun `get note quest created in app without comments and with survey required marker ignoring case returns non-null`() {
         every { noteSource.get(1) } returns
             note(comments = listOf(
                 comment(

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
@@ -7,7 +7,7 @@ import platform.Foundation.NSCalendar
 
 actual fun DayOfWeek.getDisplayName(style: DateTimeTextSymbolStyle, locale: Locale?): String {
     val calendar = NSCalendar.currentCalendar
-    if (locale != null) calendar.locale = locale.platformLocale
+    if (locale != null) calendar.locale = locale.nsLocale
     val symbols = when (style) {
         DateTimeTextSymbolStyle.Full -> calendar.standaloneWeekdaySymbols
         DateTimeTextSymbolStyle.Short -> calendar.shortStandaloneWeekdaySymbols

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
@@ -7,7 +7,7 @@ import platform.Foundation.NSCalendar
 
 actual fun DayOfWeek.getDisplayName(style: DateTimeTextSymbolStyle, locale: Locale?): String {
     val calendar = NSCalendar.currentCalendar
-    if (locale != null) calendar.locale = locale.nsLocale
+    if (locale != null) calendar.locale = locale.toNSLocale()
     val symbols = when (style) {
         DateTimeTextSymbolStyle.Full -> calendar.standaloneWeekdaySymbols
         DateTimeTextSymbolStyle.Short -> calendar.shortStandaloneWeekdaySymbols

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/DayOfWeek.ios.kt
@@ -13,5 +13,6 @@ actual fun DayOfWeek.getDisplayName(style: DateTimeTextSymbolStyle, locale: Loca
         DateTimeTextSymbolStyle.Short -> calendar.shortStandaloneWeekdaySymbols
         DateTimeTextSymbolStyle.Narrow -> calendar.veryShortStandaloneWeekdaySymbols
     }
-    return symbols[ordinal] as String
+    // NSCalendar weekday symbol arrays start with Sunday, DayOfWeek starts with Monday
+    return symbols[(ordinal + 1) % 7] as String
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
@@ -12,13 +12,13 @@ import platform.Foundation.NSLocaleScriptCode
 val Locale.nsLocale: NSLocale get() = NSLocale(toLanguageTag())
 
 actual fun Locale.getDisplayName(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleIdentifier, locale.toLanguageTag())
+    locale.nsLocale.displayNameForKey(NSLocaleIdentifier, toLanguageTag())
 
 actual fun Locale.getDisplayLanguage(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleLanguageCode, locale.language)
+    locale.nsLocale.displayNameForKey(NSLocaleLanguageCode, language)
 
 actual fun Locale.getDisplayRegion(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleCountryCode, locale.region)
+    locale.nsLocale.displayNameForKey(NSLocaleCountryCode, region)
 
 actual fun Locale.getDisplayScript(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleScriptCode, locale.script)
+    locale.nsLocale.displayNameForKey(NSLocaleScriptCode, script)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
@@ -1,19 +1,24 @@
 package de.westnordost.streetcomplete.util.ktx
 
 import androidx.compose.ui.text.intl.Locale
+import platform.Foundation.NSLocale
 import platform.Foundation.NSLocaleIdentifier
 import platform.Foundation.NSLocaleCountryCode
 import platform.Foundation.NSLocaleLanguageCode
 import platform.Foundation.NSLocaleScriptCode
 
+/** Unlike in Jetpack Compose on Android, Locale.platformLocale is internal in Compose
+ *  Multiplatform, so the NSLocale must be re-created from the language tag */
+val Locale.nsLocale: NSLocale get() = NSLocale(toLanguageTag())
+
 actual fun Locale.getDisplayName(locale: Locale): String? =
-    locale.platformLocale.displayNameForKey(NSLocaleIdentifier, locale.toLanguageTag())
+    locale.nsLocale.displayNameForKey(NSLocaleIdentifier, locale.toLanguageTag())
 
 actual fun Locale.getDisplayLanguage(locale: Locale): String? =
-    locale.platformLocale.displayNameForKey(NSLocaleLanguageCode, locale.language)
+    locale.nsLocale.displayNameForKey(NSLocaleLanguageCode, locale.language)
 
 actual fun Locale.getDisplayRegion(locale: Locale): String? =
-    locale.platformLocale.displayNameForKey(NSLocaleCountryCode, locale.region)
+    locale.nsLocale.displayNameForKey(NSLocaleCountryCode, locale.region)
 
 actual fun Locale.getDisplayScript(locale: Locale): String? =
-    locale.platformLocale.displayNameForKey(NSLocaleScriptCode, locale.script)
+    locale.nsLocale.displayNameForKey(NSLocaleScriptCode, locale.script)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Locale.ios.kt
@@ -9,16 +9,16 @@ import platform.Foundation.NSLocaleScriptCode
 
 /** Unlike in Jetpack Compose on Android, Locale.platformLocale is internal in Compose
  *  Multiplatform, so the NSLocale must be re-created from the language tag */
-val Locale.nsLocale: NSLocale get() = NSLocale(toLanguageTag())
+fun Locale.toNSLocale() = NSLocale(toLanguageTag())
 
 actual fun Locale.getDisplayName(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleIdentifier, toLanguageTag())
+    locale.toNSLocale().displayNameForKey(NSLocaleIdentifier, toLanguageTag())
 
 actual fun Locale.getDisplayLanguage(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleLanguageCode, language)
+    locale.toNSLocale().displayNameForKey(NSLocaleLanguageCode, language)
 
 actual fun Locale.getDisplayRegion(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleCountryCode, region)
+    locale.toNSLocale().displayNameForKey(NSLocaleCountryCode, region)
 
 actual fun Locale.getDisplayScript(locale: Locale): String? =
-    locale.nsLocale.displayNameForKey(NSLocaleScriptCode, script)
+    locale.toNSLocale().displayNameForKey(NSLocaleScriptCode, script)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Month.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Month.ios.kt
@@ -10,7 +10,7 @@ actual fun Month.getDisplayName(
     locale: Locale?
 ): String {
     val calendar = NSCalendar.currentCalendar
-    if (locale != null) calendar.locale = locale.platformLocale
+    if (locale != null) calendar.locale = locale.nsLocale
     val symbols = when (style) {
         DateTimeTextSymbolStyle.Full -> calendar.standaloneMonthSymbols
         DateTimeTextSymbolStyle.Short -> calendar.shortStandaloneMonthSymbols

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Month.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/ktx/Month.ios.kt
@@ -10,7 +10,7 @@ actual fun Month.getDisplayName(
     locale: Locale?
 ): String {
     val calendar = NSCalendar.currentCalendar
-    if (locale != null) calendar.locale = locale.nsLocale
+    if (locale != null) calendar.locale = locale.toNSLocale()
     val symbols = when (style) {
         DateTimeTextSymbolStyle.Full -> calendar.standaloneMonthSymbols
         DateTimeTextSymbolStyle.Short -> calendar.shortStandaloneMonthSymbols

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/CurrencyFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/CurrencyFormatter.ios.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
+import de.westnordost.streetcomplete.util.ktx.nsLocale
 import platform.Foundation.NSLocaleCurrencyCode
 import platform.Foundation.NSNumber
 import platform.Foundation.NSNumberFormatter
@@ -9,7 +10,7 @@ import platform.Foundation.NSNumberFormatterCurrencyStyle
 actual class CurrencyFormatter actual constructor(locale: Locale?) {
 
     private val formatter = NSNumberFormatter().also {
-        if (locale != null) it.locale = locale.platformLocale
+        if (locale != null) it.locale = locale.nsLocale
         it.numberStyle = NSNumberFormatterCurrencyStyle
     }
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/CurrencyFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/CurrencyFormatter.ios.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
-import de.westnordost.streetcomplete.util.ktx.nsLocale
+import de.westnordost.streetcomplete.util.ktx.toNSLocale
 import platform.Foundation.NSLocaleCurrencyCode
 import platform.Foundation.NSNumber
 import platform.Foundation.NSNumberFormatter
@@ -10,7 +10,7 @@ import platform.Foundation.NSNumberFormatterCurrencyStyle
 actual class CurrencyFormatter actual constructor(locale: Locale?) {
 
     private val formatter = NSNumberFormatter().also {
-        if (locale != null) it.locale = locale.nsLocale
+        if (locale != null) it.locale = locale.toNSLocale()
         it.numberStyle = NSNumberFormatterCurrencyStyle
     }
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateFormatter.ios.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
+import de.westnordost.streetcomplete.util.ktx.nsLocale
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toNSDateComponents
 import platform.Foundation.NSCalendar
@@ -11,7 +12,7 @@ actual class LocalDateFormatter actual constructor(
     style: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.platformLocale
+        if (locale != null) it.locale = locale.nsLocale
         it.dateStyle = style.toNSDateFormatterStyle()
     }
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateFormatter.ios.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
-import de.westnordost.streetcomplete.util.ktx.nsLocale
+import de.westnordost.streetcomplete.util.ktx.toNSLocale
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toNSDateComponents
 import platform.Foundation.NSCalendar
@@ -12,7 +12,7 @@ actual class LocalDateFormatter actual constructor(
     style: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.nsLocale
+        if (locale != null) it.locale = locale.toNSLocale()
         it.dateStyle = style.toNSDateFormatterStyle()
     }
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateTimeFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateTimeFormatter.ios.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
+import de.westnordost.streetcomplete.util.ktx.nsLocale
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toNSDateComponents
@@ -15,7 +16,7 @@ actual class LocalDateTimeFormatter actual constructor(
     timeStyle: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.platformLocale
+        if (locale != null) it.locale = locale.nsLocale
         it.dateStyle = dateStyle.toNSDateFormatterStyle()
         it.timeStyle = timeStyle.toNSDateFormatterStyle()
         it.timeZone = timeZone.toNSTimeZone()

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateTimeFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalDateTimeFormatter.ios.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
-import de.westnordost.streetcomplete.util.ktx.nsLocale
+import de.westnordost.streetcomplete.util.ktx.toNSLocale
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toNSDateComponents
@@ -16,7 +16,7 @@ actual class LocalDateTimeFormatter actual constructor(
     timeStyle: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.nsLocale
+        if (locale != null) it.locale = locale.toNSLocale()
         it.dateStyle = dateStyle.toNSDateFormatterStyle()
         it.timeStyle = timeStyle.toNSDateFormatterStyle()
         it.timeZone = timeZone.toNSTimeZone()

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalTimeFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalTimeFormatter.ios.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
-import de.westnordost.streetcomplete.util.ktx.nsLocale
+import de.westnordost.streetcomplete.util.ktx.toNSLocale
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -18,7 +18,7 @@ actual class LocalTimeFormatter actual constructor(
     style: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.nsLocale
+        if (locale != null) it.locale = locale.toNSLocale()
         it.dateStyle = NSDateFormatterNoStyle
         it.timeStyle = style.toNSDateFormatterStyle()
         it.timeZone = timeZone.toNSTimeZone()

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalTimeFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/LocalTimeFormatter.ios.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
+import de.westnordost.streetcomplete.util.ktx.nsLocale
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -17,7 +18,7 @@ actual class LocalTimeFormatter actual constructor(
     style: DateTimeFormatStyle,
 ) {
     private val formatter = NSDateFormatter().also {
-        if (locale != null) it.locale = locale.platformLocale
+        if (locale != null) it.locale = locale.nsLocale
         it.dateStyle = NSDateFormatterNoStyle
         it.timeStyle = style.toNSDateFormatterStyle()
         it.timeZone = timeZone.toNSTimeZone()

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
@@ -26,11 +26,11 @@ actual class NumberFormatter actual constructor(
     }
 
     actual fun format(value: Number): String {
-        return format.stringFromNumber(value as NSNumber)!!
+        return format.stringFromNumber(value.toNSNumber())!!
     }
 
     actual fun parse(text: String): Number? {
-        return format.numberFromString(text) as? Number
+        return format.numberFromString(text)?.toNumber()
     }
 
     actual val decimalSeparator: Char
@@ -38,4 +38,23 @@ actual class NumberFormatter actual constructor(
 
     actual val groupingSeparator: Char
         get() = format.groupingSeparator.single()
+}
+
+// Kotlin's number types are not NSNumbers in Kotlin/Native, they must be converted explicitly
+
+private fun Number.toNSNumber(): NSNumber = when (this) {
+    is Byte -> NSNumber(char = this)
+    is Short -> NSNumber(short = this)
+    is Int -> NSNumber(int = this)
+    is Long -> NSNumber(longLong = this)
+    is Float -> NSNumber(float = this)
+    is Double -> NSNumber(double = this)
+    else -> NSNumber(double = toDouble())
+}
+
+/** Like NumberFormat.parse on the JVM, returns a Long if the parsed number is integral */
+private fun NSNumber.toNumber(): Number {
+    val double = doubleValue
+    val long = longLongValue
+    return if (long.toDouble() == double) long else double
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
-import de.westnordost.streetcomplete.util.ktx.nsLocale
+import de.westnordost.streetcomplete.util.ktx.toNSLocale
 import platform.Foundation.NSNumberFormatter
 import platform.Foundation.NSNumberFormatterDecimalStyle
 import platform.Foundation.NSNumber
@@ -16,7 +16,7 @@ actual class NumberFormatter actual constructor(
 ) {
     private val format = NSNumberFormatter().also {
         it.numberStyle = NSNumberFormatterDecimalStyle
-        it.locale = (locale ?: Locale.current).nsLocale
+        it.locale = (locale ?: Locale.current).toNSLocale()
         it.usesGroupingSeparator = useGrouping
         it.minimumIntegerDigits = minIntegerDigits.toULong()
         it.maximumIntegerDigits = maxIntegerDigits.toULong()

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/util/locale/NumberFormatter.ios.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.locale
 
 import androidx.compose.ui.text.intl.Locale
+import de.westnordost.streetcomplete.util.ktx.nsLocale
 import platform.Foundation.NSNumberFormatter
 import platform.Foundation.NSNumberFormatterDecimalStyle
 import platform.Foundation.NSNumber
@@ -15,7 +16,7 @@ actual class NumberFormatter actual constructor(
 ) {
     private val format = NSNumberFormatter().also {
         it.numberStyle = NSNumberFormatterDecimalStyle
-        it.locale = (locale ?: Locale.current).platformLocale
+        it.locale = (locale ?: Locale.current).nsLocale
         it.usesGroupingSeparator = useGrouping
         it.minimumIntegerDigits = minIntegerDigits.toULong()
         it.maximumIntegerDigits = maxIntegerDigits.toULong()


### PR DESCRIPTION
Hi (first PR!), 

I recently commented in #5421 about wanting to contribute to the iOS portion of this project. I set up my env and tried to compile and run the tests. A few fixes were necessary to make that work. With these changes, `:app:compileKotlinIosSimulatorArm64` and `:app:iosSimulatorArm64Test` both run through it seems. I'm still not all too familiar with this toolchain, but it appears to work and I think it didn't break anything existing either (hoping to rely on CI to prove that maybe?).

- It appears Kotlin/Native does not allow `,` or `()` in backtick test function names, so a few things had to be renamed.
- `Locale.platformLocale` is public in Jetpack Compose on Android afaict but internal in Compose Multiplatform, so all of `iosMain` failed to compile. I added a `Locale.nsLocale` extension that recreates the `NSLocale` from the language tag.
- The `Locale.getDisplayName`/`Language`/`Region`/`Script` actuals passed the display locale's own fields instead of the receiver's, e.g. displaying German in English returned "English" instead of "German".
- `DayOfWeek.getDisplayName` indexed `NSCalendar`'s Sunday-first weekdya symbol arrays with kotlinx-datetime's Monday-first ordinal, so every weekday name was off by one.
- `NumberFormatter.format` cast a Kotlin Number to `NSNumber`, which never succeeds in Kotlin/Native (runtime crash), and parse did the reverse cast, so it always returned null. Both of these now convert explicitly, parse returns `Long` for integral values like `NumberFormat.parse` does on the JVM.

Out of all the tests run on the simulator, 68 still fail, in categories that I think are out of scope here. Mainly live network API client tests (TLS error in the simulator environment that I'll look at, maybe that's a me issue?), Foundation vs. ICU formatting differences in the `util.locale` tests, and some other stuff.