### PR TITLE
extended AddPitchSurface to fitness stations

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/surface/Surface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/surface/Surface.kt
@@ -86,7 +86,7 @@ enum class Surface(val osmValue: String?) {
             // grouped a bit: 1. very most popular, 2. artificial, 3. natural
             GRASS, ASPHALT, CONCRETE,
             ARTIFICIAL_TURF, ACRYLIC, RUBBER,
-            CLAY, SAND, DIRT,
+            CLAY, SAND, DIRT, WOODCHIPS,
             // then, roughly by popularity
             FINE_GRAVEL, PAVING_STONES, COMPACTED,
             SETT, UNHEWN_COBBLESTONE, GRASS_PAVER,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -36,21 +36,27 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
     )
 
     override val elementFilter = """
-        ways with leisure ~ pitch|track
-         and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
-         and (access !~ private|no)
-         and indoor != yes and (!building or building = no)
-         and (athletics !~ high_jump|pole_vault)
-         and (
-          !surface
-          or surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            surface ~ paved|unpaved
-            and !surface:note
-            and !note:surface
-            and !check_date:surface
-          )
-          or surface older today -12 years
+        ways with
+        (
+            (
+                leisure ~ pitch|track
+                and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
+                and (athletics !~ high_jump|pole_vault)
+            )
+            or leisure = fitness_station
+        )
+        and (access !~ private|no)
+        and indoor != yes and (!building or building = no)
+        and (
+            !surface
+            or surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+                surface ~ paved|unpaved
+                and !surface:note
+                and !note:surface
+                and !check_date:surface
+            )
+            or surface older today -12 years
         )
     """
 


### PR DESCRIPTION
Extends AddPitchSurface to [fitness_stations](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dfitness_station).
Currently 2.5% of fitness stations have their surface tagged.

Most of the most[ common values](https://qlever.dev/osm-planet/4Ve0kZ) are already supported by the quest, with the exception of "wood chips" which I added here to.

Tested.