### PR TITLE
implement IsImeVisible for iOS

### DIFF
--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/ui/util/IsImeVisible.ios.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/ui/util/IsImeVisible.ios.kt
@@ -1,6 +1,9 @@
 package de.westnordost.streetcomplete.ui.util
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
 
 @Composable
-actual fun isImeVisible(): Boolean = TODO()
+actual fun isImeVisible(): Boolean = WindowInsets.ime.getBottom(LocalDensity.current) > 0


### PR DESCRIPTION
Following up from https://github.com/streetcomplete/StreetComplete/pull/6929, this implements `IsImeVisible` for iOS.