### PR TITLE
Add quest for motorcycle parking surface

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
@@ -170,6 +170,7 @@ import de.westnordost.streetcomplete.quests.summit.AddSummitRegister
 import de.westnordost.streetcomplete.quests.surface.AddBeachSurface
 import de.westnordost.streetcomplete.quests.surface.AddCyclewayPartSurface
 import de.westnordost.streetcomplete.quests.surface.AddFootwayPartSurface
+import de.westnordost.streetcomplete.quests.surface.AddMotorcycleParkingSurface
 import de.westnordost.streetcomplete.quests.surface.AddPathSurface
 import de.westnordost.streetcomplete.quests.surface.AddPitchSurface
 import de.westnordost.streetcomplete.quests.surface.AddRoadSurface
@@ -295,6 +296,7 @@ fun questTypeRegistry(
     // motorcycle parking
     30 to AddMotorcycleParkingCover(),
     31 to AddMotorcycleParkingCapacity(), // counting + number input required but usually well visible
+    193 to AddMotorcycleParkingSurface(),
     180 to AddMotorcycleParkingFee(),
 
     // air pump, may require some checking within a garage forecourt

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddMotorcycleParkinSurfaceForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddMotorcycleParkinSurfaceForm.kt
@@ -1,0 +1,25 @@
+package de.westnordost.streetcomplete.quests.surface
+
+import androidx.compose.runtime.Composable
+import de.westnordost.streetcomplete.osm.surface.Surface
+import de.westnordost.streetcomplete.osm.surface.icon
+import de.westnordost.streetcomplete.osm.surface.title
+import de.westnordost.streetcomplete.quests.AItemSelectQuestForm
+import de.westnordost.streetcomplete.ui.common.item_select.ImageWithLabel
+import kotlinx.serialization.serializer
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+class AddMotorcycleParkingSurfaceForm : AItemSelectQuestForm<Surface, Surface>() {
+    override val items get() = Surface.getSelectableValuesForWays(countryOrSubdivisionCode)
+    override val itemsPerRow = 3
+    override val serializer = serializer<Surface>()
+
+    @Composable override fun ItemContent(item: Surface) {
+        ImageWithLabel(item.icon?.let { painterResource(it) }, stringResource(item.title))
+    }
+
+    override fun onClickOk(selectedItem: Surface) {
+        applyAnswer(selectedItem)
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddMotorcycleParkingSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddMotorcycleParkingSurface.kt
@@ -1,0 +1,36 @@
+package de.westnordost.streetcomplete.quests.surface
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.surface.Surface
+import de.westnordost.streetcomplete.osm.surface.applyTo
+import de.westnordost.streetcomplete.resources.*
+
+class AddMotorcycleParkingSurface : OsmFilterQuestType(), AndroidQuest {
+  override val elementFilter = """
+    nodes, ways with amenity = motorcycle_parking
+     and access !~ private|no
+     and !surface
+"""
+
+    override val changesetComment = "Specify motorcycle parking surface"
+    override val wikiLink = "Key:surface"
+    override val icon = R.drawable.quest_motorcycle_parking
+    override val title = Res.string.quest_surface_title
+    override val achievements = listOf(OUTDOORS)
+
+    override fun createForm() = AddMotorcycleParkingSurfaceForm()
+
+    override fun applyAnswerTo(
+        answer: Surface,
+        tags: Tags,
+        geometry: ElementGeometry,
+        timestampEdited: Long
+    ) {
+        answer.applyTo(tags)
+    }
+}


### PR DESCRIPTION
Fixes #6829
This adds a new quest for specifying the surface of motorcycle parking areas.

The quest:
- asks for `surface=*` on `amenity=motorcycle_parking`
- reuses the existing surface selection UI
- is placed together with the other motorcycle parking quests