### PR TITLE
ensure diet:vegan=only and diet:vegetarian=yes/no cannot be tagged 

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -51,7 +51,14 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override fun applyAnswerTo(answer: DietAvailabilityAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         when (answer) {
-            is DietAvailability -> tags.updateWithCheckDate("diet:vegan", answer.osmValue)
+            is DietAvailability -> {
+                tags.updateWithCheckDate("diet:vegan", answer.osmValue)
+                // vegetarian = yes/no and vegan = only is an invalid combination, since every vegan meal is also vegetarian
+                // Thus we remove the vegetarian tag in this case to prevent invalid data
+                if (answer == DietAvailability.ONLY && tags["diet:vegetarian"] != "only") {
+                    tags.remove("diet:vegetarian")
+                }
+            }
             DietAvailabilityAnswer.NoFood -> tags["food"] = "no"
         }
     }


### PR DESCRIPTION
Second attempt at https://github.com/streetcomplete/StreetComplete/pull/6978, which I sadly cannot reopen since I force pushed to it.

Based on @mnalis feedback in https://github.com/streetcomplete/StreetComplete/pull/6978#issuecomment-5160589940 I have changed the approach: Now the outdated diet:vegetarian is simply removed if it would cause an invalid combination

The diet:vegetarian quest is already programmed to not ask again in this case.