### PR TITLE
added confirmation to certain aerialway oneway answers

### DIFF
--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -904,6 +904,7 @@ Before uploading your changes, the app checks with a &lt;a href="https://www.wes
     <string name="quest_bollard_type_not_bollard">Not a bollard, but some other barrier</string>
 
     <string name="quest_bothway_title">In what direction can you ride this?</string>
+    <string name="quest_bothway_aerialway_confirm">Are you sure a person can ride this lift in both directions?</string>
 
     <string name="quest_bridge_structure_title">What’s the structure of this bridge?</string>
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
@@ -15,6 +15,7 @@ import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.BACKWARD
 import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.FORWARD
 import de.westnordost.streetcomplete.quests.oneway.OnewayAnswer.NO_ONEWAY
 import de.westnordost.streetcomplete.resources.*
+import org.jetbrains.compose.resources.StringResource
 
 class AddOnewayAerialway : OsmElementQuestType<OnewayAnswer> {
 
@@ -45,7 +46,7 @@ class AddOnewayAerialway : OsmElementQuestType<OnewayAnswer> {
 
     @Composable
     override fun Form(on: (QuestAction<OnewayAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
-        AddOnewayForm(on, geometry)
+        AddOnewayForm(on, geometry) { tags, answer -> suspiciousCombination(tags, answer) }
     }
 
     override fun applyAnswerTo(answer: OnewayAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
@@ -54,5 +55,16 @@ class AddOnewayAerialway : OsmElementQuestType<OnewayAnswer> {
             BACKWARD -> "-1"
             NO_ONEWAY -> "no"
         }
+    }
+
+    // Some types of aerialways only very rarely allow you to use them in both directions
+    // https://github.com/streetcomplete/StreetComplete/issues/6970
+    private fun suspiciousCombination(tags: Tags, answer: OnewayAnswer): StringResource? {
+        var rare_bothway_aerialways = arrayOf("t-bar","j-bar", "platter", "drag_lift")
+        if (answer== NO_ONEWAY && tags["aerialway"] in rare_bothway_aerialways)
+        {
+            return Res.string.quest_bothway_aerialway_confirm
+        }
+        return null
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayForm.kt
@@ -4,18 +4,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
+import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.ui.common.item_select.ImageWithLabel
 import de.westnordost.streetcomplete.ui.common.quest.ItemSelectQuestForm
 import de.westnordost.streetcomplete.ui.common.quest.LocalMapRotation
 import de.westnordost.streetcomplete.ui.util.ClipCirclePainter
 import de.westnordost.streetcomplete.util.math.getOrientationOrZero
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun AddOnewayForm(
     on: (QuestAction<OnewayAnswer>) -> Unit,
-    geometry: ElementGeometry
+    geometry: ElementGeometry,
+    suspiciousAnswerFunction: (tags: Tags, answer: OnewayAnswer) -> StringResource? = { null } as (tags: Tags, answer: OnewayAnswer) -> StringResource?
 ) {
     val geometryRotation = remember(geometry) { geometry.getOrientationOrZero() }
     ItemSelectQuestForm(
@@ -29,5 +32,6 @@ fun AddOnewayForm(
                 imageRotation = geometryRotation - LocalMapRotation.current
             )
         },
+        suspiciousAnswerFunction = suspiciousAnswerFunction
     )
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/ItemSelectQuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/ItemSelectQuestForm.kt
@@ -17,15 +17,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.cheonjaeung.compose.grid.SimpleGridCells
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.Answer
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.preferences.addLastPicked
 import de.westnordost.streetcomplete.data.preferences.getLastPicked
+import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.resources.*
+import de.westnordost.streetcomplete.ui.common.dialogs.AreYouSureDialog
 import de.westnordost.streetcomplete.ui.common.item_select.ItemSelectGrid
 import de.westnordost.streetcomplete.ui.util.rememberSerializable
 import de.westnordost.streetcomplete.util.takeFavorites
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -44,8 +48,11 @@ inline fun <reified I> ItemSelectQuestForm(
     favoriteKey: String? = null,
     title: String = stringResource(LocalQuestType.current!!.title),
     noinline otherAnswers: @Composable (() -> List<AnswerItem>) = { emptyList() },
+    noinline suspiciousAnswerFunction: (tags: Tags, answer: I) -> StringResource? = { _, _ -> null },
     preferences: Preferences = koinInject()
 ) {
+    var unusualImportMessage by remember { mutableStateOf<StringResource?>(null) }
+
     val reorderedItems = remember(items, itemsPerRow, favoriteKey) {
         if (favoriteKey != null) {
             val favourites = preferences.getLastPicked<I>(favoriteKey)
@@ -57,15 +64,22 @@ inline fun <reified I> ItemSelectQuestForm(
     }
     var selectedItem by rememberSerializable { mutableStateOf<I?>(null) }
 
+    val currentElement = LocalElement.current
     QuestForm(
         on = on,
         isComplete = selectedItem != null,
         onClickOk = {
             val value = selectedItem!!
-            if (favoriteKey != null) {
-                preferences.addLastPicked(favoriteKey, value)
+            val tags = StringMapChangesBuilder(currentElement!!.tags)
+            val suspiciousMessage = suspiciousAnswerFunction(tags, value)
+            if (suspiciousMessage != null) {
+                unusualImportMessage = suspiciousMessage
+            } else {
+                if (favoriteKey != null) {
+                    preferences.addLastPicked(favoriteKey, value)
+                }
+                on(Answer(value))
             }
-            on(Answer(value))
         },
         modifier = modifier,
         title = title,
@@ -78,6 +92,7 @@ inline fun <reified I> ItemSelectQuestForm(
             ) {
                 Text(stringResource(Res.string.quest_roofShape_select_one))
             }
+            val tags = LocalElement.current?.tags as? Tags
             ItemSelectGrid(
                 columns = SimpleGridCells.Fixed(itemsPerRow),
                 items = reorderedItems,
@@ -87,5 +102,12 @@ inline fun <reified I> ItemSelectQuestForm(
                 itemContent = itemContent
             )
         }
+    }
+    if (unusualImportMessage != null) {
+        AreYouSureDialog(
+            onDismissRequest = { unusualImportMessage = null },
+            onConfirmed = { on(Answer(selectedItem!!)) },
+            text = { Text(stringResource(unusualImportMessage!!)) }
+        )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/streetcomplete/StreetComplete/issues/6970

Adds a confirmation dialog when "bothways" is answered for a set of aerialways.

<img width="572" height="1280" alt="image" src="https://github.com/user-attachments/assets/096458be-44f0-4838-a83b-5187b89647c3" />

I achieved this by adding a `suspiciousAnswerFunction` to ItemSelectQuestForm. This can be used to implement similar checks to further quests (I have some ideas).