### PR TITLE
RecyclingType: Change recycling continer to recycling continer(s)

### DIFF
--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1527,8 +1527,8 @@ If there are no signs along the whole street which apply for the highlighted sec
 
     <string name="quest_recycling_type_title">What type of recycling facility is this?</string>
     <string name="recycling_centre">Center</string>
-    <string name="overground_recycling_container">Container</string>
-    <string name="underground_recycling_container">Underground container</string>
+    <string name="overground_recycling_container">Container(s)</string>
+    <string name="underground_recycling_container">Underground container(s)</string>
 
     <string name="quest_religion_for_place_of_worship_title">What religion is practiced at this place?</string>
     <string name="quest_religion_for_wayside_shrine_title">What religion is this shrine associated with?</string>


### PR DESCRIPTION
I have been noticing a few [recycling containers](https://wiki.openstreetmap.org/wiki/Tag:recycling_type%3Dcontainer)s being falsely labeled as `center`. I suspect this might be due to the name "Container" making it sound like this value is only valid for single containers. However the wiki says:

> Use [recycling_type](https://wiki.openstreetmap.org/wiki/Key:recycling_type)=container to define a recycling container, or a **group of recycling containers.**

I hope this minor string change helps clarify this.