### PR TITLE
Is this covered? for bicycle charging stations

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -17,10 +17,13 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>(), AndroidQuest {
 
     override val elementFilter = """
         nodes, ways with
-         amenity = bicycle_parking
-         and access !~ private|no
-         and !covered
-         and bicycle_parking !~ shed|lockers|building
+        (
+            amenity = bicycle_parking
+            or amenity = charging_station and bicycle ~ yes|designated and !lockable and motorcar=no
+        )
+        and access !~ private|no
+        and !covered
+        and bicycle_parking !~ shed|lockers|building
     """
     override val changesetComment = "Specify bicycle parkings covers"
     override val wikiLink = "Tag:amenity=bicycle_parking"


### PR DESCRIPTION
Extends the bicycle parking `covered` quest to bicycle charging stations.

I have excluded charging stations with `lockable`, to exclude charging station "boxes".

This information is quite useful for people who wish to charge their bikes, but may not have rain proof charging adapters.

The wiki has [examples](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station#Examples_of_bicycle_charging_stations) of covered, and non-covered charging stations.



Tested.

