### PR TITLE
fix: places (NSI) name missing

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlayForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlayForm.kt
@@ -337,7 +337,7 @@ private fun Feature.isChildOf(other: Feature): Boolean =
 
 /** return whether the feature has a fixed name which cannot be changed */
 private val Feature.hasFixedName get() =
-    addTags.containsKey("name") && preserveTags.none { it.containsMatchIn("name") }
+    addTags.containsKey("name")
     || id == "shop/vacant"
     || id == "shop/unknown"
 


### PR DESCRIPTION
Fixes https://github.com/streetcomplete/StreetComplete/issues/6907

The name field will not be shown for places selected from the NSI that have a "name" field, and the value in NSI will be set.

Tested.