### PR TITLE
extended quests to traffic park

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -59,7 +59,7 @@ mapOf(
 
         // name & opening hours
         "boat_rental", "vehicle_inspection", "motorcycle_rental", "crematorium",
-        "public_bath",
+        "public_bath", "traffic_park"
 
         // not ATM because too often it's simply 24/7 and too often it is confused with
         // a bank that might be just next door because the app does not tell the user what

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -55,7 +55,7 @@ class AddPlaceName(
 
                 // name & opening hours
                 "boat_rental", "vehicle_inspection", "motorcycle_rental", "crematorium",
-                "public_bath",
+                "public_bath", "traffic_park",
 
                 // name & wheelchair
                 "theatre",                                        // culture


### PR DESCRIPTION
Extends `name` and `opening_hours` quests to [traffic parks](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dtraffic_park).

Tested, though this was only [recently](https://github.com/openstreetmap/id-tagging-schema/commit/c68fc96ba91b9a38fb5c8aa027f7759b639e75fc) added to id-tagging, so the feature requires a dependency update to match.
