### PR TITLE
Don't ask for islands and kerb heights on continuous crossings

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -24,6 +24,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean>, AndroidQuest {
           and foot != no
           and !crossing:island
           and crossing != island
+          and crossing:continuous != yes
     """.toElementFilterExpression() }
 
     private val excludedWaysFilter by lazy { """

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
@@ -22,6 +22,7 @@ class AddCrossingKerbHeight : OsmElementQuestType<KerbHeight>, AndroidQuest {
         nodes with
           highway = crossing
           and foot != no
+          and crossing:continuous != yes
           and (!kerb:left or !kerb:right)
           and (
             !kerb

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIslandTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIslandTest.kt
@@ -27,6 +27,17 @@ class AddCrossingIslandTest {
         assertNull(questType.isApplicableTo(crossing))
     }
 
+    @Test fun `not applicable to continuous crossing`() {
+        val crossing = node(tags = mapOf(
+            "highway" to "crossing",
+            "crossing" to "something",
+            "crossing:continuous" to "yes"
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(crossing))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+        assertEquals(false, questType.isApplicableTo(crossing))
+    }
+
     @Test fun `not applicable to crossing with private road`() {
         val crossing = node(id = 1, tags = mapOf(
             "highway" to "crossing",


### PR DESCRIPTION
[Continuous crossings](https://wiki.openstreetmap.org/wiki/Key:crossing:continuous) are very unlikely to have islands, so this stops StreetComplete asking for them.

Among the ~9k `crossing:continuous=yes`, there are only [22 cases](https://overpass-turbo.eu/s/2ulD) with `crossing:island=yes`. Most of these either don't actually have an island or aren't actually continuous. The only real cases I found are these bicycle crossings in the Netherlands and islands are probably less important when cycling:
- https://www.openstreetmap.org/node/317439715 (note that the parallel pedestrian crossing is not continuous)
- https://www.openstreetmap.org/node/7466006701 (this is a pedestrian crossing that's not actually continuous, but the parallel bicycle one is)

~Not tested locally, it's just a query change.~ Confirmed it works as expected with debug apk.

Motivated by: https://community.openstreetmap.org/t/vorgehen-gegen-das-eintragen-von-nicht-eigenschaften/145808