### PR TITLE
highlight intersecting elements with MaxPhysicalHeight

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
@@ -62,20 +63,6 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
         ways with
           highway ~ ${ALL_PATHS.joinToString("|")}
           and (access !~ private|no or (foot and foot !~ private|no))
-    """.toElementFilterExpression() }
-
-    private val bridgeFilter by lazy { """
-        ways with (
-            (
-              highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
-              or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
-            )
-            and bridge and bridge != no
-          ) or (
-            building = roof
-            or man_made = pipeline and location = overhead
-          )
-          and layer
     """.toElementFilterExpression() }
 
     private val noMaxHeight = """
@@ -180,5 +167,5 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
     override fun getHighlightedElements(
         element: Element,
         mapData: MapDataWithGeometry
-    ): Sequence<Element> = getIntersectingStructures(element, mapData)
+    ): Sequence<Element> = (element as? Way)?.getIntersectingBridges(mapData).orEmpty()
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -186,4 +186,9 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
             }
         }
     }
+
+    override fun getHighlightedElements(
+        element: Element,
+        mapData: MapDataWithGeometry
+    ): Sequence<Element> = highlightIntersectingStructures(element, mapData)
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -64,16 +64,6 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
           and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }
 
-    private val tunnelFilter by lazy { """
-        ways with
-          highway
-          and (
-            covered = yes
-            or tunnel ~ yes|building_passage|avalanche_protector
-            or bridge = covered
-          )
-    """.toElementFilterExpression() }
-
     private val bridgeFilter by lazy { """
         ways with (
             (
@@ -190,5 +180,5 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
     override fun getHighlightedElements(
         element: Element,
         mapData: MapDataWithGeometry
-    ): Sequence<Element> = highlightIntersectingStructures(element, mapData)
+    ): Sequence<Element> = getIntersectingStructures(element, mapData)
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeightForm.kt
@@ -19,8 +19,8 @@ import de.westnordost.streetcomplete.quests.AnswerItem
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.ui.util.content
 import de.westnordost.streetcomplete.ui.util.rememberSerializable
-import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import de.westnordost.streetcomplete.quests.max_height.tunnelFilter
 
 class AddMaxHeightForm : AbstractOsmQuestForm<MaxHeightAnswer>() {
 
@@ -34,7 +34,7 @@ class AddMaxHeightForm : AbstractOsmQuestForm<MaxHeightAnswer>() {
 
     @Composable
     override fun getHint(): String? =
-        if (element.type == ElementType.WAY) {
+        if (element.type == ElementType.WAY && !tunnelFilter.matches(element)) {
             stringResource(Res.string.quest_maxheight_split_way_hint,
                 stringResource(Res.string.quest_generic_answer_differs_along_the_way)
             )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -70,13 +70,12 @@ class AddMaxPhysicalHeight(
         get() = if (!checkArSupport()) Res.string.default_disabled_msg_no_ar else null
 
     override fun getTitle(tags: Map<String, String>): StringResource {
-        val isBelowBridge = tags["amenity"] != "parking_entrance"
+        val isBelowWay = tags["amenity"] != "parking_entrance"
             && tags["barrier"] != "height_restrictor"
             && tags["tunnel"] == null
             && tags["covered"] == null
-            && tags["man_made"] != "pipeline"
         // only the "below the bridge" situation may need some context
-        return if (isBelowBridge) {
+        return if (isBelowWay) {
             Res.string.quest_maxheight_below_bridge_title
         } else {
             Res.string.quest_maxheight_title
@@ -102,4 +101,9 @@ class AddMaxPhysicalHeight(
             tags.remove("source:maxheight")
         }
     }
+
+    override fun getHighlightedElements(
+        element: Element,
+        mapData: MapDataWithGeometry
+    ): Sequence<Element> = highlightIntersectingStructures(element, mapData)
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -5,6 +5,7 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
@@ -109,5 +110,5 @@ class AddMaxPhysicalHeight(
     override fun getHighlightedElements(
         element: Element,
         mapData: MapDataWithGeometry
-    ): Sequence<Element> = getIntersectingStructures(element, mapData)
+    ): Sequence<Element> = (element as? Way)?.getIntersectingBridges(mapData).orEmpty()
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -70,6 +70,10 @@ class AddMaxPhysicalHeight(
         get() = if (!checkArSupport()) Res.string.default_disabled_msg_no_ar else null
 
     override fun getTitle(tags: Map<String, String>): StringResource {
+        // We can't actually check if the element with the given [tags] is below another way here.
+        // What we do instead, is, by knowledge of the quest filter used (see above),  
+        // we infer that if the element has the following tags, the quest must have been created
+        // because it crosses with another way above it and not because it itself is a tunnel etc.
         val isBelowWay = tags["amenity"] != "parking_entrance"
             && tags["barrier"] != "height_restrictor"
             && tags["tunnel"] == null

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -71,7 +71,7 @@ class AddMaxPhysicalHeight(
 
     override fun getTitle(tags: Map<String, String>): StringResource {
         // We can't actually check if the element with the given [tags] is below another way here.
-        // What we do instead, is, by knowledge of the quest filter used (see above),  
+        // What we do instead, is, by knowledge of the quest filter used (see above),
         // we infer that if the element has the following tags, the quest must have been created
         // because it crosses with another way above it and not because it itself is a tunnel etc.
         val isBelowWay = tags["amenity"] != "parking_entrance"
@@ -109,5 +109,5 @@ class AddMaxPhysicalHeight(
     override fun getHighlightedElements(
         element: Element,
         mapData: MapDataWithGeometry
-    ): Sequence<Element> = highlightIntersectingStructures(element, mapData)
+    ): Sequence<Element> = getIntersectingStructures(element, mapData)
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.databinding.ComposeViewBinding
 import de.westnordost.streetcomplete.osm.Length
@@ -56,6 +57,14 @@ class AddMaxPhysicalHeightForm : AbstractArMeasureQuestForm<MaxPhysicalHeightAns
         this.length.value = length
         checkIsFormComplete()
     }
+
+    @Composable
+    override fun getHint(): String? =
+        if (element.type == ElementType.WAY) {
+            stringResource(Res.string.quest_maxheight_split_way_hint,
+                stringResource(Res.string.quest_generic_answer_differs_along_the_way)
+            )
+        } else super.getHint()
 
     override fun isFormComplete(): Boolean = length.value != null
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
@@ -63,7 +63,7 @@ class AddMaxPhysicalHeightForm : AbstractArMeasureQuestForm<MaxPhysicalHeightAns
 
     @Composable
     override fun getHint(): String? =
-        if (element.type == ElementType.WAY && element.tags["tunnel"] != null) {
+        if (!tunnelFilter.matches(element)) {
             stringResource(Res.string.quest_maxheight_split_way_hint,
                 stringResource(Res.string.quest_generic_answer_differs_along_the_way)
             )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeightForm.kt
@@ -4,18 +4,21 @@ import android.os.Bundle
 import android.view.View
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.databinding.ComposeViewBinding
 import de.westnordost.streetcomplete.osm.Length
 import de.westnordost.streetcomplete.quests.AbstractArMeasureQuestForm
 import de.westnordost.streetcomplete.quests.LengthForm
+import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.screens.measure.ArSupportChecker
 import de.westnordost.streetcomplete.ui.util.content
 import de.westnordost.streetcomplete.ui.util.rememberSerializable
+import org.jetbrains.compose.resources.stringResource
 import org.koin.android.ext.android.inject
 
 class AddMaxPhysicalHeightForm : AbstractArMeasureQuestForm<MaxPhysicalHeightAnswer>() {
@@ -60,7 +63,7 @@ class AddMaxPhysicalHeightForm : AbstractArMeasureQuestForm<MaxPhysicalHeightAns
 
     @Composable
     override fun getHint(): String? =
-        if (element.type == ElementType.WAY) {
+        if (element.type == ElementType.WAY && element.tags["tunnel"] != null) {
             stringResource(Res.string.quest_maxheight_split_way_hint,
                 stringResource(Res.string.quest_generic_answer_differs_along_the_way)
             )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
@@ -13,22 +14,10 @@ import de.westnordost.streetcomplete.util.math.intersects
 
 /** Returns ways that intersect with the given element, that triggered the MaxHeight quest. */
 fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Element> {
-    val geometry = mapData.getWayGeometry(element.id) as? ElementPolylinesGeometry ?: return emptySequence()
-    val ways = mapData.filter("""
-    ways with (
-        (
-          highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
-          or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
-        )
-        and bridge and bridge != no
-      ) or (
-        building = roof
-        or man_made = pipeline and location = overhead
-      )
-      and layer
-    """)
+    val geometry = mapData.getWayGeometry(id) as? ElementPolylinesGeometry ?: return emptySequence()
+    val ways = mapData.filter(bridgeFilter)
 
-    val layer = element.tags["layer"]?.toIntOrNull() ?: 0
+    val layer = tags["layer"]?.toIntOrNull() ?: 0
 
     return ways
         .filter { (it.tags["layer"]?.toIntOrNull() ?: 0) > layer }
@@ -43,3 +32,17 @@ val tunnelFilter: ElementFilterExpression by lazy { """
         or bridge = covered
       )
 """.toElementFilterExpression() }
+
+val bridgeFilter by lazy { """
+        ways with (
+            (
+              highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+              or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
+            )
+            and bridge and bridge != no
+          ) or (
+            building = roof
+            or man_made = pipeline and location = overhead
+          )
+          and layer
+    """.toElementFilterExpression() }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -12,8 +12,8 @@ import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.util.math.intersects
 
-/** Returns ways that intersect with the given element, that triggered the MaxHeight quest. */
-fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Element> {
+/** Returns ways that intersect with and are bridges above this way */
+fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Way> {
     val geometry = mapData.getWayGeometry(id) as? ElementPolylinesGeometry ?: return emptySequence()
     val ways = mapData.filter(bridgeFilter)
 
@@ -23,6 +23,7 @@ fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Element> 
         .filter { (it.tags["layer"]?.toIntOrNull() ?: 0) > layer }
         .filter { mapData.getWayGeometry(it.id)?.intersects(geometry) == true }
 }
+
 val tunnelFilter: ElementFilterExpression by lazy { """
     ways with
       highway
@@ -34,15 +35,15 @@ val tunnelFilter: ElementFilterExpression by lazy { """
 """.toElementFilterExpression() }
 
 val bridgeFilter by lazy { """
-        ways with (
-            (
-              highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
-              or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
-            )
-            and bridge and bridge != no
-          ) or (
-            building = roof
-            or man_made = pipeline and location = overhead
-          )
-          and layer
-    """.toElementFilterExpression() }
+    ways with (
+        (
+          highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+          or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
+        )
+        and bridge and bridge != no
+      ) or (
+        building = roof
+        or man_made = pipeline and location = overhead
+      )
+      and layer
+""".toElementFilterExpression() }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -1,0 +1,41 @@
+package de.westnordost.streetcomplete.quests.max_height
+
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.osm.ALL_PATHS
+import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.util.math.intersects
+
+// Returns ways that intersect with the given element, that triggered the quest.
+fun highlightIntersectingStructures(
+    element: Element,
+    mapData: MapDataWithGeometry
+): Sequence<Element> {
+    if (element.type != ElementType.WAY) return emptySequence()
+    val geometry = mapData.getWayGeometry(element.id) as? ElementPolylinesGeometry ?: return emptySequence()
+    val ways = mapData.filter("""
+    ways with (
+        (
+          highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+          or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail
+        )
+        and bridge and bridge != no
+      ) or (
+        building = roof
+        or man_made = pipeline and location = overhead
+      )
+      and layer
+    """).toList()
+
+    val layer = element.tags["layer"]?.toIntOrNull() ?: 0
+
+    return ways.asSequence().filter { way ->
+        val structureLayer = way.tags["layer"]?.toIntOrNull() ?: 0
+        val wayGeometry = mapData.getWayGeometry(way.id)
+        val intersects = wayGeometry != null && structureLayer > layer &&wayGeometry.intersects(geometry)
+        intersects
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -3,8 +3,6 @@ package de.westnordost.streetcomplete.quests.max_height
 import de.westnordost.streetcomplete.data.elementfilter.ElementFilterExpression
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
-import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
@@ -15,7 +13,7 @@ import de.westnordost.streetcomplete.util.math.intersects
 /** Returns ways that intersect with and are bridges above this way */
 fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Way> {
     val geometry = mapData.getWayGeometry(id) as? ElementPolylinesGeometry ?: return emptySequence()
-    val ways = mapData.filter(bridgeFilter)
+    val ways = mapData.filter(bridgeFilter).filterIsInstance<Way>()
 
     val layer = tags["layer"]?.toIntOrNull() ?: 0
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -1,5 +1,7 @@
 package de.westnordost.streetcomplete.quests.max_height
 
+import de.westnordost.streetcomplete.data.elementfilter.ElementFilterExpression
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
@@ -9,8 +11,8 @@ import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.util.math.intersects
 
-/** Returns ways that intersect with the given element, that triggered the quest. */
-fun highlightIntersectingStructures(
+/** Returns ways that intersect with the given element, that triggered the MaxHeight quest. */
+fun getIntersectingStructures(
     element: Element,
     mapData: MapDataWithGeometry
 ): Sequence<Element> {
@@ -28,14 +30,23 @@ fun highlightIntersectingStructures(
         or man_made = pipeline and location = overhead
       )
       and layer
-    """).toList()
+    """)
 
     val layer = element.tags["layer"]?.toIntOrNull() ?: 0
 
-    return ways.asSequence().filter { way ->
+    return ways.filter { way ->
         val structureLayer = way.tags["layer"]?.toIntOrNull() ?: 0
         val wayGeometry = mapData.getWayGeometry(way.id)
         val intersects = wayGeometry != null && structureLayer > layer &&wayGeometry.intersects(geometry)
         intersects
     }
 }
+val tunnelFilter: ElementFilterExpression by lazy { """
+    ways with
+      highway
+      and (
+        covered = yes
+        or tunnel ~ yes|building_passage|avalanche_protector
+        or bridge = covered
+      )
+""".toElementFilterExpression() }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -12,11 +12,7 @@ import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.util.math.intersects
 
 /** Returns ways that intersect with the given element, that triggered the MaxHeight quest. */
-fun getIntersectingStructures(
-    element: Element,
-    mapData: MapDataWithGeometry
-): Sequence<Element> {
-    if (element.type != ElementType.WAY) return emptySequence()
+fun Way.getIntersectingBridges(mapData: MapDataWithGeometry): Sequence<Element> {
     val geometry = mapData.getWayGeometry(element.id) as? ElementPolylinesGeometry ?: return emptySequence()
     val ways = mapData.filter("""
     ways with (
@@ -34,12 +30,9 @@ fun getIntersectingStructures(
 
     val layer = element.tags["layer"]?.toIntOrNull() ?: 0
 
-    return ways.filter { way ->
-        val structureLayer = way.tags["layer"]?.toIntOrNull() ?: 0
-        val wayGeometry = mapData.getWayGeometry(way.id)
-        val intersects = wayGeometry != null && structureLayer > layer &&wayGeometry.intersects(geometry)
-        intersects
-    }
+    return ways
+        .filter { (it.tags["layer"]?.toIntOrNull() ?: 0) > layer }
+        .filter { mapData.getWayGeometry(it.id)?.intersects(geometry) == true }
 }
 val tunnelFilter: ElementFilterExpression by lazy { """
     ways with

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.util.math.intersects
 
-// Returns ways that intersect with the given element, that triggered the quest.
+/** Returns ways that intersect with the given element, that triggered the quest. */
 fun highlightIntersectingStructures(
     element: Element,
     mapData: MapDataWithGeometry

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -1013,10 +1013,10 @@ class MainActivity :
                 // don't highlight "this" element
                 if (element == e) return@mapNotNull null
                 // include only elements with the same (=intersecting) level, if any
-               // val eLevels = parseLevelsOrNull(e.tags)
-               // if (!levels.levelsIntersect(eLevels)) return@mapNotNull null
+                val eLevels = parseLevelsOrNull(e.tags)
+                if (!levels.levelsIntersect(eLevels)) return@mapNotNull null
                 // include only elements with the same layer, if any
-              //  if (element.tags["layer"] != e.tags["layer"]) return@mapNotNull null
+                if (element.tags["layer"] != e.tags["layer"]) return@mapNotNull null
 
                 val geometry = lazyMapData.getGeometry(e.type, e.id) ?: return@mapNotNull null
                 val icon = getIcon(featureDictionary.value, e)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -1013,10 +1013,10 @@ class MainActivity :
                 // don't highlight "this" element
                 if (element == e) return@mapNotNull null
                 // include only elements with the same (=intersecting) level, if any
-                val eLevels = parseLevelsOrNull(e.tags)
-                if (!levels.levelsIntersect(eLevels)) return@mapNotNull null
+               // val eLevels = parseLevelsOrNull(e.tags)
+               // if (!levels.levelsIntersect(eLevels)) return@mapNotNull null
                 // include only elements with the same layer, if any
-                if (element.tags["layer"] != e.tags["layer"]) return@mapNotNull null
+              //  if (element.tags["layer"] != e.tags["layer"]) return@mapNotNull null
 
                 val geometry = lazyMapData.getGeometry(e.type, e.id) ?: return@mapNotNull null
                 val icon = getIcon(featureDictionary.value, e)

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1242,8 +1242,8 @@ If any lanes are reserved for buses, please leave a note instead.</string>
 
     <string name="quest_lit_title">Is it lit here?</string>
 
-    <string name="quest_maxheight_title">What’s the measured height below the highlighted bridge (or other structure)?</string>
-    <string name="quest_maxheight_below_bridge_title">What’s the measured height below the bridge?</string>
+    <string name="quest_maxheight_title">Measure the maximum height here.</string>
+    <string name="quest_maxheight_below_bridge_title">Measure the height below the highlighted bridge (or other structure).</string>
     <string name="quest_maxheight_sign_title">What height limit is indicated here?</string>
     <string name="quest_maxheight_answer_noSign">There is no sign…</string>
     <string name="quest_maxheight_split_way_hint">This road section passes under a bridge, roof, overhead pipe or similar structure, which is highlighted. \nAlso, if it doesn’t apply for the whole road section, consider answering “%1$s”.</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1242,11 +1242,11 @@ If any lanes are reserved for buses, please leave a note instead.</string>
 
     <string name="quest_lit_title">Is it lit here?</string>
 
-    <string name="quest_maxheight_title">What’s the measured height here?</string>
+    <string name="quest_maxheight_title">What's the measured height below the highlighted bridge (or other structure)?</string>
     <string name="quest_maxheight_below_bridge_title">What’s the measured height below the bridge?</string>
     <string name="quest_maxheight_sign_title">What height limit is indicated here?</string>
     <string name="quest_maxheight_answer_noSign">There is no sign…</string>
-    <string name="quest_maxheight_split_way_hint">This question is also asked for roads that run under bridges, roofs, overhead pipes etc.\nAlso, if it doesn’t apply for the whole highlighted section, consider answering “%1$s”.</string>
+    <string name="quest_maxheight_split_way_hint">This road section passes under a bridge, roof, overhead pipe or similar structure, which is highlighted. \nAlso, if it doesn’t apply for the whole road section, consider answering “%1$s”.</string>
     <string name="quest_maxheight_unusualInput_confirmation_description">This height looks implausible. Are you sure that it is correct?</string>
 
     <string name="quest_maxspeed_title_short2">What’s the speed limit for this street?</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1242,7 +1242,7 @@ If any lanes are reserved for buses, please leave a note instead.</string>
 
     <string name="quest_lit_title">Is it lit here?</string>
 
-    <string name="quest_maxheight_title">What's the measured height below the highlighted bridge (or other structure)?</string>
+    <string name="quest_maxheight_title">What’s the measured height below the highlighted bridge (or other structure)?</string>
     <string name="quest_maxheight_below_bridge_title">What’s the measured height below the bridge?</string>
     <string name="quest_maxheight_sign_title">What height limit is indicated here?</string>
     <string name="quest_maxheight_answer_noSign">There is no sign…</string>


### PR DESCRIPTION
First part of #6917

This will also require some changes to [app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt](https://github.com/streetcomplete/StreetComplete/pull/6926/files/f31d8420b3f78173620722122d6bbd9a6f4e13f0#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1)

Adds highlighting to the MaxHeight quests, which highlights the way causing the max height restriction.

Also adjusts some strings.

Changes to app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt are only temporary, and required for testing.

<img width="572" height="1280" alt="image" src="https://github.com/user-attachments/assets/5106e579-533f-4d8b-a31c-8e94730dc9cd" />


