### PR TITLE
fix android host test config

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Run unit tests with Gradle
-        run: ./gradlew test
+        run: ./gradlew :app:testAndroidHostTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -264,9 +264,9 @@ kotlin {
                 implementation("androidx.sqlite:sqlite-bundled:2.7.0")
             }
         }
-        androidUnitTest {
+        getByName("androidHostTest") {
             dependencies {
-                // without it, :app:testDebugUnitTest throws java.lang.NoClassDefFoundError at BundledSQLiteDriver.jvmAndAndroid.kt
+                // without it, :app:testAndroidHostTest throws java.lang.UnsatisfiedLinkError for sqliteJni
                 implementation("androidx.sqlite:sqlite-bundled-jvm:2.7.0")
             }
         }


### PR DESCRIPTION
## Summary

[PR #6202](https://github.com/streetcomplete/StreetComplete/pull/6202) introduced the SQLite JVM test dependency under `androidUnitTest`, which was the correct source set at the time.

The later [AGP 9 migration commit](https://github.com/streetcomplete/StreetComplete/commit/12c4f0116c4db8857a19bab046987ca0d688acd6) brought `withHostTest` and `testAndroidHostTest`, but left the SQLite dependency attached to `androidUnitTest`, which no longer exists. CI also continued calling the aggregate `test` task, which now only reached the `androidApp` test task with `NO-SOURCE`.

The [Android-KMP migration guide](https://developer.android.com/kotlin/multiplatform/plugin#configure-tests) documents that `androidUnitTest` becomes `androidHostTest` when host testing is enabled with `withHostTest`. The [Kotlin Android-KMP migration documentation](https://kotlinlang.org/docs/multiplatform/multiplatform-publish-lib-setup.html#publish-an-android-library) likewise maps the former `testDebugUnitTest` and `testReleaseUnitTest` tasks to `testAndroidHostTest`.

## Testing

- `./gradlew :app:testAndroidHostTest` — 2,449 tests, 0 failures, 1 skipped
- `./gradlew assembleDebug -Papp.streetcomplete.debug=true`
