### PR TITLE
Add iOS active network connection interface

### DIFF
--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
@@ -124,7 +124,7 @@ val iosModule = module {
 
     // connection
 
-    factory<ActiveNetworkConnection> { IosActiveNetworkConnection() }
+    single<ActiveNetworkConnection> { IosActiveNetworkConnection() }
 
     // background jobs
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
@@ -124,7 +124,7 @@ val iosModule = module {
 
     // connection
 
-    single<ActiveNetworkConnection> { IosActiveNetworkConnection() }
+    factory<ActiveNetworkConnection> { IosActiveNetworkConnection() }
 
     // background jobs
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/IosModule.kt
@@ -22,7 +22,6 @@ import de.westnordost.streetcomplete.screens.main.EmailAppLauncher
 import de.westnordost.streetcomplete.screens.main.IosEmailAppLauncher
 import de.westnordost.streetcomplete.screens.main.IosMapAppLauncher
 import de.westnordost.streetcomplete.screens.main.MapAppLauncher
-import de.westnordost.streetcomplete.ui.util.measure.ArMeasureAppLauncher
 import de.westnordost.streetcomplete.ui.util.measure.ArSupportChecker
 import de.westnordost.streetcomplete.ui.util.measure.IosArSupportChecker
 import de.westnordost.streetcomplete.util.error_reporting.CrashReportHolder
@@ -121,7 +120,7 @@ val iosModule = module {
 
     // connection
 
-    factory<ActiveNetworkConnection> { IosActiveNetworkConnection() }
+    single<ActiveNetworkConnection> { IosActiveNetworkConnection() }
 
     // background jobs
 

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -2,9 +2,6 @@ package de.westnordost.streetcomplete.data.connection
 
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import platform.Network.nw_path_get_status
 import platform.Network.nw_path_is_expensive
 import platform.Network.nw_path_monitor_cancel
@@ -16,7 +13,6 @@ import platform.Network.nw_path_status_invalid
 import platform.Network.nw_path_status_satisfied
 import platform.Network.nw_path_t
 import platform.darwin.dispatch_queue_create
-import kotlin.time.Duration.Companion.milliseconds
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
     private val queue = dispatch_queue_create("network-monitor", null)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -1,8 +1,37 @@
 package de.westnordost.streetcomplete.data.connection
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.Network.nw_path_t
+import platform.darwin.dispatch_queue_create
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
+    private val monitor = nw_path_monitor_create()
+    private val queue = dispatch_queue_create("network-monitor", null)
+    private val _flow = MutableStateFlow<NetworkCapabilities?>(null)
+
+    init {
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            if(path != null) _flow.value = mapPath(path)
+        }
+        nw_path_monitor_start(monitor)
+    }
+
+    private fun mapPath(path: nw_path_t): NetworkCapabilities? {
+        val status = nw_path_get_status(path)
+        if (status != nw_path_status_satisfied) return null
+        val isMetered = nw_path_is_expensive(path)
+        return NetworkCapabilities(hasInternet = true, isMetered = isMetered)
+    }
+
     override val capabilities: Flow<NetworkCapabilities?>
-        get() = TODO("Not yet implemented")
+        get() = _flow
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -1,9 +1,18 @@
 package de.westnordost.streetcomplete.data.connection
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.stateIn
 import platform.Network.nw_path_get_status
 import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_cancel
 import platform.Network.nw_path_monitor_create
 import platform.Network.nw_path_monitor_set_queue
 import platform.Network.nw_path_monitor_set_update_handler
@@ -13,17 +22,8 @@ import platform.Network.nw_path_t
 import platform.darwin.dispatch_queue_create
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
-    private val monitor = nw_path_monitor_create()
     private val queue = dispatch_queue_create("network-monitor", null)
     private val _flow = MutableStateFlow<NetworkCapabilities?>(null)
-
-    init {
-        nw_path_monitor_set_queue(monitor, queue)
-        nw_path_monitor_set_update_handler(monitor) { path ->
-            _flow.value = mapPath(path)
-        }
-        nw_path_monitor_start(monitor)
-    }
 
     private fun mapPath(path: nw_path_t): NetworkCapabilities? {
         if(path == null) return null
@@ -34,6 +34,17 @@ class IosActiveNetworkConnection : ActiveNetworkConnection {
         return NetworkCapabilities(hasInternet = true, isMetered = isMetered)
     }
 
-    override val capabilities: Flow<NetworkCapabilities?>
-        get() = _flow
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val state: StateFlow<NetworkCapabilities?> = callbackFlow {
+        val monitor = nw_path_monitor_create()
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            _flow.value = mapPath(path)
+            trySend(_flow.value)
+        }
+        nw_path_monitor_start(monitor)
+        awaitClose { nw_path_monitor_cancel(monitor) }
+    }.stateIn(scope, SharingStarted.WhileSubscribed(), null)
+
+    override val capabilities: Flow<NetworkCapabilities?> get() = state
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -1,14 +1,10 @@
 package de.westnordost.streetcomplete.data.connection
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import platform.Network.nw_path_get_status
 import platform.Network.nw_path_is_expensive
 import platform.Network.nw_path_monitor_cancel
@@ -16,24 +12,26 @@ import platform.Network.nw_path_monitor_create
 import platform.Network.nw_path_monitor_set_queue
 import platform.Network.nw_path_monitor_set_update_handler
 import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_invalid
 import platform.Network.nw_path_status_satisfied
 import platform.Network.nw_path_t
 import platform.darwin.dispatch_queue_create
+import kotlin.time.Duration.Companion.milliseconds
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
     private val queue = dispatch_queue_create("network-monitor", null)
 
     private fun mapPath(path: nw_path_t): NetworkCapabilities? {
-        if(path == null) return null
-
+        if (path == null) return null
         val status = nw_path_get_status(path)
-        if (status != nw_path_status_satisfied) return null
-        val isMetered = nw_path_is_expensive(path)
-        return NetworkCapabilities(hasInternet = true, isMetered = isMetered)
+        if (status == nw_path_status_invalid) return null
+        return NetworkCapabilities(
+            hasInternet = status == nw_path_status_satisfied,
+            isMetered = nw_path_is_expensive(path),
+        )
     }
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val state: StateFlow<NetworkCapabilities?> = callbackFlow {
+    override val capabilities = callbackFlow {
         val monitor = nw_path_monitor_create()
         nw_path_monitor_set_queue(monitor, queue)
         nw_path_monitor_set_update_handler(monitor) { path ->
@@ -42,7 +40,5 @@ class IosActiveNetworkConnection : ActiveNetworkConnection {
         }
         nw_path_monitor_start(monitor)
         awaitClose { nw_path_monitor_cancel(monitor) }
-    }.stateIn(scope, SharingStarted.WhileSubscribed(), null)
-
-    override val capabilities: Flow<NetworkCapabilities?> get() = state
+    }
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
@@ -23,7 +22,6 @@ import platform.darwin.dispatch_queue_create
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
     private val queue = dispatch_queue_create("network-monitor", null)
-    private val _flow = MutableStateFlow<NetworkCapabilities?>(null)
 
     private fun mapPath(path: nw_path_t): NetworkCapabilities? {
         if(path == null) return null
@@ -39,8 +37,8 @@ class IosActiveNetworkConnection : ActiveNetworkConnection {
         val monitor = nw_path_monitor_create()
         nw_path_monitor_set_queue(monitor, queue)
         nw_path_monitor_set_update_handler(monitor) { path ->
-            _flow.value = mapPath(path)
-            trySend(_flow.value)
+            val capabilities = mapPath(path)
+            trySend(capabilities)
         }
         nw_path_monitor_start(monitor)
         awaitClose { nw_path_monitor_cancel(monitor) }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -20,12 +20,14 @@ class IosActiveNetworkConnection : ActiveNetworkConnection {
     init {
         nw_path_monitor_set_queue(monitor, queue)
         nw_path_monitor_set_update_handler(monitor) { path ->
-            if(path != null) _flow.value = mapPath(path)
+            _flow.value = mapPath(path)
         }
         nw_path_monitor_start(monitor)
     }
 
     private fun mapPath(path: nw_path_t): NetworkCapabilities? {
+        if(path == null) return null
+
         val status = nw_path_get_status(path)
         if (status != nw_path_status_satisfied) return null
         val isMetered = nw_path_is_expensive(path)

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -1,9 +1,18 @@
 package de.westnordost.streetcomplete.data.connection
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.stateIn
 import platform.Network.nw_path_get_status
 import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_cancel
 import platform.Network.nw_path_monitor_create
 import platform.Network.nw_path_monitor_set_queue
 import platform.Network.nw_path_monitor_set_update_handler
@@ -13,17 +22,8 @@ import platform.Network.nw_path_t
 import platform.darwin.dispatch_queue_create
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
-    private val monitor = nw_path_monitor_create()
     private val queue = dispatch_queue_create("network-monitor", null)
     private val _flow = MutableStateFlow<NetworkCapabilities?>(null)
-
-    init {
-        nw_path_monitor_set_queue(monitor, queue)
-        nw_path_monitor_set_update_handler(monitor) { path ->
-            _flow.value = mapPath(path)
-        }
-        nw_path_monitor_start(monitor)
-    }
 
     private fun mapPath(path: nw_path_t): NetworkCapabilities? {
         if(path == null) return null
@@ -34,8 +34,18 @@ class IosActiveNetworkConnection : ActiveNetworkConnection {
         return NetworkCapabilities(hasInternet = true, isMetered = isMetered)
     }
 
-    override val capabilitiesFlow: Flow<NetworkCapabilities?>
-        get() = _flow
-    override val capabilities: NetworkCapabilities?
-        get() = _flow.value
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val state: StateFlow<NetworkCapabilities?> = callbackFlow {
+        val monitor = nw_path_monitor_create()
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            _flow.value = mapPath(path)
+            trySend(_flow.value)
+        }
+        nw_path_monitor_start(monitor)
+        awaitClose { nw_path_monitor_cancel(monitor) }
+    }.stateIn(scope, SharingStarted.WhileSubscribed(), null)
+
+    override val capabilitiesFlow: Flow<NetworkCapabilities?> get() = state
+    override val capabilities: NetworkCapabilities? get() = state.value
 }

--- a/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
+++ b/app/src/iosMain/kotlin/de/westnordost/streetcomplete/data/connection/IosActiveNetworkConnection.kt
@@ -1,10 +1,39 @@
 package de.westnordost.streetcomplete.data.connection
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.Network.nw_path_t
+import platform.darwin.dispatch_queue_create
 
 class IosActiveNetworkConnection : ActiveNetworkConnection {
+    private val monitor = nw_path_monitor_create()
+    private val queue = dispatch_queue_create("network-monitor", null)
+    private val _flow = MutableStateFlow<NetworkCapabilities?>(null)
+
+    init {
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            if(path != null) _flow.value = mapPath(path)
+        }
+        nw_path_monitor_start(monitor)
+    }
+
+    private fun mapPath(path: nw_path_t): NetworkCapabilities? {
+        val status = nw_path_get_status(path)
+        if (status != nw_path_status_satisfied) return null
+        val isMetered = nw_path_is_expensive(path)
+        return NetworkCapabilities(hasInternet = true, isMetered = isMetered)
+    }
+
     override val capabilitiesFlow: Flow<NetworkCapabilities?>
-        get() = TODO("Not yet implemented")
+        get() = _flow
     override val capabilities: NetworkCapabilities?
-        get() = TODO("Not yet implemented")
+        get() = _flow.value
 }


### PR DESCRIPTION
This PR implements the `IosActiveNetworkConnection` interface to get information about the devices current network state.

`capabilitiesFlow` supports a stream of events, whereas `capabilities` just provides the current value. Should be at parity with the Android side of things.

Being my first PR to StreetComplete, feedback is very welcome (though, feedback is always welcome)!

Closes #7032 