### PR TITLE
Stop asking for 'fee' of 'customer' parking

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -12,7 +12,7 @@ class AddParkingFee : OsmFilterQuestType<ParkingFeeAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         nodes, ways, relations with amenity = parking
-        and access ~ yes|customers|public
+        and access ~ yes|public
         and (
             !fee and !fee:conditional
             or fee older today -8 years


### PR DESCRIPTION
Closes https://github.com/streetcomplete/StreetComplete/issues/6961

Currently AddParkingFee ask for customer parking lots.
Surveying these might require asking inside of hotels or shops, if customers must pay an additional fee.

It may also be confusing to users: Imagine a parking lot attached to a museum, where only customers of the museum may park, but they are not required to pay an additional fee? Without further clarification, users may answer either way.

I have not tested this change.