### PR TITLE
skip asking for existence of non-permanent shops

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -90,7 +90,7 @@ class CheckExistence(
         and access !~ no|private
         and (!seasonal or seasonal = no)
         and (!intermittent or intermittent = no)
-        and (!permanent or permanent != yes)
+        and (!permanent or permanent = yes)
         and (!heritage or heritage = no)
         and !listed_status
     """.toElementFilterExpression() }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -43,6 +43,10 @@ class CheckShopExistence(
             or ${LAST_CHECK_DATE_KEYS.joinToString(" or ") { "$it < today -2 years" }}
           )
           and (name or brand or noname = yes or name:signed = no)
+          and (!seasonal or seasonal = no)
+          and (!intermittent or intermittent = no)
+          and (!permanent or permanent != yes)
+          and (!street_vendor or street_vendor = no)
     """).toElementFilterExpression() }
 
     override val changesetComment = "Survey if places still exist"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -45,7 +45,7 @@ class CheckShopExistence(
           and (name or brand or noname = yes or name:signed = no)
           and (!seasonal or seasonal = no)
           and (!intermittent or intermittent = no)
-          and (!permanent or permanent != yes)
+          and (!permanent or permanent = yes)
           and (!street_vendor or street_vendor = no)
     """).toElementFilterExpression() }
 


### PR DESCRIPTION
Similar to `CheckExistence.kt`, do not ask for existence of temporary or seasonal shops either,
as it might likely cause unwarranted removed damage due to them being missing or look
non-existent at certain times.

Mostly tagged on `shop=farm`, `shop=greengrocer`, `street_vendor=yes` shops and similar; e.g. [n12210061745](https://www.openstreetmap.org/node/12210061745), [n12210061753](https://www.openstreetmap.org/node/12210061753), [n9554749649](https://www.openstreetmap.org/node/9554749649), [n12250612108](https://www.openstreetmap.org/node/12250612108), [w1371002108](https://www.openstreetmap.org/way/1371002108), [n12175078026](https://www.openstreetmap.org/node/12175078026) etc.

Also fixes similarly broken check in `CheckExistence.kt` for `permanent=*`

([compiles](https://github.com/mnalis/StreetComplete/actions/runs/32147153247), but not tested yet)