### PR TITLE
disable AddCycleway in Sweden

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -42,8 +42,8 @@ class AddCycleway(
     // https://en.wikivoyage.org/wiki/Cycling
     // http://peopleforbikes.org/get-local/ (US)
     override val enabledInCountries = NoCountriesExcept(
-        // all of Northern and Western Europe, most of Central Europe, some of Southern Europe
-        "NO", "SE", "FI", "IS", "DK", "SI",
+        // most of Northern and Western Europe, most of Central Europe, some of Southern Europe
+        "NO", "FI", "IS", "DK", "SI",
         "GB", "IE", "NL", "BE", "FR", "LU",
         "DE", "PL", "CZ", "HU", "AT", "CH", "LI",
         "ES", "IT", "HR",


### PR DESCRIPTION
This disables the "AddCycleway" quest in Sweden.

Discussed with the Swedish osm community [here](https://community.openstreetmap.org/t/streetcomplete-i-sverige/135708/4).

---
The AddCycleWay quest in SC has recently been [enabled by default](https://github.com/streetcomplete/StreetComplete/commit/bdc7e4702aaadd803634bfdfee92843a2e327040#diff-9337c68ff8dbf88035e78d29d310946065806d34b1b6a83bdc2c4245f165b554).

This quest is currently [enabled](https://github.com/streetcomplete/StreetComplete/blob/f0ffc4e455dff32ed8f6cf0de5b8055c0a22fa21/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt#L46) in Sweden, which means any new user will be asked this quest for most roads.

I think this quest should be disabled in Sweden, since I find it of little use here:

Cycle lanes alongside the road are quite uncommon in Sweden. Bike paths are more commonly built as separated, bi-directional paths, within a separate system that does not often follow along roads, especially in more rural and suburban areas.

Most of these paths are already mapped.

This leads to the cycle quest becoming very repetitive. In rural and suburban areas, the answer is almost always “no”, for both directions, since the bike paths do not follow the roads. In urban areas, the answer is almost always “no” and very rarely “seperate”.

Neither of these answers add much of value, but they use a lot of time, and create a lot of “quests”.

This quest makes more sense in other European countries, where bike paths along the road are more common, but for Sweden I do not think it makes any sense at the moment.