### PR TITLE
expanded AddShelterCapacity to lean_to shelters

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shelter_capacity/AddShelterCapacity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shelter_capacity/AddShelterCapacity.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.RARE
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.resources.*
@@ -19,7 +20,7 @@ class AddShelterCapacity : OsmFilterQuestType<Int>(), AndroidQuest {
           (
             (
               amenity = shelter
-              and shelter_type = basic_hut
+              and shelter_type ~ basic_hut|lean_to
             )
             or tourism = wilderness_hut
           )
@@ -32,7 +33,7 @@ class AddShelterCapacity : OsmFilterQuestType<Int>(), AndroidQuest {
     override val icon = R.drawable.quest_shelter_capacity
     override val title = Res.string.quest_shelter_capacity_title
     override val isDeleteElementEnabled = true
-    override val achievements = listOf(OUTDOORS)
+    override val achievements = listOf(OUTDOORS, RARE)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("nodes, ways with amenity = shelter")


### PR DESCRIPTION
In https://github.com/streetcomplete/StreetComplete/pull/6442 I implemented AddShelterCapacity for [wilderness huts](https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dwilderness_hut), and [basic huts](https://wiki.openstreetmap.org/wiki/Tag:shelter_type%3Dbasic_hut).

Back then I intentionally excluded [lean to](https://wiki.openstreetmap.org/wiki/Tag:shelter_type%3Dlean_to) shelters, because I believed that it was to hard to judge for lean_to shelters, mostly because many of them have a single large wooden floor, without individual bed spots. However having recently visited, and slept in more of them I have changed my mind due to:

1. Many lean to*s have individual, large, "benches" which serve as sleeping spots, these are easy to count (2 out of the 4 examples in the wiki).
2. Even for the large wooden floors, estimating an upper bound is still possible. While maybe a bit subjective I do not think any end users expect any exact metrics here. As in, a group of 6 people, who find a shelter with 6 slots, might well expect that they will not have as much space individually.

Also added it to the Rare quest.