### PR TITLE
Make quest forms testable on iOS

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsViewModel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.QuestType
@@ -42,7 +43,10 @@ class ShowQuestFormsViewModelImpl(
 
     private val questTitles = MutableStateFlow<Map<String, String>>(emptyMap())
 
-    private val mockPosition get() = prefs.mapPosition
+    // The map runs only on Android currently, no map position is ever stored on iOS.
+    // Null Island lies within no country, so no CountryInfo can be resolved for it.
+    private val mockPosition get() =
+        prefs.mapPosition.takeIf { it != NULL_ISLAND } ?: FALLBACK_MOCK_POSITION
 
     override val filteredQuests: StateFlow<List<QuestType>> =
         combine(searchText, questTitles) { searchText, titles ->
@@ -123,3 +127,7 @@ class ShowQuestFormsViewModelImpl(
         }
     }
 }
+
+private val NULL_ISLAND = LatLon(0.0, 0.0)
+// arbitrary, just needs to lie within some country
+private val FALLBACK_MOCK_POSITION = LatLon(53.6074, 9.9030)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosApp.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosApp.kt
@@ -18,10 +18,11 @@ import androidx.compose.ui.Modifier
 import de.westnordost.streetcomplete.screens.about.ChangelogScreen
 import de.westnordost.streetcomplete.screens.about.CreditsScreen
 import de.westnordost.streetcomplete.screens.about.PrivacyStatementScreen
+import de.westnordost.streetcomplete.screens.settings.debug.ShowQuestFormsScreen
 import org.koin.compose.viewmodel.koinViewModel
 import platform.Foundation.NSUserDefaults
 
-private enum class Screen { Changelog, Credits, PrivacyStatement }
+private enum class Screen { Changelog, Credits, PrivacyStatement, ShowQuestForms }
 
 /** Allows opening a screen directly for development, e.g.
  *  xcrun simctl launch booted <bundle id> -screen Changelog */
@@ -47,6 +48,10 @@ fun IosApp() {
                 onClickBack = { screen = null },
             )
             Screen.PrivacyStatement -> PrivacyStatementScreen(
+                onClickBack = { screen = null },
+            )
+            Screen.ShowQuestForms -> ShowQuestFormsScreen(
+                viewModel = koinViewModel(),
                 onClickBack = { screen = null },
             )
         }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/Koin.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/Koin.kt
@@ -1,29 +1,12 @@
 package de.westnordost.streetcomplete
 
-import de.westnordost.streetcomplete.resources.Res
-import de.westnordost.streetcomplete.screens.about.ChangelogViewModel
-import de.westnordost.streetcomplete.screens.about.ChangelogViewModelImpl
-import de.westnordost.streetcomplete.screens.about.CreditsViewModel
-import de.westnordost.streetcomplete.screens.about.CreditsViewModelImpl
 import org.koin.core.context.startKoin
-import org.koin.core.module.dsl.viewModel
-import org.koin.dsl.module
-
-/* Only what already works on iOS is registered here. Most of the modules Android registers in
- * StreetCompleteApplication either are not multiplatform yet or require a Database, which does
- * not exist for iOS yet. */
-val iosAppModule = module {
-    single<Res> { Res }
-
-    viewModel<ChangelogViewModel> { ChangelogViewModelImpl(get()) }
-    viewModel<CreditsViewModel> { CreditsViewModelImpl(get()) }
-}
 
 fun initKoin() {
     startKoin {
         modules(
             iosModule,
-            iosAppModule,
+            commonModule,
         )
     }
 }


### PR DESCRIPTION
Follow-up to #6989. A few small changes that make the "Show Quest Forms" debug screen usable on iOS.

The change in `ShowQuestFormsViewModel` is worth noting, since iOS doesn't yet have a map that sets a position but needs `CountryInfos.get` to return data.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6cb60367-836d-483d-8427-1e25208cc935" />

edit: oooh, fancy PR number 🤩