### PR TITLE
fix path to compose resource files on iOS

### DIFF
--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
@@ -25,7 +25,8 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDefaults
 import platform.Foundation.NSUserDomainMask
 
-private val COMPOSE_FILES_DIR = NSBundle.mainBundle.resourcePath + "/compose-resources/files"
+private val COMPOSE_FILES_DIR = NSBundle.mainBundle.resourcePath +
+    "/compose-resources/composeResources/de.westnordost.streetcomplete.resources/files"
 
 @OptIn(ExperimentalForeignApi::class)
 val iosModule = module {


### PR DESCRIPTION
I was playing around with the changes on `compose-quest-form` trying to get the quest UI working, but the app kept crashing. I found `COMPOSE_FILES_DIR` in `IosModule.kt` that points at `<bundle>/compose-resources/files`, but the Compose resources are laid out at `<bundle>/compose-resources/composeResources/de.westnordost.streetcomplete.resources/files`.

With this fix, plus registering `commonModule` in the iOS `initKoin()` and adding a launcher entry (both local-only for now), the quest forms render on iOS 🎉

<img width="300" alt="file-516bd00008fa2b6b95f60c883b2c324a" src="https://github.com/user-attachments/assets/7e47c2d7-568b-4c82-b045-085c7fb97a00" />
<img width="300" alt="file-0be5394f5ea705b98bce3bfed925a551" src="https://github.com/user-attachments/assets/712d0df1-2b58-4297-8f83-4e8fae27a9fd" />