### PR TITLE
Also use "do you have to pay to **stay** here?" for caravan sites

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -62,7 +62,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
                 if (element.tags["amenity"] != null || element.tags["waterway"] != null) {
                     // Things you must pay to "use"
                     Res.string.quest_generalFee_title
-                } else if (element.tags["tourism"] == "wilderness_hut" || element.tags["tourism"] == "camp_site" || element.tags["tourism"] == "camp_site") {
+                } else if (element.tags["tourism"] == "wilderness_hut" || element.tags["tourism"] == "camp_site" || element.tags["tourism"] == "caravan_site") {
                     // Places you must pay to "stay at"
                     Res.string.quest_generalFee_title3
                 } else {


### PR DESCRIPTION
I *think* this is what was meant instead of the duplicate `tourism=camp_site` check in 11503b623b1fc49b28ab2ee2364466025a04fa89 (#7003).