### PR TITLE
survey places with fixme=name and alternatives, and remove these tags

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
@@ -48,14 +48,10 @@ abstract class AAddLocalizedNameForm<T> : AbstractOsmQuestForm<T>() {
 
         binding.composeViewBase.content { Surface {
             localizedNames = rememberSerializable {
-                // On resurvey, prefill with existing names
-                val existingNames = parseLocalizedNames(element.tags).orEmpty()
-                // Otherwise, use empty string for the default language
-                val initialNames = existingNames.ifEmpty {
-                    listOf(LocalizedName(countryInfo.language.orEmpty(), ""))
-                }
-
-                mutableStateOf(initialNames)
+                mutableStateOf(
+                    parseLocalizedNames(element.tags)
+                    ?: listOf(LocalizedName(countryInfo.language.orEmpty(), ""))
+                )
             }
 
             Column {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
@@ -14,6 +14,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.databinding.ComposeViewBinding
 import de.westnordost.streetcomplete.osm.localized_name.LocalizedName
+import de.westnordost.streetcomplete.osm.localized_name.parseLocalizedNames
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.ui.common.localized_name.LocalizedNamesForm
 import de.westnordost.streetcomplete.ui.util.content
@@ -47,7 +48,14 @@ abstract class AAddLocalizedNameForm<T> : AbstractOsmQuestForm<T>() {
 
         binding.composeViewBase.content { Surface {
             localizedNames = rememberSerializable {
-                mutableStateOf(listOf(LocalizedName(countryInfo.language.orEmpty(), "")))
+                // On resurvey, prefill with existing names
+                val existingNames = parseLocalizedNames(element.tags).orEmpty()
+                // Otherwise, use empty string for the default language
+                val initialNames = existingNames.ifEmpty {
+                    listOf(LocalizedName(countryInfo.language.orEmpty(), ""))
+                }
+
+                mutableStateOf(initialNames)
             }
 
             Column {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -33,7 +33,7 @@ class AddPlaceName(
         // The common list is shared by the opening hours quest and the wheelchair quest.
         // It is also mostly shared by the name quest, that has some wildcards (for say craft and office)
         // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
-        // Independent tags can by added in the "name only" tab.
+        // Independent tags can be added in the "name only" tab.
 
         mapOf(
             "amenity" to arrayOf(
@@ -132,7 +132,15 @@ class AddPlaceName(
             ),
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
         )
-        and !name and !brand and noname != yes and name:signed != no
+        and (
+            (
+                !name
+                and !brand
+                and noname != yes
+            )
+            or ~fixme|FIXME ~ name|name\?|Name|Name\?
+        )
+        and name:signed != no
     """).toElementFilterExpression() }
 
     override val changesetComment = "Determine place names"

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -17,14 +17,14 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-          (
+          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
+          and (
              !name and !name:left and !name:right
              or ~fixme|FIXME ~ name|name\?|Name|Name\?
           )
+          and !ref
           and noname != yes
           and name:signed != no
-          and highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
-          and !ref
           and !junction
           and area != yes
           and (

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -18,7 +18,6 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
     override val elementFilter = """
         ways with
           highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
-          and !name and !name:left and !name:right
           and !ref
           and noname != yes
           and name:signed != no
@@ -27,6 +26,10 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
           and (
             access !~ private|no
             or foot and foot !~ private|no
+          )
+          and (
+             !name and !name:left and !name:right
+             or ~fixme|FIXME ~ name|name\?|Name|Name\?
           )
     """
     override val enabledInCountries = AllCountriesExcept("JP")

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -17,13 +17,13 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-          and (
+          (
              !name and !name:left and !name:right
              or ~fixme|FIXME ~ name|name\?|Name|Name\?
           )
           and noname != yes
           and name:signed != no
-          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
+          and highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
           and !ref
           and !junction
           and area != yes

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -17,19 +17,19 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
-          and !ref
+          and (
+             !name and !name:left and !name:right
+             or ~fixme|FIXME ~ name|name\?|Name|Name\?
+          )
           and noname != yes
           and name:signed != no
+          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
+          and !ref
           and !junction
           and area != yes
           and (
             access !~ private|no
             or foot and foot !~ private|no
-          )
-          and (
-             !name and !name:left and !name:right
-             or ~fixme|FIXME ~ name|name\?|Name|Name\?
           )
     """
     override val enabledInCountries = AllCountriesExcept("JP")

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedName.kt
@@ -62,6 +62,14 @@ fun List<LocalizedName>.applyTo(tags: Tags) {
     tags.remove("noname")
     tags.remove("name:signed")
 
+    // remove fixme=name tags
+    val values = setOf("name", "Name", "Name?", "name?")
+    for (key in listOf("fixme", "FIXME")) {
+        if (tags[key] in values) {
+            tags.remove(key)
+        }
+    }
+
     // language is only specified explicitly in OSM (usually) if there is more than one name specified
     if (size == 1) {
         tags["name"] = first().name.trim()

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedNameTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedNameTest.kt
@@ -69,6 +69,16 @@ internal class LocalizedNameTest {
         )
     }
 
+    @Test fun `apply localized names removes fixme=name and variants`() {
+        assertEquals(
+            setOf(),
+            listOf<LocalizedName>().appliedTo(mapOf(
+                "fixme" to "name",
+                "FIXME" to "Name?"
+            ))
+        )
+    }
+
     @Test fun `apply localized names`() {
         assertEquals(
             setOf(

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedNameTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedNameTest.kt
@@ -71,8 +71,12 @@ internal class LocalizedNameTest {
 
     @Test fun `apply localized names removes fixme=name and variants`() {
         assertEquals(
-            setOf(),
-            listOf<LocalizedName>().appliedTo(mapOf(
+            setOf(
+                StringMapEntryAdd("name", "N"),
+                StringMapEntryDelete("fixme", "name"),
+                StringMapEntryDelete("FIXME", "Name?")
+            ),
+            listOf(LocalizedName("", "N")).appliedTo(mapOf(
                 "fixme" to "name",
                 "FIXME" to "Name?"
             ))


### PR DESCRIPTION
Fixes https://github.com/streetcomplete/StreetComplete/issues/5934

Changes:

- app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/localized_name/LocalizedName.kt now removes any fixme=`name` alternatives when setting a name
- resurvey roads and places with fixme=`name` (and alternatives), that also have `name`, `brand` or similar tagged.

The latter deliberately does not apply to places with name:signed=`no`, since these are impossible to survey.

I did not apply this filter to all `name` quests, since the remaining ones (public transport and information board) very rarely have todo=name, so it does not seem worth it.

In the future I plan to implement some form of prefilling of the name if already set, but since this is such a rare case, it can be ignored for now.

Tested.