### PR TITLE
Allow the `tactile_paving` quest to be answered once for the whole crossing

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
@@ -23,7 +23,9 @@ import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.move.RevertMoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.RevertUpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.RevertUpdateElementsTagsAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementsTagsAction
 import de.westnordost.streetcomplete.util.Mockable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -42,6 +44,8 @@ class ElementEditsDao(
             polymorphic(ElementEditAction::class) {
                 subclass(UpdateElementTagsAction::class)
                 subclass(RevertUpdateElementTagsAction::class)
+                subclass(UpdateElementsTagsAction::class)
+                subclass(RevertUpdateElementsTagsAction::class)
                 subclass(SplitWayAction::class)
                 subclass(DeletePoiNodeAction::class)
                 subclass(RevertDeletePoiNodeAction::class)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementsTagsAction.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementsTagsAction.kt
@@ -1,0 +1,58 @@
+package de.westnordost.streetcomplete.data.osm.edits.update_tags
+
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
+import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
+import de.westnordost.streetcomplete.data.osm.edits.IsActionRevertable
+import de.westnordost.streetcomplete.data.osm.edits.IsRevertAction
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataChanges
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+import kotlinx.serialization.Serializable
+
+/** Action that updates the tags of several elements in one edit. Used when the answer to a quest
+ *  on one element also implies tag changes on other, nearby elements.
+ *
+ *  If the tag changes cannot be applied to any one of the elements, the whole action conflicts. */
+@Serializable
+data class UpdateElementsTagsAction(
+    val actions: List<UpdateElementTagsAction>
+) : ElementEditAction, IsActionRevertable {
+
+    init {
+        require(actions.isNotEmpty())
+    }
+
+    override val elementKeys: List<ElementKey> get() = actions.flatMap { it.elementKeys }
+
+    override fun idsUpdatesApplied(updatedIds: Map<ElementKey, Long>) =
+        copy(actions = actions.map { it.idsUpdatesApplied(updatedIds) })
+
+    override fun createUpdates(
+        mapDataRepository: MapDataRepository,
+        idProvider: ElementIdProvider
+    ) = MapDataChanges(
+        modifications = actions.flatMap { it.createUpdates(mapDataRepository, idProvider).modifications }
+    )
+
+    override fun createReverted(idProvider: ElementIdProvider) =
+        RevertUpdateElementsTagsAction(actions.map { it.createReverted(idProvider) })
+}
+
+/** Contains the information necessary to apply a revert of tag changes made on several elements */
+@Serializable
+data class RevertUpdateElementsTagsAction(
+    val actions: List<RevertUpdateElementTagsAction>
+) : ElementEditAction, IsRevertAction {
+
+    override val elementKeys: List<ElementKey> get() = actions.flatMap { it.elementKeys }
+
+    override fun idsUpdatesApplied(updatedIds: Map<ElementKey, Long>) =
+        copy(actions = actions.map { it.idsUpdatesApplied(updatedIds) })
+
+    override fun createUpdates(
+        mapDataRepository: MapDataRepository,
+        idProvider: ElementIdProvider
+    ) = MapDataChanges(
+        modifications = actions.flatMap { it.createUpdates(mapDataRepository, idProvider).modifications }
+    )
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmElementQuestType.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.data.osm.osmquests
 import androidx.compose.runtime.Composable
 import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditType
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
@@ -61,6 +62,10 @@ interface OsmElementQuestType<T> : QuestType, ElementEditType {
      * not (this is slow). */
     fun isApplicableTo(element: Element): Boolean?
 
+    /** Whether editing [element] may affect this quest type on nearby elements. If true, this
+     *  quest type is re-evaluated around the edited element. */
+    fun mayAffectNearbyQuests(element: Element): Boolean = false
+
     /** Elements that should be highlighted on the map alongside the selected one because they
      *  provide context for the given element. For example, nearby benches should be shown when
      *  answering a question for a bench so the user knows which of the benches is meant. */
@@ -118,6 +123,26 @@ interface OsmElementQuestType<T> : QuestType, ElementEditType {
      * with the given [tags] and the given [geometry].
      * The element is not directly modified, instead, a map of [tags] is modified */
     fun applyAnswerTo(answer: T, tags: Tags, geometry: ElementGeometry, timestampEdited: Long)
+}
+
+/** Additional interface for an [OsmElementQuestType] whose answer may also imply tag changes on
+ *  other, nearby elements, not only on the element the quest refers to.
+ *
+ *  E.g. that a crosswalk has tactile paving on both ends implies that the kerbs at its ends have
+ *  tactile paving. */
+interface AppliesAnswerToNearbyElements<in T> {
+    /** Radius in meters around the quest's element for which map data is provided to
+     *  [applyAnswerToNearbyElements] */
+    val nearbyElementsRadius: Double get() = 100.0
+
+    /** Returns the tag changes on other, nearby elements that are implied by the given [answer]
+     *  to the quest on the given [element]. The element itself is not changed here, but in
+     *  [OsmElementQuestType.applyAnswerTo]. */
+    fun applyAnswerToNearbyElements(
+        answer: T,
+        element: Element,
+        mapData: MapDataWithGeometry
+    ): List<Pair<Element, StringMapChanges>>
 }
 
 sealed interface QuestAction<out T>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
@@ -68,7 +68,27 @@ class OsmQuestController(
                 val geometry = updated.getGeometry(element.type, element.id) ?: continue
                 deferredQuests.addAll(createQuestsForElementDeferred(element, geometry, allQuestTypes))
             }
-            val quests = runBlocking { deferredQuests.awaitAll().filterNotNull() }
+
+            // Some quests depend on tags of a different, nearby element.
+            val nearbyQuestRegions = mutableListOf<Pair<BoundingBox, List<OsmElementQuestType<*>>>>()
+            for (element in updated) {
+                val geometry = updated.getGeometry(element.type, element.id) ?: continue
+                val affectedQuestTypes = allQuestTypes.filter { it.mayAffectNearbyQuests(element) }
+                if (affectedQuestTypes.isNotEmpty()) {
+                    val bbox = geometry.bounds.enlargedBy(NEARBY_QUESTS_PADDING)
+                    nearbyQuestRegions.add(bbox to affectedQuestTypes)
+                }
+            }
+            val nearbyQuests = nearbyQuestRegions.flatMap { (bbox, questTypes) ->
+                // Include context beyond the area in which quests are replaced.
+                val mapData = mapDataSource.getMapDataWithGeometry(
+                    bbox.enlargedBy(ApplicationConstants.QUEST_FILTER_PADDING)
+                )
+                createQuestsForBBox(bbox, mapData, questTypes)
+            }
+
+            val quests = (runBlocking { deferredQuests.awaitAll().filterNotNull() } + nearbyQuests)
+                .distinctBy { it.key }
 
             for (quest in quests) {
                 Log.d(TAG, "Created ${quest.type.name} for ${quest.elementType.name}#${quest.elementId}")
@@ -77,7 +97,10 @@ class OsmQuestController(
             var obsoleteQuestKeys: List<OsmQuestKey> = listOf()
             var visibleQuests: Collection<OsmQuest> = listOf()
             lock.withLock {
-                val previousQuests = db.getAllForElements(updated.map { it.key })
+                val previousNearbyQuests = nearbyQuestRegions.flatMap { (bbox, questTypes) ->
+                    db.getAllInBBox(bbox, questTypes.map { it.name })
+                }
+                val previousQuests = db.getAllForElements(updated.map { it.key }) + previousNearbyQuests
                 // quests that refer to elements that have been deleted shall be deleted
                 val deleteQuestKeys = db.getAllForElements(deleted).map { it.key }
 
@@ -330,5 +353,7 @@ class OsmQuestController(
 
     companion object {
         private const val TAG = "OsmQuestController"
+
+        private const val NEARBY_QUESTS_PADDING = 50.0
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -3,15 +3,19 @@ package de.westnordost.streetcomplete.quests.tactile_paving
 import androidx.compose.runtime.Composable
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfo
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChanges
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.Answer
+import de.westnordost.streetcomplete.data.osm.osmquests.AppliesAnswerToNearbyElements
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BLIND
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.isCrossing
+import de.westnordost.streetcomplete.osm.kerb.findAllKerbNodes
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.quests.tactile_paving.TactilePavingCrosswalkAnswer.INCORRECT
 import de.westnordost.streetcomplete.quests.tactile_paving.TactilePavingCrosswalkAnswer.NO
@@ -19,9 +23,12 @@ import de.westnordost.streetcomplete.quests.tactile_paving.TactilePavingCrosswal
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
 import de.westnordost.streetcomplete.ui.common.quest.QuestForm
+import de.westnordost.streetcomplete.util.ktx.firstAndLast
 import org.jetbrains.compose.resources.stringResource
 
-class AddTactilePavingCrosswalk : OsmElementQuestType<TactilePavingCrosswalkAnswer> {
+class AddTactilePavingCrosswalk :
+    OsmElementQuestType<TactilePavingCrosswalkAnswer>,
+    AppliesAnswerToNearbyElements<TactilePavingCrosswalkAnswer> {
 
     private val crossingFilter by lazy { """
         nodes with
@@ -35,13 +42,6 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<TactilePavingCrosswalkAnsw
             or tactile_paving ~ no|partial|incorrect and tactile_paving older today -8 years
             or tactile_paving = yes and tactile_paving older today -12 years
           )
-    """.toElementFilterExpression() }
-
-    private val excludedWaysFilter by lazy { """
-        ways with
-          highway = cycleway and foot !~ yes|designated
-          or highway = service and service = driveway
-          or highway and access ~ private|no
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether crosswalks have tactile paving"
@@ -62,7 +62,7 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<TactilePavingCrosswalkAnsw
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         val excludedWayNodeIds = mapData.ways
-            .filter { excludedWaysFilter.matches(it) }
+            .filter { tactilePavingCrosswalkExcludedWaysFilter.matches(it) }
             .flatMapTo(HashSet()) { it.nodeIds }
 
         return mapData.nodes
@@ -71,6 +71,33 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<TactilePavingCrosswalkAnsw
 
     override fun isApplicableTo(element: Element): Boolean? =
         if (!crossingFilter.matches(element)) false else null
+
+    /* A "yes" for the whole crosswalk also answers the question for its end kerbs. */
+    override fun applyAnswerToNearbyElements(
+        answer: TactilePavingCrosswalkAnswer,
+        element: Element,
+        mapData: MapDataWithGeometry
+    ): List<Pair<Element, StringMapChanges>> {
+        // "no" only means that tactile paving is not present on both ends
+        if (answer != YES) return emptyList()
+
+        val crosswalkEndNodeIds = mapData.ways.asSequence()
+            .filter { way -> way.tags["footway"] == "crossing" && element.id in way.nodeIds }
+            .flatMapTo(HashSet()) { it.nodeIds.firstAndLast() }
+        if (crosswalkEndNodeIds.isEmpty()) return emptyList()
+
+        return mapData.findAllKerbNodes()
+            .filter { it.id in crosswalkEndNodeIds }
+            .mapNotNull { kerb ->
+                val tags = StringMapChangesBuilder(kerb.tags)
+                tags.updateWithCheckDate("tactile_paving", "yes")
+                if (tags["kerb"] != "no") {
+                    tags["barrier"] = "kerb"
+                }
+                val changes = tags.create()
+                if (changes.isEmpty()) null else kerb to changes
+            }
+    }
 
     @Composable
     override fun Form(on: (QuestAction<TactilePavingCrosswalkAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerb.kt
@@ -1,7 +1,6 @@
 package de.westnordost.streetcomplete.quests.tactile_paving
 
 import androidx.compose.runtime.Composable
-import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
@@ -19,14 +18,6 @@ import de.westnordost.streetcomplete.ui.common.quest.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
-
-    private val eligibleKerbsFilter by lazy { """
-        nodes with
-          !tactile_paving
-          or tactile_paving = unknown
-          or tactile_paving = no and tactile_paving older today -8 years
-          or tactile_paving = yes and tactile_paving older today -12 years
-    """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether kerbs have tactile paving"
     override val wikiLink = "Key:tactile_paving"
@@ -46,11 +37,20 @@ class AddTactilePavingKerb : OsmElementQuestType<Boolean> {
         YesNoQuestForm(on)
     }
 
-    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
-        mapData.findAllKerbNodes().filter { eligibleKerbsFilter.matches(it) }
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
+        // The crossing quest covers both ends unless its value is no, partial, or incorrect.
+        val coveredByCrossingNode = mapData.findCrosswalkEndNodeIdsCoveredByCrossingNode()
+        return mapData.findAllKerbNodes().filter {
+            it.id !in coveredByCrossingNode && kerbsWithUnknownTactilePavingFilter.matches(it)
+        }
+    }
+
+    /* Editing a crossing may make its individual kerb quests applicable. */
+    override fun mayAffectNearbyQuests(element: Element): Boolean =
+        tactilePavingCrossingsFilter.matches(element)
 
     override fun isApplicableTo(element: Element): Boolean? =
-        if (!eligibleKerbsFilter.matches(element) || element !is Node || !element.couldBeAKerb()) {
+        if (!kerbsWithUnknownTactilePavingFilter.matches(element) || element !is Node || !element.couldBeAKerb()) {
             false
         } else {
             null

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/TactilePavingCrosswalkKerbs.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/TactilePavingCrosswalkKerbs.kt
@@ -1,0 +1,62 @@
+package de.westnordost.streetcomplete.quests.tactile_paving
+
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.osm.mapdata.MapData
+import de.westnordost.streetcomplete.util.ktx.firstAndLast
+
+/* The crossing quest covers both end kerbs. Individual kerb quests are only needed when the
+ * crossing is tagged no, partial, or incorrect. */
+
+/** Kerb nodes whose tactile paving situation is unknown or stale. */
+internal val kerbsWithUnknownTactilePavingFilter by lazy { """
+    nodes with
+      !tactile_paving
+      or tactile_paving = unknown
+      or tactile_paving = no and tactile_paving older today -8 years
+      or tactile_paving = yes and tactile_paving older today -12 years
+""".toElementFilterExpression() }
+
+/** Nodes representing pedestrian crossings. */
+internal val tactilePavingCrossingsFilter by lazy { """
+    nodes with
+      highway = traffic_signals and crossing = traffic_signals and foot != no
+      or highway = crossing and foot != no
+""".toElementFilterExpression() }
+
+/** Crossing nodes that cover the tactile-paving question for their end kerbs. */
+private val tactilePavingCrossingsCoveringKerbsFilter by lazy { """
+    nodes with
+      (
+        highway = traffic_signals and crossing = traffic_signals and foot != no
+        or highway = crossing and foot != no
+      )
+      and (
+        !tactile_paving
+        or tactile_paving !~ no|partial|incorrect
+        or tactile_paving older today -8 years
+      )
+""".toElementFilterExpression() }
+
+/** Ways on whose crossing nodes the crosswalk quest is not asked. */
+internal val tactilePavingCrosswalkExcludedWaysFilter by lazy { """
+    ways with
+      highway = cycleway and foot !~ yes|designated
+      or highway = service and service = driveway
+      or highway and access ~ private|no
+""".toElementFilterExpression() }
+
+/** Returns crosswalk end nodes covered by a crossing-node tactile-paving question. */
+internal fun MapData.findCrosswalkEndNodeIdsCoveredByCrossingNode(): Set<Long> {
+    val excludedWayNodeIds = ways
+        .filter { tactilePavingCrosswalkExcludedWaysFilter.matches(it) }
+        .flatMapTo(HashSet()) { it.nodeIds }
+
+    val crossingNodeIds = nodes
+        .filter { tactilePavingCrossingsCoveringKerbsFilter.matches(it) && it.id !in excludedWayNodeIds }
+        .mapTo(HashSet()) { it.id }
+    if (crossingNodeIds.isEmpty()) return emptySet()
+
+    return ways.asSequence()
+        .filter { way -> way.tags["footway"] == "crossing" && way.nodeIds.any { it in crossingNodeIds } }
+        .flatMapTo(HashSet()) { it.nodeIds.firstAndLast() }
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/quest/OsmQuestFormContainer.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/quest/OsmQuestFormContainer.kt
@@ -15,11 +15,13 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.data.meta.CountryInfos
 import de.westnordost.streetcomplete.data.meta.get
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditAction
+import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.edits.delete.DeletePoiNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementsTagsAction
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
@@ -28,6 +30,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.Action
 import de.westnordost.streetcomplete.data.osm.osmquests.Answer
+import de.westnordost.streetcomplete.data.osm.osmquests.AppliesAnswerToNearbyElements
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.osm.places.applyReplacePlaceTo
@@ -56,6 +59,7 @@ import de.westnordost.streetcomplete.ui.util.ReplaceBottomSheetTransitionSpec
 import de.westnordost.streetcomplete.ui.util.rememberSerializable
 import de.westnordost.streetcomplete.util.countryboundaries.CountryBoundaries
 import de.westnordost.streetcomplete.util.ktx.geometryType
+import de.westnordost.streetcomplete.util.math.enlargedBy
 import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -91,6 +95,7 @@ fun <T> OsmQuestFormContainer(
     countryBoundaries: CountryBoundaries = koinInject(),
     featureDictionary: FeatureDictionary = koinInject(),
     countryInfos: CountryInfos = koinInject(),
+    mapDataSource: MapDataWithEditsSource = koinInject(),
 ) {
     val center = geometry.center
     val countryInfo = remember(center) { countryInfos.get(countryBoundaries, center) }
@@ -106,6 +111,20 @@ fun <T> OsmQuestFormContainer(
     // markers shown are per-form
     LaunchedEffect(state) { onSetMapMarkers(emptyList()) }
 
+    /** Tag updates on other, nearby elements that are implied by the given [answer], if the quest
+     *  type is one whose answer applies to nearby elements, too */
+    fun createNearbyElementsActions(answer: T): List<UpdateElementTagsAction> {
+        if (questType !is AppliesAnswerToNearbyElements<*>) return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val quest = questType as AppliesAnswerToNearbyElements<T>
+        val mapData = mapDataSource.getMapDataWithGeometry(
+            geometry.bounds.enlargedBy(quest.nearbyElementsRadius)
+        )
+        return quest.applyAnswerToNearbyElements(answer, element, mapData)
+            .filter { (_, changes) -> !changes.isEmpty() }
+            .map { (otherElement, changes) -> UpdateElementTagsAction(otherElement, changes) }
+    }
+
     fun onAction(action: QuestAction<T>) {
         when (action) {
             Action.Dismiss -> onDismiss()
@@ -119,8 +138,13 @@ fun <T> OsmQuestFormContainer(
             is Answer<T> -> {
                 val changesBuilder = StringMapChangesBuilder(element.tags)
                 questType.applyAnswerTo(action.value, changesBuilder, geometry, element.timestampEdited)
-                val changes = changesBuilder.create()
-                onEdit(UpdateElementTagsAction(element, changes))
+                val elementAction = UpdateElementTagsAction(element, changesBuilder.create())
+                val nearbyElementsActions = createNearbyElementsActions(action.value)
+                if (nearbyElementsActions.isEmpty()) {
+                    onEdit(elementAction)
+                } else {
+                    onEdit(UpdateElementsTagsAction(listOf(elementAction) + nearbyElementsActions))
+                }
             }
         }
     }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditDescription.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditDescription.kt
@@ -30,6 +30,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryCh
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementsTagsAction
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestHidden
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEdit
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestHidden
@@ -58,6 +59,8 @@ fun EditDescription(
             when (edit.action) {
                 is UpdateElementTagsAction ->
                     TagUpdatesList(edit.action.changes.changes, modifier)
+                is UpdateElementsTagsAction ->
+                    TagUpdatesList(edit.action.actions.flatMap { it.changes.changes }.distinct(), modifier)
                 is DeletePoiNodeAction ->
                     Text(stringResource(Res.string.deleted_poi_action_description), modifier)
                 is SplitWayAction ->

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
@@ -29,6 +29,7 @@ import de.westnordost.streetcomplete.data.osm.edits.delete.DeletePoiNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.move.MoveNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.split_way.SplitWayAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementsTagsAction
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.QuestType
@@ -105,6 +106,10 @@ fun ShowQuestFormsScreen(
                         }
                         is UpdateElementTagsAction -> {
                             val tagging = action.changes.changes.joinToString("\n")
+                            message = "Tagging\n$tagging"
+                        }
+                        is UpdateElementsTagsAction -> {
+                            val tagging = action.actions.flatMap { it.changes.changes }.joinToString("\n")
                             message = "Tagging\n$tagging"
                         }
                     }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
@@ -17,6 +17,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementsTagsAction
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
@@ -53,6 +54,14 @@ class ElementEditsDaoTest : StreetCompleteDatabaseTestCase() {
 
     @Test fun addGet_UpdateElementTagsEdit() {
         val edit = updateTags()
+        dao.put(edit)
+        assertNotNull(edit.id)
+        val dbEdit = dao.get(edit.id)
+        assertEquals(edit, dbEdit)
+    }
+
+    @Test fun addGet_UpdateElementsTagsEdit() {
+        val edit = updateTagsOfSeveralElements()
         dao.put(edit)
         assertNotNull(edit.id)
         val dbEdit = dao.get(edit.id)
@@ -249,6 +258,20 @@ private fun updateTags(
             StringMapEntryDelete("f", "g"),
         ))
     ),
+    false
+)
+
+private fun updateTagsOfSeveralElements(timestamp: Long = 123L, isSynced: Boolean = false) = ElementEdit(
+    0,
+    TEST_QUEST_TYPE,
+    geom,
+    "survey",
+    timestamp,
+    isSynced,
+    UpdateElementsTagsAction(listOf(
+        UpdateElementTagsAction(node, StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+        UpdateElementTagsAction(Node(2, p), StringMapChanges(listOf(StringMapEntryAdd("c", "d")))),
+    )),
     false
 )
 

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementsTagsActionTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/edits/update_tags/UpdateElementsTagsActionTest.kt
@@ -1,0 +1,90 @@
+package de.westnordost.streetcomplete.data.osm.edits.update_tags
+
+import de.westnordost.streetcomplete.data.ConflictException
+import de.westnordost.streetcomplete.data.osm.edits.ElementIdProvider
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType.*
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataRepository
+import de.westnordost.streetcomplete.testutils.node
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UpdateElementsTagsActionTest {
+
+    private lateinit var repos: MapDataRepository
+    private val provider = ElementIdProvider(emptyList())
+
+    @BeforeTest fun setUp() {
+        repos = mock()
+    }
+
+    @Test fun `apply changes to all elements`() {
+        val n1 = node(1)
+        val n2 = node(2)
+        every { repos.get(NODE, 1) } returns n1
+        every { repos.get(NODE, 2) } returns n2
+
+        val data = UpdateElementsTagsAction(listOf(
+            UpdateElementTagsAction(n1, StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+            UpdateElementTagsAction(n2, StringMapChanges(listOf(StringMapEntryAdd("c", "d")))),
+        )).createUpdates(repos, provider)
+
+        assertEquals(
+            listOf(mapOf("a" to "b"), mapOf("c" to "d")),
+            data.modifications.map { it.tags }
+        )
+    }
+
+    @Test fun `conflict if changes to any element are not applicable`() {
+        val n1 = node(1)
+        val n2 = node(2, tags = mapOf("c" to "x"))
+        every { repos.get(NODE, 1) } returns n1
+        every { repos.get(NODE, 2) } returns n2
+
+        assertFailsWith<ConflictException> {
+            UpdateElementsTagsAction(listOf(
+                UpdateElementTagsAction(n1, StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+                UpdateElementTagsAction(n2, StringMapChanges(listOf(StringMapEntryAdd("c", "d")))),
+            )).createUpdates(repos, provider)
+        }
+    }
+
+    @Test fun elementKeys() {
+        assertEquals(
+            listOf(ElementKey(NODE, 1), ElementKey(NODE, 2)),
+            UpdateElementsTagsAction(listOf(
+                UpdateElementTagsAction(node(1), StringMapChanges(listOf(StringMapEntryAdd("a", "b")))),
+                UpdateElementTagsAction(node(2), StringMapChanges(listOf(StringMapEntryAdd("c", "d")))),
+            )).elementKeys
+        )
+    }
+
+    @Test fun idsUpdatesApplied() {
+        val n = node(id = -1)
+        val changes = StringMapChanges(listOf(StringMapEntryAdd("a", "b")))
+        val idUpdates = mapOf(ElementKey(NODE, -1) to 5L)
+
+        assertEquals(
+            UpdateElementsTagsAction(listOf(UpdateElementTagsAction(n.copy(id = 5), changes))),
+            UpdateElementsTagsAction(listOf(UpdateElementTagsAction(n, changes))).idsUpdatesApplied(idUpdates)
+        )
+    }
+
+    @Test fun createReverted() {
+        val action1 = UpdateElementTagsAction(node(1), StringMapChanges(listOf(StringMapEntryAdd("a", "b"))))
+        val action2 = UpdateElementTagsAction(node(2), StringMapChanges(listOf(StringMapEntryAdd("c", "d"))))
+
+        assertEquals(
+            RevertUpdateElementsTagsAction(listOf(
+                action1.createReverted(provider),
+                action2.createReverted(provider),
+            )),
+            UpdateElementsTagsAction(listOf(action1, action2)).createReverted(provider)
+        )
+    }
+}

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
@@ -72,7 +72,8 @@ class OsmQuestControllerTest {
             1 to NotApplicableQuestType,
             2 to ComplexQuestTypeApplicableToNode42,
             3 to ApplicableQuestTypeNotInAnyCountry,
-            4 to ApplicableQuestType2
+            4 to ApplicableQuestType2,
+            5 to QuestTypeAffectedByCrossingNodes
         ))
         countryBoundaries = object : CountryBoundaries {
             override fun isInAny(position: LatLon, countries: Countries): Boolean =
@@ -220,6 +221,53 @@ class OsmQuestControllerTest {
         }
     }
 
+    @Test fun `updates quests for nearby elements when an updated element may affect them`() {
+        val crossingGeom = pGeom(0.0, 0.0)
+        val crossing = node(1, tags = mapOf("highway" to "crossing"))
+        val updatedMapData = MutableMapDataWithGeometry(
+            listOf(crossing),
+            listOf(ElementGeometryEntry(NODE, 1, crossingGeom))
+        )
+
+        // map data around the crossing contains node 5, to which QuestTypeAffectedByCrossingNodes
+        // is applicable
+        val nearbyGeom = pGeom(0.0001, 0.0001)
+        val nearbyMapData = MutableMapDataWithGeometry(
+            listOf(crossing, node(5, p(0.0001, 0.0001))),
+            listOf(
+                ElementGeometryEntry(NODE, 1, crossingGeom),
+                ElementGeometryEntry(NODE, 5, nearbyGeom),
+            )
+        )
+
+        // a quest of that type exists for node 6, to which it is not applicable anymore
+        val existingNearbyQuest = osmQuest(QuestTypeAffectedByCrossingNodes, NODE, 6)
+
+        every { db.getAllForElements(listOf(ElementKey(NODE, 1))) } returns emptyList()
+        every { db.getAllForElements(emptyList()) } returns emptyList()
+        every { db.getAllInBBox(any(), any()) } returns listOf(existingNearbyQuest)
+        every { mapDataSource.getMapDataWithGeometry(any()) } returns nearbyMapData
+        every { notesSource.getAllPositions(any()) } returns emptyList()
+
+        mapDataListener.onUpdated(updatedMapData, emptyList())
+
+        val expectedCreatedQuests = listOf(
+            OsmQuest(ApplicableQuestType, NODE, 1, crossingGeom),
+            OsmQuest(ApplicableQuestType2, NODE, 1, crossingGeom),
+            OsmQuest(QuestTypeAffectedByCrossingNodes, NODE, 5, nearbyGeom),
+        )
+        val expectedDeletedQuestKeys = listOf(existingNearbyQuest.key)
+
+        verify { db.deleteAll(matches { it.containsExactlyInAnyOrder(expectedDeletedQuestKeys) }) }
+        verify { db.putAll(matches { it.containsExactlyInAnyOrder(expectedCreatedQuests) }) }
+        verify {
+            listener.onUpdated(
+                added = matches { it.containsExactlyInAnyOrder(expectedCreatedQuests) },
+                deleted = matches { it.containsExactlyInAnyOrder(expectedDeletedQuestKeys) }
+            )
+        }
+    }
+
     @Test fun `updates quests on map data listener replace for bbox`() {
         val elements = listOf(
             node(1),
@@ -299,4 +347,9 @@ private object NotApplicableQuestType : TestQuestTypeA() {
 private object ComplexQuestTypeApplicableToNode42 : TestQuestTypeA() {
     override fun isApplicableTo(element: Element): Boolean? = null
     override fun getApplicableElements(mapData: MapDataWithGeometry) = listOf(node(42))
+}
+
+private object QuestTypeAffectedByCrossingNodes : TestQuestTypeA() {
+    override fun isApplicableTo(element: Element) = element.id == 5L
+    override fun mayAffectNearbyQuests(element: Element) = element.tags["highway"] == "crossing"
 }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalkTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalkTest.kt
@@ -1,11 +1,14 @@
 package de.westnordost.streetcomplete.quests.tactile_paving
 
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.testutils.TestMapDataWithGeometry
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.testutils.way
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class AddTactilePavingCrosswalkTest {
     private val questType = AddTactilePavingCrosswalk()
@@ -33,5 +36,60 @@ class AddTactilePavingCrosswalkTest {
         val mapData = TestMapDataWithGeometry(listOf(crossing, privateRoad))
         assertEquals(0, questType.getApplicableElements(mapData).toList().size)
         assertNull(questType.isApplicableTo(crossing))
+    }
+
+    private val crossingNode = node(2, tags = mapOf("highway" to "crossing"))
+    private val kerb1 = node(1, tags = mapOf("barrier" to "kerb"))
+    private val kerb3 = node(3, tags = mapOf("barrier" to "kerb"))
+    private val crosswalk = way(1, nodes = listOf(1, 2, 3), tags = mapOf(
+        "highway" to "footway",
+        "footway" to "crossing"
+    ))
+
+    @Test fun `answering yes also applies tactile paving to the kerbs at both ends`() {
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk))
+
+        val nearbyChanges = questType.applyAnswerToNearbyElements(
+            TactilePavingCrosswalkAnswer.YES, crossingNode, mapData
+        )
+
+        assertEquals(setOf(1L, 3L), nearbyChanges.map { it.first.id }.toSet())
+        for ((_, changes) in nearbyChanges) {
+            assertTrue(StringMapEntryAdd("tactile_paving", "yes") in changes.changes)
+        }
+    }
+
+    @Test fun `answering no does not change the kerbs`() {
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk))
+
+        assertEquals(
+            emptyList(),
+            questType.applyAnswerToNearbyElements(TactilePavingCrosswalkAnswer.NO, crossingNode, mapData)
+        )
+    }
+
+    @Test fun `answering yes overrides a kerb tagged no`() {
+        val answeredKerb = node(1, tags = mapOf("barrier" to "kerb", "tactile_paving" to "no"))
+        val mapData = TestMapDataWithGeometry(listOf(answeredKerb, crossingNode, kerb3, crosswalk))
+
+        val nearbyChanges = questType.applyAnswerToNearbyElements(
+            TactilePavingCrosswalkAnswer.YES, crossingNode, mapData
+        )
+
+        assertEquals(setOf(1L, 3L), nearbyChanges.map { it.first.id }.toSet())
+        val answeredKerbChanges = nearbyChanges.single { it.first.id == 1L }.second
+        assertTrue(
+            StringMapEntryModify("tactile_paving", "no", "yes") in answeredKerbChanges.changes
+        )
+    }
+
+    @Test fun `answering yes changes nothing when the crosswalk is not mapped as a way`() {
+        val road = way(1, nodes = listOf(4, 2, 5), tags = mapOf("highway" to "residential"))
+        val mapData = TestMapDataWithGeometry(listOf(crossingNode, road))
+
+        assertEquals(
+            emptyList(),
+            questType.applyAnswerToNearbyElements(TactilePavingCrosswalkAnswer.YES, crossingNode, mapData)
+        )
     }
 }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerbTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingKerbTest.kt
@@ -1,0 +1,77 @@
+package de.westnordost.streetcomplete.quests.tactile_paving
+
+import de.westnordost.streetcomplete.testutils.TestMapDataWithGeometry
+import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.way
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AddTactilePavingKerbTest {
+    private val questType = AddTactilePavingKerb()
+
+    private val kerb1 = node(1, tags = mapOf("barrier" to "kerb"))
+    private val kerb3 = node(3, tags = mapOf("barrier" to "kerb"))
+    private val crosswalk = way(1, nodes = listOf(1, 2, 3), tags = mapOf(
+        "highway" to "footway",
+        "footway" to "crossing"
+    ))
+
+    @Test fun `applicable to kerbs of crosswalk without a crossing node`() {
+        val middleNode = node(2)
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, middleNode, kerb3, crosswalk))
+        assertEquals(
+            setOf(1L, 3L),
+            questType.getApplicableElements(mapData).map { it.id }.toSet()
+        )
+        assertNull(questType.isApplicableTo(kerb1))
+    }
+
+    @Test fun `not applicable to kerbs of crosswalk with a crossing node`() {
+        val crossingNode = node(2, tags = mapOf("highway" to "crossing"))
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk))
+        assertEquals(0, questType.getApplicableElements(mapData).count())
+    }
+
+    @Test fun `not applicable to kerbs of crosswalk whose crossing node has tactile paving on both ends`() {
+        val crossingNode = node(2, tags = mapOf(
+            "highway" to "crossing",
+            "tactile_paving" to "yes"
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk))
+        assertEquals(0, questType.getApplicableElements(mapData).count())
+    }
+
+    @Test fun `applicable to kerbs of crosswalk whose crossing node does not have tactile paving on both ends`() {
+        val crossingNode = node(2, tags = mapOf(
+            "highway" to "crossing",
+            "tactile_paving" to "no"
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk))
+        assertEquals(
+            setOf(1L, 3L),
+            questType.getApplicableElements(mapData).map { it.id }.toSet()
+        )
+    }
+
+    @Test fun `editing a crossing node may affect nearby quests`() {
+        assertTrue(questType.mayAffectNearbyQuests(node(tags = mapOf("highway" to "crossing"))))
+        assertFalse(questType.mayAffectNearbyQuests(node(tags = mapOf("barrier" to "kerb"))))
+        assertFalse(questType.mayAffectNearbyQuests(node()))
+    }
+
+    @Test fun `applicable to kerbs of crosswalk whose crossing node is on an excluded way`() {
+        val crossingNode = node(2, tags = mapOf("highway" to "crossing"))
+        val driveway = way(2, nodes = listOf(4, 2, 5), tags = mapOf(
+            "highway" to "service",
+            "service" to "driveway"
+        ))
+        val mapData = TestMapDataWithGeometry(listOf(kerb1, crossingNode, kerb3, crosswalk, driveway))
+        assertEquals(
+            setOf(1L, 3L),
+            questType.getApplicableElements(mapData).map { it.id }.toSet()
+        )
+    }
+}


### PR DESCRIPTION
Context: https://github.com/streetcomplete/StreetComplete/issues/3407#issuecomment-946865467 I hope that this can be considered anyway 🙏 

While editing with StreetComplete, I wished that I could answer `Does this crosswalk have tactile paving on both ends?` in the affirmative and have it put `tactile_paving=yes` on not just the `highway=crossing` but also on both `highway=kerb` connected by `footway=crossing`.

With this PR, there is only one such tactile paving quest visible, which is the one on the crossing node. If you answer "yes (both)", it tags all three as yes. If you answer "no (not both)", the quests on each kerb will appear and you can answer those individually.

Undo works properly. I have loaded this as an .apk onto my phone to make sure it does it right. Unit tests added too.