### PR TITLE
Allow specifying that the toilet only has a fee for non-customers

### DIFF
--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1715,6 +1715,7 @@
     <string name="quest_toiletAvailability_title">Is there a restroom here?</string>
 
     <string name="quest_toiletsFee_title">Do you have to pay to use this restroom?</string>
+    <string name="quest_toiletsFee_fee_for_non_customers">Only non-customers must pay a fee</string>
 
     <string name="quest_tourism_information_title">What type of tourist information is this?</string>
     <string name="quest_tourism_information_office">Tourist information office</string>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -4,16 +4,19 @@ import androidx.compose.runtime.Composable
 import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.osmquests.Answer
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.resources.*
-import de.westnordost.streetcomplete.ui.common.quest.YesNoQuestForm
+import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
+import de.westnordost.streetcomplete.ui.common.quest.QuestForm
 import de.westnordost.streetcomplete.util.countryboundaries.AllCountriesExcept
 import de.westnordost.streetcomplete.util.ktx.toYesNo
+import org.jetbrains.compose.resources.stringResource
 
-class AddToiletsFee : OsmFilterQuestType<Boolean>() {
+class AddToiletsFee : OsmFilterQuestType<ToiletFeeAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
@@ -32,11 +35,30 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
     override val achievements = listOf(CITIZEN)
 
     @Composable
-    override fun Form(on: (QuestAction<Boolean>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
-        YesNoQuestForm(on)
+    override fun Form(on: (QuestAction<ToiletFeeAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
+        QuestForm(
+            on = on,
+            answers = listOf(
+                AnswerItem(stringResource(Res.string.quest_generic_hasFeature_no)) { on(Answer(ToiletFee(false))) },
+                AnswerItem(stringResource(Res.string.quest_generic_hasFeature_yes)) { on(Answer(ToiletFee(true))) },
+            ),
+            otherAnswers = { listOf(
+                AnswerItem(stringResource(Res.string.quest_toiletsFee_fee_for_non_customers)) {
+                    on(Answer(ToiletFeeForNonCustomers))
+                },
+            ) }
+        )
+
     }
 
-    override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        tags["fee"] = answer.toYesNo()
+    override fun applyAnswerTo(answer: ToiletFeeAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags.remove("fee:conditional")
+        when (answer) {
+            is ToiletFee -> tags["fee"] = answer.fee.toYesNo()
+            is ToiletFeeForNonCustomers -> {
+                tags["fee"] = "yes"
+                tags["fee:conditional"] = "no @ customers"
+            }
+        }
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.kt
@@ -20,6 +20,7 @@ class AddToiletsFee : OsmFilterQuestType<Boolean>() {
           amenity = toilets
           and access !~ private|customers
           and !fee
+          and !fee:conditional
           and (!seasonal or seasonal = no)
     """
     override val changesetComment = "Specify toilet fees"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/ToiletFeeAnswer.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilets_fee/ToiletFeeAnswer.kt
@@ -1,0 +1,5 @@
+package de.westnordost.streetcomplete.quests.toilets_fee
+
+sealed interface ToiletFeeAnswer
+data class ToiletFee(val fee: Boolean) : ToiletFeeAnswer
+data object ToiletFeeForNonCustomers : ToiletFeeAnswer


### PR DESCRIPTION
Toilets where only non-customers are required to pay a fee should be tagged with `fee=yes`, `fee:conditional=no @ customers`, if I read the Wiki correctly.