### PR TITLE
Add quest for surveying beer availability (drink:beer)

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
@@ -27,6 +27,7 @@ import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnPath
 import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnRoad
 import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierType
 import de.westnordost.streetcomplete.quests.barrier_type.AddStileType
+import de.westnordost.streetcomplete.quests.beer.AddBeer
 import de.westnordost.streetcomplete.quests.bbq_fuel.AddBbqFuel
 import de.westnordost.streetcomplete.quests.bench_backrest.AddBenchBackrest
 import de.westnordost.streetcomplete.quests.bicycle_repair_station.AddBicycleRepairStationServices
@@ -466,6 +467,7 @@ fun questTypeRegistry(
     110 to AddAirConditioning(), // often visible from the outside across the street, if not, visible/feelable inside
 
     111 to AddSmoking(), // often marked on the entrance, if not, visible/smellable inside
+    198 to AddBeer(),
 
     /* ↓ 4.quests that may need to go inside ------------------------------------------------ */
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeer.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeer.kt
@@ -1,0 +1,51 @@
+package de.westnordost.streetcomplete.quests.beer
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.updateWithCheckDate
+import de.westnordost.streetcomplete.resources.*
+
+class AddBeer : OsmFilterQuestType<BeerServed>(), AndroidQuest {
+
+    override val elementFilter = """
+         nodes, ways with
+         amenity ~ restaurant|bar|biergarten|pub|cafe|nightclub
+         and (
+             !drink:beer 
+             or drink:beer ~ yes|served
+             or drink:beer older today -4 years
+         )
+         and !microbrewery
+         and (!brewery or brewery = no)
+    """
+    override val changesetComment = "Survey whether beer is served and how"
+    override val wikiLink = "Key:drink:beer"
+    override val icon = R.drawable.preset_fas_beer
+    override val title = Res.string.quest_drink_beer_title
+    override val isReplacePlaceEnabled = true
+    override val achievements = listOf(CITIZEN)
+    override val defaultDisabledMessage = Res.string.default_disabled_msg_go_inside
+
+    override fun getTitle(tags: Map<String, String>) =
+        if (tags["amenity"] in listOf("pub", "bar", "biergarten")) {
+            Res.string.quest_drink_beer_title_pub
+        } else {
+            Res.string.quest_drink_beer_title
+        }
+
+    override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
+        mapData.asSequence().filter { it.isPlaceOrDisusedPlace() }
+
+    override fun createForm() = AddBeerForm()
+
+    override fun applyAnswerTo(answer: BeerServed, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags.updateWithCheckDate("drink:beer", answer.osmValue)
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeerForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeerForm.kt
@@ -1,0 +1,26 @@
+package de.westnordost.streetcomplete.quests.beer
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import de.westnordost.streetcomplete.quests.ARadioGroupQuestForm
+import de.westnordost.streetcomplete.quests.beer.BeerServed.*
+import org.jetbrains.compose.resources.stringResource
+
+class AddBeerForm : ARadioGroupQuestForm<BeerServed, BeerServed>() {
+
+    override val items: List<BeerServed> get() {
+        val tags = element.tags
+        val isPubOrBar = tags["amenity"] == "pub" || tags["amenity"] == "bar" || tags["amenity"] == "biergarten"
+
+        return if (isPubOrBar) {
+            listOf(DRAUGHT, BOTTLED)
+        } else {
+            listOf(DRAUGHT, BOTTLED, YES, NO)
+        }
+    }
+
+    @Composable override fun BoxScope.ItemContent(item: BeerServed) {
+        Text(stringResource(item.text))
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/BeerServed.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/beer/BeerServed.kt
@@ -1,0 +1,18 @@
+package de.westnordost.streetcomplete.quests.beer
+
+import de.westnordost.streetcomplete.resources.*
+import org.jetbrains.compose.resources.StringResource
+
+enum class BeerServed(val osmValue: String) {
+    DRAUGHT("draught"),
+    BOTTLED("bottled"),
+    YES("yes"),
+    NO("no")
+}
+
+val BeerServed.text: StringResource get() = when (this) {
+    BeerServed.DRAUGHT -> Res.string.quest_drink_beer_draught
+    BeerServed.BOTTLED -> Res.string.quest_drink_beer_bottled
+    BeerServed.YES -> Res.string.quest_drink_beer_yes
+    BeerServed.NO -> Res.string.quest_drink_beer_no
+}

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeerTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/beer/AddBeerTest.kt
@@ -1,0 +1,73 @@
+package de.westnordost.streetcomplete.quests.beer
+
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.quests.answerApplied
+import de.westnordost.streetcomplete.testutils.node
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddBeerTest {
+    private val questType = AddBeer()
+
+    @Test fun `not applicable to empty tags`() {
+        assertFalse(questType.isApplicableTo(node()))
+    }
+
+    @Test fun `applicable to pub without beer tag`() {
+        assertTrue(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub"))
+        ))
+    }
+
+    @Test fun `not applicable to microbrewery`() {
+        assertFalse(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub", "microbrewery" to "yes"))
+        ))
+    }
+
+    @Test fun `not applicable to brewery`() {
+        assertFalse(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub", "brewery" to "yes"))
+        ))
+    }
+
+    @Test fun `applicable to pub with drink beer yes`() {
+        assertTrue(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub", "drink:beer" to "yes"))
+        ))
+    }
+
+    @Test fun `applicable to pub with drink beer served`() {
+        assertTrue(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub", "drink:beer" to "served"))
+        ))
+    }
+
+    @Test fun `not applicable to pub with drink beer draught`() {
+        assertFalse(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "pub", "drink:beer" to "draught"))
+        ))
+    }
+
+    @Test fun `applicable to restaurant`() {
+        assertTrue(questType.isApplicableTo(
+            node(tags = mapOf("amenity" to "restaurant"))
+        ))
+    }
+
+    @Test fun `draught answer sets correct answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("drink:beer", "draught")),
+            questType.answerApplied(BeerServed.DRAUGHT)
+        )
+    }
+
+    @Test fun `no answer sets correct answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("drink:beer", "no")),
+            questType.answerApplied(BeerServed.NO)
+        )
+    }
+}

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1587,6 +1587,13 @@ If there are no signs along the whole street which apply for the highlighted sec
     <string name="quest_smoking_separated">Only in separated areas</string>
     <string name="quest_smoking_yes">Yes, everywhere</string>
 
+    <string name="quest_drink_beer_title">Do they serve beer here?</string>
+    <string name="quest_drink_beer_title_pub">What kind of beer is served here?</string>
+    <string name="quest_drink_beer_yes">Yes, unspecified</string>
+    <string name="quest_drink_beer_draught">Yes, draught beer</string>
+    <string name="quest_drink_beer_bottled">Yes, bottled beer only</string>
+    <string name="quest_drink_beer_no">No</string>
+
     <string name="quest_smoothness_square_title">What’s the surface quality of this square?</string>
     <string name="quest_smoothness_road_title">What’s the surface quality of this road here?</string>
     <string name="quest_smoothness_title">What’s the surface quality here?</string>


### PR DESCRIPTION
This PR adds a new `AddBeer` quest to improve mapping of beer availability in OpenStreetMap.

### Motivation
While POIs like `amenity=pub`, `bar`, and `restaurant` imply food/drinks are served, the specific tagging of whether beer is served (`drink:beer`) and how it is served (draught vs. bottled) is often missing or ambiguous (`drink:beer=yes` or `drink:beer=served`). This quest aims to collect this granular data. 

### Implementation details
- Targets `amenity ~ restaurant|bar|biergarten|pub|cafe|nightclub`.
- Hides the "No" option for dedicated beer places (`pub`, `bar`, `biergarten`) and changes the question title to *"What kind of beer is served here?"*.
- For other establishments, asks *"Do they serve beer here?"* with "Yes, unspecified", "Yes, draught beer", "Yes, bottled beer only", and "No".
- Specifically excludes places mapped with `microbrewery=yes` or `brewery=yes` to avoid redundant tagging.
- Also targets places already tagged with `drink:beer=yes` or `drink:beer=served` that are older than 4 years or simply need their tagging upgraded from vague to "draught" / "bottled".
- A comprehensive test suite (`AddBeerTest.kt`) is included and passing.

This relies on standard tags (`drink:beer=yes/no/draught/bottled`) and avoids the complexity of free-text inputs for specific `brewery=*` brands.