### PR TITLE
added permit as an answer for parking access

### DIFF
--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1385,10 +1385,10 @@
     <string name="quest_parcel_locker_brand">What’s the brand of this parcel locker?</string>
 
     <string name="quest_parking_access_title2">Who is allowed to park here? Parking may be free or paid.</string>
-    <string name="quest_access_yes">Any member of the general public</string>
+    <string name="quest_access_yes">Anyone</string>
     <string name="quest_access_customers">Any person visiting a specific place (e.g. customers only)</string>
     <string name="quest_access_private">Only individuals with permission</string>
-    <string name="quest_access_permit">Only individuals with a permit obtainable by the general public</string>
+    <string name="quest_access_permit">Holders of permits (generally obtainable)</string>
 
     <string name="quest_parking_fee_title">Do you have to pay to park here?</string>
     <string name="quest_fee_answer_hours">Depends on time and day…</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1387,7 +1387,8 @@
     <string name="quest_parking_access_title2">Who is allowed to park here? Parking may be free or paid.</string>
     <string name="quest_access_yes">Any member of the general public</string>
     <string name="quest_access_customers">Any person visiting a specific place (e.g. customers only)</string>
-    <string name="quest_access_private">Only individual(s) with permission</string>
+    <string name="quest_access_private">Only individuals with permission</string>
+    <string name="quest_access_permit">Only individuals with a permit obtainable by the general public</string>
 
     <string name="quest_parking_fee_title">Do you have to pay to park here?</string>
     <string name="quest_fee_answer_hours">Depends on time and day…</string>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/ParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/ParkingAccess.kt
@@ -8,10 +8,12 @@ enum class ParkingAccess(val osmValue: String) {
     YES("yes"),
     CUSTOMERS("customers"),
     PRIVATE("private"),
+    PERMIT("permit"),
 }
 
 val ParkingAccess.text: StringResource get() = when (this) {
     YES -> Res.string.quest_access_yes
     CUSTOMERS -> Res.string.quest_access_customers
     PRIVATE -> Res.string.quest_access_private
+    PERMIT -> Res.string.quest_access_permit
 }


### PR DESCRIPTION
Closes https://github.com/streetcomplete/StreetComplete/issues/2662

I added the string "Only individuals with a permit obtainable by the general public", I hope this addresses the objection raised by @matkoniecz in https://github.com/streetcomplete/StreetComplete/issues/2662#issuecomment-1008248400

I also removed the "(s) from individuals, for better legibility.
<img width="572" height="1280" alt="image" src="https://github.com/user-attachments/assets/362af189-6bcb-4885-a132-c15c5ec79ef2" />
