### PR TITLE
Remove ineffective offline tile count limit

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -78,7 +78,6 @@ open class MapFragment : Fragment() {
         mapView.onCreate(savedInstanceState)
         mapView.foreground = view.context.getDrawable(R.color.background)
 
-        initOfflineCacheSize()
         cleanOldOfflineRegions()
 
         viewLifecycleScope.launch {
@@ -86,11 +85,6 @@ open class MapFragment : Fragment() {
             this@MapFragment.map = map
             initMap(map)
         }
-    }
-
-    private fun initOfflineCacheSize() {
-        // set really high tile count limit
-        OfflineManager.getInstance(requireContext()).setOfflineMapboxTileCountLimit(10000) // very roughly 1000 km²
     }
 
     private fun cleanOldOfflineRegions() {


### PR DESCRIPTION
I ran into this while evaluating gaps uncovered in #7068. I hadn't yet exposed this API, and when I went to go look it up, I realized it's a no-op in maplibre-native for modern styles. It seems to be there for the mapbox-era commercial tile providers that billed for offline tile caching.

AI-generated citations below:

> MapLibre applies this limit only to tile resources with a canonical provider URL. This condition was present in [the MapLibre version used when the call was added](https://github.com/maplibre/maplibre-native/blob/1ba9a475f48e806448054843e9b143d1a077bbfa/platform/default/src/mbgl/storage/offline_database.cpp#L1423-L1426) and remains in [MapLibre Android 13.3.1](https://github.com/maplibre/maplibre-native/blob/ea5dc44ee4e753252d0929e9ad731716b7524e55/platform/default/src/mln/storage/offline_database.cpp#L1454-L1456). StreetComplete uses a [direct Jawg HTTPS tile URL](https://github.com/streetcomplete/StreetComplete/blob/c778f48b1613d5641d10bcb93d6363b7809589a5/app/src/androidMain/assets/map_theme/streetcomplete.json#L5-L9), so the tile-count check does not run for its offline downloads.
> 
> The original implementation had already observed that a limit of 10 did not invoke the callback. The [development discussion](https://github.com/Helium314/SCEE/pull/516#issuecomment-2040345707) proposed setting a high value to avoid unexpected failures, and [the resulting commit](https://github.com/streetcomplete/StreetComplete/commit/debb53bcf6d161d9f6f9c6ab8c7a875921be5bba) used 10,000. The missing callback was a consequence of the URL predicate, not the chosen limit.
> 
> Removing the call does not change StreetComplete cache eviction or offline-region retention.