### PR TITLE
Standardize quest filter syntax

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/kerb/KerbUtil.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/kerb/KerbUtil.kt
@@ -12,7 +12,8 @@ import de.westnordost.streetcomplete.util.ktx.allExceptFirstAndLast
 import de.westnordost.streetcomplete.util.ktx.firstAndLast
 
 private val footwaysFilter by lazy { """
-    ways with (
+    ways with
+      (
         highway ~ footway|path
         or highway = cycleway and foot ~ yes|designated
       )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/address/AddressOverlayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/address/AddressOverlayForm.kt
@@ -325,10 +325,11 @@ private fun isAddressTag(key: String, value: String): Boolean =
     key == "noaddress" ||
     key == "nohousenumber"
 
-private val roadsWithNamesFilter by lazy {
-    "ways with highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")} and name"
-        .toElementFilterExpression()
-}
+private val roadsWithNamesFilter by lazy { """
+    ways with
+      highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+      and name
+""".toElementFilterExpression() }
 
 private val allBuildingsFilter by lazy {
     "ways, relations with building".toElementFilterExpression()

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
@@ -41,9 +41,9 @@ class SidewalkOverlay : Overlay {
         // footways etc, just to highlight e.g. separately mapped sidewalks. However, it is also
         // possible to add sidewalks to them. At least in NL, cycleways with sidewalks actually exist
         mapData.filter("""
-            ways with (
+            ways with
               highway ~ footway|steps|path|bridleway|cycleway
-            ) and area != yes
+              and area != yes
         """).map { it to getFootwayStyle(it).copy(disabled = true) }
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/LaneNarrowingTrafficCalmingOverlayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/LaneNarrowingTrafficCalmingOverlayForm.kt
@@ -153,7 +153,9 @@ fun LaneNarrowingTrafficCalmingForm(
 }
 
 private val allRoadsFilter by lazy { """
-        ways with highway ~ ${ALL_ROADS.joinToString("|")} and area != yes
+        ways with
+          highway ~ ${ALL_ROADS.joinToString("|")}
+          and area != yes
     """.toElementFilterExpression()
 }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -42,7 +42,8 @@ class StreetParkingOverlay : Overlay {
         """).map { it to getStreetParkingStyle(it) } +
         // separate parking
         mapData.filter("""
-            nodes, ways, relations with amenity = parking
+            nodes, ways, relations with
+              amenity = parking
         """).map {
             val style =
                 if (it is Node) parkingLotPointStyle.copy(disabled = true)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -36,7 +36,8 @@ class StreetParkingOverlay : Overlay {
     override fun getStyledElements(mapData: MapDataWithGeometry): Sequence<Pair<Element, OverlayStyle>> =
         // roads
         mapData.filter("""
-            ways with highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
+            ways with
+            highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
             and area != yes
         """).map { it to getStreetParkingStyle(it) } +
         // separate parking

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -37,8 +37,8 @@ class StreetParkingOverlay : Overlay {
         // roads
         mapData.filter("""
             ways with
-            highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
-            and area != yes
+              highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
+              and area != yes
         """).map { it to getStreetParkingStyle(it) } +
         // separate parking
         mapData.filter("""
@@ -52,8 +52,8 @@ class StreetParkingOverlay : Overlay {
         // chokers
         mapData.filter("""
             nodes with
-            traffic_calming ~ "(choker|chicane|island|choked_.*)"
-            or crossing:island = yes
+              traffic_calming ~ "(choker|chicane|island|choked_.*)"
+              or crossing:island = yes
         """).mapNotNull {
             val style = getNarrowingTrafficCalmingStyle(it)
             if (style != null) it to style else null

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -41,8 +41,7 @@ class StreetParkingOverlay : Overlay {
         """).map { it to getStreetParkingStyle(it) } +
         // separate parking
         mapData.filter("""
-            nodes, ways, relations with
-            amenity = parking
+            nodes, ways, relations with amenity = parking
         """).map {
             val style =
                 if (it is Node) parkingLotPointStyle.copy(disabled = true)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/surface/SurfaceOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/surface/SurfaceOverlay.kt
@@ -40,7 +40,8 @@ class SurfaceOverlay : Overlay {
 
     override fun getStyledElements(mapData: MapDataWithGeometry) =
         mapData.filter("""
-            ways, relations with highway ~ ${(ALL_PATHS + ALL_ROADS).joinToString("|")}
+            ways, relations with
+              highway ~ ${(ALL_PATHS + ALL_ROADS).joinToString("|")}
         """).map { it to getStyle(it) }
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/surface/SurfaceOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/surface/SurfaceOverlay.kt
@@ -40,8 +40,7 @@ class SurfaceOverlay : Overlay {
 
     override fun getStyledElements(mapData: MapDataWithGeometry) =
         mapData.filter("""
-            ways, relations with
-                highway ~ ${(ALL_PATHS + ALL_ROADS).joinToString("|")}
+            ways, relations with highway ~ ${(ALL_PATHS + ALL_ROADS).joinToString("|")}
         """).map { it to getStyle(it) }
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/way_lit/WayLitOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/way_lit/WayLitOverlay.kt
@@ -29,9 +29,10 @@ class WayLitOverlay : Overlay {
     override val hidesQuestTypes = setOf(AddWayLit::class.simpleName!!)
 
     override fun getStyledElements(mapData: MapDataWithGeometry) =
-        mapData
-            .filter("ways, relations with highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}")
-            .map { it to getStyle(it) }
+        mapData.filter("""
+            ways, relations with
+              highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+        """).map { it to getStyle(it) }
 
     @Composable
     override fun Form(

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -19,7 +19,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
 
     override val elementFilter = """
-        nodes, ways with (
+        nodes, ways with
+        (
           amenity ~ restaurant|cafe|fast_food|ice_cream|pub|bar|luggage_locker
           or (shop and shop !~ no|vacant|mall)
           or tourism = alpine_hut

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -20,17 +20,17 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|ice_cream|pub|bar|luggage_locker
-          or (shop and shop !~ no|vacant|mall)
-          or tourism = alpine_hut
-        )
-        and !payment:credit_cards and !payment:debit_cards and payment:others != no
-        and !brand and !wikipedia:brand and !wikidata:brand
-        and (!seasonal or seasonal = no)
-        and (!fee or fee != no)
-        and (name or noname = yes or name:signed = no)
-        and access !~ private|no
+          (
+            amenity ~ restaurant|cafe|fast_food|ice_cream|pub|bar|luggage_locker
+            or (shop and shop !~ no|vacant|mall)
+            or tourism = alpine_hut
+          )
+          and !payment:credit_cards and !payment:debit_cards and payment:others != no
+          and !brand and !wikipedia:brand and !wikidata:brand
+          and (!seasonal or seasonal = no)
+          and (!fee or fee != no)
+          and (name or noname = yes or name:signed = no)
+          and access !~ private|no
     """
     override val changesetComment = "Survey whether payment with cards is accepted"
     override val wikiLink = "Key:payment"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -19,31 +19,31 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          (shop and shop !~ no|vacant|mall)
-          or amenity ~ ${arrayOf(
-            "bar", "cafe", "fast_food", "ice_cream", "pub", "biergarten", "restaurant", "fuel",
-            "cinema", "nightclub", "planetarium", "theatre", "internet_cafe", "car_wash",
-            "pharmacy", "telephone", "vending_machine", "luggage_locker"
-          ).joinToString("|")}
-          or leisure ~ ${arrayOf(
-            "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game",
-            "miniature_golf","sauna", "trampoline_park", "tanning_salon"
-          ).joinToString("|")}
-          or craft ~ ${arrayOf(
-            "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
-            "electronics_repair", "key_cutter", "stonemason"
-          ).joinToString("|")}
-          or tourism ~ ${arrayOf(
-            "theme_park", "hotel", "hostel", "motel", "guest_house",
-            "apartment", "camp_site"
-          ).joinToString("|")}
-          or tourism ~ ${arrayOf(
-            "attraction", "museum", "gallery", "zoo", "aquarium"
-          ).joinToString("|")} and fee = yes
-        )
-        and !payment:cash and !payment:coins and !payment:notes and payment:others != no
-        and (name or brand or noname = yes or name:signed = no)
+          (
+            (shop and shop !~ no|vacant|mall)
+            or amenity ~ ${arrayOf(
+              "bar", "cafe", "fast_food", "ice_cream", "pub", "biergarten", "restaurant", "fuel",
+              "cinema", "nightclub", "planetarium", "theatre", "internet_cafe", "car_wash",
+              "pharmacy", "telephone", "vending_machine", "luggage_locker"
+            ).joinToString("|")}
+            or leisure ~ ${arrayOf(
+              "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game",
+              "miniature_golf","sauna", "trampoline_park", "tanning_salon"
+            ).joinToString("|")}
+            or craft ~ ${arrayOf(
+              "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
+              "electronics_repair", "key_cutter", "stonemason"
+            ).joinToString("|")}
+            or tourism ~ ${arrayOf(
+              "theme_park", "hotel", "hostel", "motel", "guest_house",
+              "apartment", "camp_site"
+            ).joinToString("|")}
+            or tourism ~ ${arrayOf(
+              "attraction", "museum", "gallery", "zoo", "aquarium"
+            ).joinToString("|")} and fee = yes
+          )
+          and !payment:cash and !payment:coins and !payment:notes and payment:others != no
+          and (name or brand or noname = yes or name:signed = no)
     """
 
     override val changesetComment = "Survey whether payment with cash is accepted"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/access_point_ref/AddAccessPointRef.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/access_point_ref/AddAccessPointRef.kt
@@ -14,11 +14,11 @@ class AddAccessPointRef : OsmFilterQuestType<AccessPointRefAnswer>() {
 
     override val elementFilter = """
         nodes with
-        (
-          highway = emergency_access_point
-          or emergency = access_point
-        )
-        and !name and !ref and noref != yes and ref:signed != no and !~"ref:.*"
+          (
+            highway = emergency_access_point
+            or emergency = access_point
+          )
+          and !name and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
     override val changesetComment = "Determine emergency access point refs"
     override val wikiLink = "Key:ref"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -40,7 +40,8 @@ class AddAddressStreet : OsmElementQuestType<StreetOrPlaceName> {
 
     // #2112 - exclude indirect addr:street
     private val excludedWaysFilter by lazy { """
-        ways with addr:street and addr:interpolation
+        ways with
+          addr:street and addr:interpolation
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify street/place names to addresses"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -40,8 +40,7 @@ class AddAddressStreet : OsmElementQuestType<StreetOrPlaceName> {
 
     // #2112 - exclude indirect addr:street
     private val excludedWaysFilter by lazy { """
-        ways with
-          addr:street and addr:interpolation
+        ways with addr:street and addr:interpolation
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify street/place names to addresses"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreet.kt
@@ -78,8 +78,8 @@ class AddAddressStreet : OsmElementQuestType<StreetOrPlaceName> {
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
             nodes, ways, relations with
-            (addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber)
-            and !name and !brand and !operator and !ref
+              (addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber)
+              and !name and !brand and !operator and !ref
         """)
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
@@ -91,7 +91,8 @@ fun AddAddressStreetForm(
  *  he answered it in this session */
 private var lastWasPlaceName = false
 
-private val roadsWithNamesFilter by lazy {
-    "ways with highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")} and name"
-        .toElementFilterExpression()
-}
+private val roadsWithNamesFilter by lazy { """
+    ways with
+      highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+      and name
+""".toElementFilterExpression() }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -152,8 +152,8 @@ class AddHousenumber(
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
             nodes, ways, relations with
-            (addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber)
-            and !name and !brand and !operator and !ref
+              (addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber)
+              and !name and !brand and !operator and !ref
         """.toElementFilterExpression())
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -191,7 +191,8 @@ private val nonMultipolygonRelationsWithAddressFilter by lazy { """
 """.toElementFilterExpression() }
 
 private val nodesWithAddressFilter by lazy { """
-    nodes with addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber
+    nodes with
+      addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber
 """.toElementFilterExpression() }
 
 private val buildingsWithMissingAddressFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -191,8 +191,7 @@ private val nonMultipolygonRelationsWithAddressFilter by lazy { """
 """.toElementFilterExpression() }
 
 private val nodesWithAddressFilter by lazy { """
-   nodes with
-     addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber
+    nodes with addr:housenumber or addr:housename or addr:conscriptionnumber or addr:streetnumber
 """.toElementFilterExpression() }
 
 private val buildingsWithMissingAddressFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/aerialway/AddAerialwayBicycleAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/aerialway/AddAerialwayBicycleAccess.kt
@@ -58,7 +58,5 @@ class AddAerialwayBicycleAccess : OsmFilterQuestType<AerialwayBicycleAccessAnswe
     }
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("""
-            nodes, ways with aerialway
-        """.toElementFilterExpression())
+        mapData.filter("nodes, ways with aerialway".toElementFilterExpression())
     }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
@@ -18,16 +18,16 @@ class AddAirConditioning : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar|library|community_centre|youth_centre|ranger_station
-          or tourism ~ apartment|hotel
-          or tourism = information and information ~ office|visitor_center
-          or aeroway = terminal
-          or shop ~ mall|department_store
-        )
-        and indoor_seating != no
-        and takeaway != only
-        and !air_conditioning
+          (
+            amenity ~ restaurant|cafe|fast_food|ice_cream|food_court|pub|bar|library|community_centre|youth_centre|ranger_station
+            or tourism ~ apartment|hotel
+            or tourism = information and information ~ office|visitor_center
+            or aeroway = terminal
+            or shop ~ mall|department_store
+          )
+          and indoor_seating != no
+          and takeaway != only
+          and !air_conditioning
     """
     override val changesetComment = "Survey availability of air conditioning"
     override val wikiLink = "Key:air_conditioning"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/air_pump/AddAirCompressor.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/air_pump/AddAirCompressor.kt
@@ -20,11 +20,11 @@ class AddAirCompressor : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        amenity = fuel
-        and (
+          amenity = fuel
+          and (
             !compressed_air
             or compressed_air older today -6 years
-        )
+          )
     """
 
     override val changesetComment = "Survey availability of air compressors"
@@ -36,8 +36,8 @@ class AddAirCompressor : OsmFilterQuestType<Boolean>() {
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
             nodes, ways with
-            compressed_air = yes
-            or amenity ~ compressed_air|fuel
+              compressed_air = yes
+              or amenity ~ compressed_air|fuel
         """)
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/amenity_indoor/AddIsAmenityIndoor.kt
@@ -46,13 +46,15 @@ class AddIsAmenityIndoor(
      * for verifiability). For these, the question shall always be asked, even when not within a
      * building outline. */
     private val nodesOnWalls by lazy { """
-        nodes with emergency ~ defibrillator|fire_extinguisher|fire_hose
+        nodes with
+          emergency ~ defibrillator|fire_extinguisher|fire_hose
     """.toElementFilterExpression() }
 
     /* We only want survey nodes within building outlines.
      * Roofs do not count as inside a building */
     private val buildingFilter by lazy { """
-        ways, relations with building and building != roof
+        ways, relations with
+          building and building != roof
     """.toElementFilterExpression() }
 
     override val changesetComment = "Determine whether amenities are inside buildings"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/artwork/AddArtworkType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/artwork/AddArtworkType.kt
@@ -18,7 +18,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddArtworkType : OsmFilterQuestType<ArtworkType>() {
 
-    override val elementFilter = "nodes, ways with tourism = artwork and !artwork_type"
+    override val elementFilter = """
+        nodes, ways with
+          tourism = artwork and !artwork_type
+    """
     override val changesetComment = "Survey artwork type"
     override val wikiLink = "Key:artwork_type"
     override val icon = Res.drawable.quest_artwork

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashIn.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/atm_cashin/AddAtmCashIn.kt
@@ -16,7 +16,10 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddAtmCashIn : OsmFilterQuestType<Boolean>() {
 
-    override val elementFilter = "nodes with amenity = atm and !cash_in"
+    override val elementFilter = """
+        nodes with
+          amenity = atm and !cash_in
+    """
     override val changesetComment = "Determine whether ATM allows depositing cash"
     override val wikiLink = "Key:cash_in"
     override val icon = Res.drawable.quest_money

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/atm_operator/AddAtmOperator.kt
@@ -15,7 +15,11 @@ import de.westnordost.streetcomplete.ui.common.quest.NameWithSuggestionsQuestFor
 
 class AddAtmOperator : OsmFilterQuestType<String>() {
 
-    override val elementFilter = "nodes with amenity = atm and !operator and !name and !brand"
+    override val elementFilter = """
+        nodes with
+          amenity = atm
+          and !operator and !name and !brand
+    """
     override val changesetComment = "Specify ATM operator"
     override val wikiLink = "Tag:amenity=atm"
     override val icon = Res.drawable.quest_money

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/baby_changing_table/AddBabyChangingTable.kt
@@ -19,16 +19,16 @@ class AddBabyChangingTable : OsmFilterQuestType<BabyChangingTableAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity = toilets
-          or (
-            amenity ~ restaurant|cafe|biergarten|food_court|fuel|library|community_centre
-            or amenity = fast_food and indoor_seating = yes
-            or shop ~ mall|department_store|baby_goods
-            or shop = bakery and indoor_seating = yes
-          ) and toilets != no
-        )
-        and !diaper and !changing_table
+          (
+            amenity = toilets
+            or (
+              amenity ~ restaurant|cafe|biergarten|food_court|fuel|library|community_centre
+              or amenity = fast_food and indoor_seating = yes
+              or shop ~ mall|department_store|baby_goods
+              or shop = bakery and indoor_seating = yes
+            ) and toilets != no
+          )
+          and !diaper and !changing_table
     """
     override val changesetComment = "Survey availability of baby changing tables"
     override val wikiLink = "Key:changing_table"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_installation/AddBicycleBarrierInstallation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_installation/AddBicycleBarrierInstallation.kt
@@ -23,10 +23,10 @@ class AddBicycleBarrierInstallation : OsmFilterQuestType<BicycleBarrierInstallat
 
     override val elementFilter = """
         nodes, ways with
-         barrier = cycle_barrier
-         and cycle_barrier
-         and cycle_barrier != tilted
-         and !cycle_barrier:installation
+          barrier = cycle_barrier
+          and cycle_barrier
+          and cycle_barrier != tilted
+          and !cycle_barrier:installation
     """
     override val changesetComment = "Specify cycle barrier installation"
     override val wikiLink = "Key:cycle_barrier:installation"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_installation/AddBicycleBarrierInstallation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_installation/AddBicycleBarrierInstallation.kt
@@ -22,7 +22,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddBicycleBarrierInstallation : OsmFilterQuestType<BicycleBarrierInstallationAnswer>() {
 
     override val elementFilter = """
-        nodes, ways with barrier = cycle_barrier
+        nodes, ways with
+         barrier = cycle_barrier
          and cycle_barrier
          and cycle_barrier != tilted
          and !cycle_barrier:installation

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_bicycle_barrier_type/AddBicycleBarrierType.kt
@@ -20,7 +20,11 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddBicycleBarrierType : OsmFilterQuestType<BicycleBarrierTypeAnswer>() {
 
-    override val elementFilter = "nodes with barrier = cycle_barrier and !cycle_barrier"
+    override val elementFilter = """
+        nodes with
+          barrier = cycle_barrier
+          and !cycle_barrier
+    """
     override val changesetComment = "Specify cycle barrier types"
     override val wikiLink = "Key:cycle_barrier"
     override val icon = Res.drawable.quest_no_bicycles

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_opening/AddBarrierOpening.kt
@@ -25,21 +25,21 @@ class AddBarrierOpening(
 
     private val nodeFilter by lazy { """
         nodes with
-            (
-                barrier ~ gate|entrance|sliding_gate|swing_gate|wicket_gate|bollard|block
-                or barrier = cycle_barrier and cycle_barrier ~ single|diagonal
-            )
-            and (!maxwidth:physical or source:maxwidth_physical ~ ".*estimat.*")
-            and (!width or source:width ~ ".*estimat.*")
-            and (!maxwidth or source:maxwidth ~ ".*estimat.*")
-            and access !~ private|no|customers|agricultural
+          (
+            barrier ~ gate|entrance|sliding_gate|swing_gate|wicket_gate|bollard|block
+            or barrier = cycle_barrier and cycle_barrier ~ single|diagonal
+          )
+          and (!maxwidth:physical or source:maxwidth_physical ~ ".*estimat.*")
+          and (!width or source:width ~ ".*estimat.*")
+          and (!maxwidth or source:maxwidth ~ ".*estimat.*")
+          and access !~ private|no|customers|agricultural
     """.toElementFilterExpression() }
 
     private val waysFilter by lazy { """
         ways with
-            highway ~ ${ALL_PATHS.joinToString("|")}
-            and area != yes
-            and (access !~ private|no or (foot and foot !~ private|no))
+          highway ~ ${ALL_PATHS.joinToString("|")}
+          and area != yes
+          and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify width of opening"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -23,21 +23,21 @@ class AddBarrierType : OsmFilterQuestType<BarrierType>() {
 
     override val elementFilter = """
         nodes with
-         barrier = yes
-         and !man_made
-         and !historic
-         and !military
-         and !power
-         and !tourism
-         and !attraction
-         and !amenity
-         and !leisure
-         and !aeroway
-         and !railway
-         and !craft
-         and !healthcare
-         and !office
-         and !shop
+          barrier = yes
+          and !man_made
+          and !historic
+          and !military
+          and !power
+          and !tourism
+          and !attraction
+          and !amenity
+          and !leisure
+          and !aeroway
+          and !railway
+          and !craft
+          and !healthcare
+          and !office
+          and !shop
     """
     override val changesetComment = "Specify type of barriers"
     override val wikiLink = "Key:barrier"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddBarrierType.kt
@@ -22,7 +22,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddBarrierType : OsmFilterQuestType<BarrierType>() {
 
     override val elementFilter = """
-        nodes with barrier = yes
+        nodes with
+         barrier = yes
          and !man_made
          and !historic
          and !military

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/barrier_type/AddStileType.kt
@@ -23,8 +23,8 @@ class AddStileType : OsmElementQuestType<StileType> {
 
     private val stileNodeFilter by lazy { """
         nodes with
-         barrier = stile
-         and (!stile or older today -8 years)
+          barrier = stile
+          and (!stile or older today -8 years)
     """.toElementFilterExpression() }
 
     private val excludedWaysFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -18,8 +18,8 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
     override val elementFilter = """
         nodes, ways with
           (
-              (amenity = bbq and !fuel)
-              or (amenity = baking_oven and (!oven or oven = yes))
+            (amenity = bbq and !fuel)
+            or (amenity = baking_oven and (!oven or oven = yes))
           )
           and access !~ no|private
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bbq_fuel/AddBbqFuel.kt
@@ -18,15 +18,8 @@ class AddBbqFuel : OsmFilterQuestType<BbqFuelAnswer>() {
     override val elementFilter = """
         nodes, ways with
           (
-              (
-                  amenity = bbq
-                  and !fuel
-              )
-              or
-              (
-                  amenity = baking_oven
-                  and (!oven or oven = yes)
-              )
+              (amenity = bbq and !fuel)
+              or (amenity = baking_oven and (!oven or oven = yes))
           )
           and access !~ no|private
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bench_backrest/AddBenchBackrest.kt
@@ -36,7 +36,11 @@ class AddBenchBackrest : OsmFilterQuestType<BenchBackrestAnswer>() {
     override val achievements = listOf(PEDESTRIAN, OUTDOORS)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways with amenity = bench or leisure = picnic_table")
+        mapData.filter("""
+            nodes, ways with
+              amenity = bench
+              or leisure = picnic_table
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<BenchBackrestAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
@@ -24,8 +24,7 @@ class AddBicycleRepairStationServices : OsmFilterQuestType<Set<BicycleRepairStat
     override val elementFilter = """
         nodes, ways with
         amenity = bicycle_repair_station
-        and
-        (
+        and (
           !service:bicycle:pump
           or !service:bicycle:stand
           or !service:bicycle:tools

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
@@ -56,7 +56,8 @@ class AddBicycleRepairStationServices : OsmFilterQuestType<Set<BicycleRepairStat
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-            nodes, ways with amenity ~ bicycle_repair_station|compressed_air
+            nodes, ways with
+              amenity ~ bicycle_repair_station|compressed_air
         """)
 
     override fun applyAnswerTo(answer: Set<BicycleRepairStationService>, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
@@ -23,15 +23,15 @@ class AddBicycleRepairStationServices : OsmFilterQuestType<Set<BicycleRepairStat
 
     override val elementFilter = """
         nodes, ways with
-        amenity = bicycle_repair_station
-        and (
-          !service:bicycle:pump
-          or !service:bicycle:stand
-          or !service:bicycle:tools
-          or !service:bicycle:chain_tool
-          or older today -2 years
-        )
-        and access !~ private|no
+          amenity = bicycle_repair_station
+          and (
+            !service:bicycle:pump
+            or !service:bicycle:stand
+            or !service:bicycle:tools
+            or !service:bicycle:chain_tool
+            or older today -2 years
+          )
+          and access !~ private|no
     """
 
     override val changesetComment = "Specify features of bicycle repair stations"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bicycle_repair_station/AddBicycleRepairStationServices.kt
@@ -56,8 +56,7 @@ class AddBicycleRepairStationServices : OsmFilterQuestType<Set<BicycleRepairStat
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-            nodes, ways with
-            amenity ~ bicycle_repair_station|compressed_air
+            nodes, ways with amenity ~ bicycle_repair_station|compressed_air
         """)
 
     override fun applyAnswerTo(answer: Set<BicycleRepairStationService>, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -19,16 +19,16 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
 
     override val elementFilter = """
         nodes, ways with
-         amenity = bicycle_parking
-         and access !~ private|no
-         and bicycle_parking !~ floor|informal
-         and (
-           !capacity
-           or (
-             bicycle_parking ~ stands|wall_loops|safe_loops|handlebar_holder
-             and capacity older today -8 years
-           )
-         )
+          amenity = bicycle_parking
+          and access !~ private|no
+          and bicycle_parking !~ floor|informal
+          and (
+            !capacity
+            or (
+              bicycle_parking ~ stands|wall_loops|safe_loops|handlebar_holder
+              and capacity older today -8 years
+            )
+          )
     """
     /* Bike capacity may change more often for stands and wheelbenders as adding or
        removing a few of them is minor work

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -18,13 +18,13 @@ class AddBikeParkingCover : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
+          (
             amenity = bicycle_parking
             or amenity = charging_station and bicycle ~ yes|designated and !lockable and motorcar=no
-        )
-        and access !~ private|no
-        and !covered
-        and bicycle_parking !~ shed|lockers|building
+          )
+          and access !~ private|no
+          and !covered
+          and bicycle_parking !~ shed|lockers|building
     """
     override val changesetComment = "Specify bicycle parkings covers"
     override val wikiLink = "Tag:amenity=bicycle_parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_rental_capacity/AddBikeRentalCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_rental_capacity/AddBikeRentalCapacity.kt
@@ -19,10 +19,10 @@ class AddBikeRentalCapacity : OsmFilterQuestType<Int>() {
 
     override val elementFilter = """
         nodes, ways with
-         amenity = bicycle_rental
-         and access !~ private|no
-         and bicycle_rental = docking_station
-         and (!capacity or capacity older today -6 years)
+          amenity = bicycle_rental
+          and access !~ private|no
+          and bicycle_rental = docking_station
+          and (!capacity or capacity older today -6 years)
     """
 
     override val changesetComment = "Specify bicycle rental capacities"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBicyclePump.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBicyclePump.kt
@@ -19,12 +19,12 @@ class AddBicyclePump : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        shop = bicycle
-        and !compressed_air
-        and (
+          shop = bicycle
+          and !compressed_air
+          and (
             !service:bicycle:pump
             or service:bicycle:pump older today -6 years
-        )
+          )
     """
     override val changesetComment = "Survey whether shop offers public pump"
     override val wikiLink = "Key:service:bicycle:pump"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
@@ -18,7 +18,8 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddBikeRepairAvailability : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with shop = bicycle
+        nodes, ways with
+        shop = bicycle
         and (
             !service:bicycle:repair
             or service:bicycle:repair older today -6 years

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
@@ -19,12 +19,12 @@ class AddBikeRepairAvailability : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        shop = bicycle
-        and (
+          shop = bicycle
+          and (
             !service:bicycle:repair
             or service:bicycle:repair older today -6 years
-        )
-        and access !~ private|no
+          )
+          and access !~ private|no
     """
 
     override val changesetComment = "Specify whether bicycle shops offer repairs"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
@@ -19,17 +19,17 @@ import org.jetbrains.compose.resources.stringResource
 class AddSecondHandBicycleAvailability : OsmFilterQuestType<SecondHandBicycleAvailability>() {
     override val elementFilter = """
         nodes, ways with
-        shop = bicycle
-        and (
+          shop = bicycle
+          and (
             !service:bicycle:second_hand
             or service:bicycle:second_hand older today -6 years
-        )
-        and (
+          )
+          and (
             service:bicycle:retail != no
             or service:bicycle:retail older today -6 years
-        )
-        and !second_hand
-        and access !~ private|no
+          )
+          and !second_hand
+          and access !~ private|no
         """
 
     override val changesetComment = "Survey whether bicycle shop sells second-hand bicycles"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
@@ -18,7 +18,8 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddSecondHandBicycleAvailability : OsmFilterQuestType<SecondHandBicycleAvailability>() {
     override val elementFilter = """
-        nodes, ways with shop = bicycle
+        nodes, ways with
+        shop = bicycle
         and (
             !service:bicycle:second_hand
             or service:bicycle:second_hand older today -6 years

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
@@ -21,12 +21,10 @@ class AddBoardName : OsmFilterQuestType<List<LocalizedName>>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
           tourism = information and information = board
           and board_type !~ notice|public_transport
           and !board:title
-        )
-        and !name and noname != yes and name:signed != no
+          and !name and noname != yes and name:signed != no
     """
 
     override val changesetComment = "Determine information board names"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_name/AddBoardName.kt
@@ -34,7 +34,10 @@ class AddBoardName : OsmFilterQuestType<List<LocalizedName>>() {
     override val achievements = listOf(OUTDOORS)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways, relations with tourism = information and information = board")
+        mapData.filter("""
+            nodes, ways, relations with
+              tourism = information and information = board
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<List<LocalizedName>>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -18,10 +18,10 @@ class AddBoardType : OsmFilterQuestType<BoardTypeAnswer>() {
 
     override val elementFilter = """
         nodes with
-         tourism = information
-         and information = board
-         and access !~ private|no
-         and (!board_type or board_type ~ yes|board)
+          tourism = information
+          and information = board
+          and access !~ private|no
+          and (!board_type or board_type ~ yes|board)
     """
     override val changesetComment = "Specify board types"
     override val wikiLink = "Key:board_type"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -30,7 +30,10 @@ class AddBoardType : OsmFilterQuestType<BoardTypeAnswer>() {
     override val achievements = listOf(RARE, CITIZEN, OUTDOORS)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes with tourism = information and information = board")
+        mapData.filter("""
+            nodes with
+              tourism = information and information = board
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<BoardTypeAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/boat_rental/AddBoatRental.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/boat_rental/AddBoatRental.kt
@@ -19,11 +19,11 @@ class AddBoatRental : OsmFilterQuestType<Set<BoatRental>>() {
 
     override val elementFilter = """
         nodes, ways with
-        amenity = boat_rental
-        and (
-          ${BoatRental.entries.joinToString(" and ") { "!${it.osmValue}" }}
-          or ${DEPRECATED_RENTALS.joinToString(" or ")}
-        )
+          amenity = boat_rental
+          and (
+            ${BoatRental.entries.joinToString(" and ") { "!${it.osmValue}" }}
+            or ${DEPRECATED_RENTALS.joinToString(" or ")}
+          )
     """
     override val changesetComment = "Specify boats for rental"
     override val wikiLink = "Tag:amenity=boat_rental"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance/AddEntrance.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance/AddEntrance.kt
@@ -23,7 +23,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddEntrance : OsmElementQuestType<EntranceAnswer> {
 
     private val withoutEntranceFilter by lazy { """
-        nodes with !entrance and !barrier and noexit != yes and !railway
+        nodes with
+          !entrance and !barrier and noexit != yes and !railway
     """.toElementFilterExpression() }
 
     private val buildingFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReference.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance_reference/AddEntranceReference.kt
@@ -40,9 +40,11 @@ class AddEntranceReference : OsmElementQuestType<EntranceReferenceAnswer> {
           and !ref
     """.toElementFilterExpression() }
 
-    private val privateFootwaysFilter by lazy {
-        "ways with highway ~ footway|steps|pedestrian and access ~ private|no".toElementFilterExpression()
-    }
+    private val privateFootwaysFilter by lazy { """
+        ways with
+          highway ~ footway|steps|pedestrian
+          and access ~ private|no
+    """.toElementFilterExpression() }
 
     override val changesetComment = "Specify entrance identifications"
     override val wikiLink = "Key:ref"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -15,16 +15,16 @@ class AddBuildingLevels : OsmFilterQuestType<BuildingLevels>() {
 
     override val elementFilter = """
         ways, relations with
-           building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}
-           and (
-             !building:levels
-             or !roof:levels and !roof:height and roof:shape and roof:shape != flat
-           )
-           and !(height and roof:height)
-           and !building:min_level
-           and !man_made
-           and location != underground
-           and ruins != yes
+          building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}
+          and (
+            !building:levels
+            or !roof:levels and !roof:height and roof:shape and roof:shape != flat
+          )
+          and !(height and roof:height)
+          and !building:min_level
+          and !man_made
+          and location != underground
+          and ruins != yes
     """
     override val changesetComment = "Specify building and roof levels"
     override val wikiLink = "Key:building:levels"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -18,12 +18,12 @@ class AddBuildingType : OsmFilterQuestType<BuildingType>() {
 
     override val elementFilter = """
         ways, relations with
-        building ~ yes|${INVALID_BUILDING_TYPES.joinToString("|")}
-        and ${OTHER_KEYS_POTENTIALLY_DESCRIBING_BUILDING_TYPE.joinToString(" and ") { "!$it" }}
-        and location != underground
-        and disused != yes
-        and abandoned != yes
-        and ruins != yes
+          building ~ yes|${INVALID_BUILDING_TYPES.joinToString("|")}
+          and ${OTHER_KEYS_POTENTIALLY_DESCRIBING_BUILDING_TYPE.joinToString(" and ") { "!$it" }}
+          and location != underground
+          and disused != yes
+          and abandoned != yes
+          and ruins != yes
     """
     override val changesetComment = "Specify building types"
     override val wikiLink = "Key:building"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/building_underground/AddIsBuildingUnderground.kt
@@ -13,7 +13,10 @@ import de.westnordost.streetcomplete.ui.common.quest.YesNoQuestForm
 
 class AddIsBuildingUnderground : OsmFilterQuestType<Boolean>() {
 
-    override val elementFilter = "ways, relations with building and layer ~ -[0-9]+ and !location"
+    override val elementFilter = """
+        ways, relations with
+          building and layer ~ -[0-9]+ and !location
+    """
     override val changesetComment = "Determine whether buildings are fully underground"
     override val wikiLink = "Key:location"
     override val icon = Res.drawable.quest_building_underground

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_bench/AddBenchStatusOnBusStop.kt
@@ -17,14 +17,14 @@ class AddBenchStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform
-          or (highway = bus_stop and public_transport != stop_position)
-          or highway = hitchhiking
-        )
-        and physically_present != no and naptan:BusStopType != HAR
-        and access !~ no|private
-        and (!bench or bench older today -4 years)
+          (
+            public_transport = platform
+            or (highway = bus_stop and public_transport != stop_position)
+            or highway = hitchhiking
+          )
+          and physically_present != no and naptan:BusStopType != HAR
+          and access !~ no|private
+          and (!bench or bench older today -4 years)
     """
     override val changesetComment = "Specify whether public transport stops have benches"
     override val wikiLink = "Key:bench"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_bin/AddBinStatusOnBusStop.kt
@@ -17,14 +17,14 @@ class AddBinStatusOnBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform
-          or (highway = bus_stop and public_transport != stop_position)
-          or highway = hitchhiking
-        )
-        and physically_present != no and naptan:BusStopType != HAR
-        and access !~ no|private
-        and (!bin or bin older today -4 years)
+          (
+            public_transport = platform
+            or (highway = bus_stop and public_transport != stop_position)
+            or highway = hitchhiking
+          )
+          and physically_present != no and naptan:BusStopType != HAR
+          and access !~ no|private
+          and (!bin or bin older today -4 years)
     """
     override val changesetComment = "Specify whether public transport stops have bins"
     override val wikiLink = "Key:bin"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_lit/AddBusStopLit.kt
@@ -17,20 +17,20 @@ class AddBusStopLit : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform
-          or (highway = bus_stop and public_transport != stop_position)
-        )
-        and physically_present != no and naptan:BusStopType != HAR
-        and access !~ no|private
-        and location !~ underground|indoor
-        and indoor != yes
-        and (!level or level >= 0)
-        and (
-          !lit
-          or lit = no and lit older today -8 years
-          or lit older today -16 years
-        )
+          (
+            public_transport = platform
+            or (highway = bus_stop and public_transport != stop_position)
+          )
+          and physically_present != no and naptan:BusStopType != HAR
+          and access !~ no|private
+          and location !~ underground|indoor
+          and indoor != yes
+          and (!level or level >= 0)
+          and (
+            !lit
+            or lit = no and lit older today -8 years
+            or lit older today -16 years
+          )
     """
     override val changesetComment = "Add whether public transport stops are lit"
     override val wikiLink = "Key:lit"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopName.kt
@@ -18,13 +18,13 @@ class AddBusStopName : OsmFilterQuestType<List<LocalizedName>>() {
     // this filter needs to be kept somewhat in sync with the filter in AddBusStopNameForm https://github.com/streetcomplete/StreetComplete/issues/6390#issuecomment-3057235984
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform and bus = yes
-          or highway = bus_stop and public_transport != stop_position
-          or railway ~ halt|station|tram_stop
-        )
-        and access !~ no|private
-        and !name and noname != yes and name:signed != no
+          (
+            public_transport = platform and bus = yes
+            or highway = bus_stop and public_transport != stop_position
+            or railway ~ halt|station|tram_stop
+          )
+          and access !~ no|private
+          and !name and noname != yes and name:signed != no
     """
 
     override val enabledInCountries = AllCountriesExcept(

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopNameForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_name/AddBusStopNameForm.kt
@@ -54,11 +54,11 @@ fun AddBusStopNameForm(
 // this filter needs to be kept somewhat in sync with the filter in AddBusStopName
 private val busStopsWithNamesFilter by lazy { """
     nodes, ways, relations with
-    (
-      public_transport = platform and bus = yes
-      or highway = bus_stop and public_transport != stop_position
-      or railway ~ halt|station|tram_stop
-    )
-    and name
+      (
+        public_transport = platform and bus = yes
+        or highway = bus_stop and public_transport != stop_position
+        or railway ~ halt|station|tram_stop
+      )
+      and name
     """.toElementFilterExpression()
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -17,8 +17,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
         nodes with
         (
           (public_transport = platform and ~bus|trolleybus|tram ~ yes)
-          or
-          (highway = bus_stop and public_transport != stop_position)
+          or (highway = bus_stop and public_transport != stop_position)
         )
         and access !~ no|private
         and !ref and noref != yes and ref:signed != no and !~"ref:.*"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -15,12 +15,12 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>() {
 
     override val elementFilter = """
         nodes with
-        (
-          (public_transport = platform and ~bus|trolleybus|tram ~ yes)
-          or (highway = bus_stop and public_transport != stop_position)
-        )
-        and access !~ no|private
-        and !ref and noref != yes and ref:signed != no and !~"ref:.*"
+          (
+            (public_transport = platform and ~bus|trolleybus|tram ~ yes)
+            or (highway = bus_stop and public_transport != stop_position)
+          )
+          and access !~ no|private
+          and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
     override val enabledInCountries = NoCountriesExcept(
         "AU", // https://github.com/streetcomplete/StreetComplete/issues/4487

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_shelter/AddBusStopShelter.kt
@@ -22,19 +22,19 @@ class AddBusStopShelter : OsmFilterQuestType<BusStopShelterAnswer>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform
-          or (highway = bus_stop and public_transport != stop_position)
-          or highway = hitchhiking
-        )
-        and physically_present != no and naptan:BusStopType != HAR
-        and access !~ no|private
-        and !covered
-        and location !~ underground|indoor
-        and indoor != yes
-        and tunnel != yes
-        and (!level or level >= 0)
-        and (!shelter or shelter older today -4 years)
+          (
+            public_transport = platform
+            or (highway = bus_stop and public_transport != stop_position)
+            or highway = hitchhiking
+          )
+          and physically_present != no and naptan:BusStopType != HAR
+          and access !~ no|private
+          and !covered
+          and location !~ underground|indoor
+          and indoor != yes
+          and tunnel != yes
+          and (!level or level >= 0)
+          and (!shelter or shelter older today -4 years)
     """
     /* Not asking again if it is covered because it means the stop itself is under a large
        building or roof building so this won't usually change */

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -31,7 +31,10 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
     override val achievements = listOf(CITIZEN)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes with surveillance and surveillance:type = camera")
+        mapData.filter("""
+            nodes with
+              surveillance and surveillance:type = camera
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<CameraType>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/camera_type/AddCameraType.kt
@@ -20,9 +20,9 @@ class AddCameraType : OsmFilterQuestType<CameraType>() {
 
     override val elementFilter = """
         nodes with
-         surveillance:type = camera
-         and surveillance ~ public|outdoor|traffic
-         and !camera:type
+          surveillance:type = camera
+          and surveillance ~ public|outdoor|traffic
+          and !camera:type
     """
     override val changesetComment = "Specify camera types"
     override val wikiLink = "Tag:surveillance:type"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashType.kt
@@ -19,7 +19,11 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddCarWashType : OsmFilterQuestType<Set<CarWashType>>() {
 
-    override val elementFilter = "nodes, ways with amenity = car_wash and !automated and !self_service"
+    override val elementFilter = """
+        nodes, ways with
+          amenity = car_wash
+          and !automated and !self_service
+    """
     override val changesetComment = "Specify car wash types"
     override val wikiLink = "Tag:amenity=car_wash"
     override val icon = Res.drawable.quest_car_wash

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
@@ -33,10 +33,7 @@ class AddParkingCharge : OsmFilterQuestType<Charge>() {
     override val title = Res.string.quest_parking_charge_title
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("""
-            nodes, ways, relations with
-              amenity = parking
-        """.toElementFilterExpression())
+        mapData.filter("nodes, ways, relations with amenity = parking".toElementFilterExpression())
 
     @Composable
     override fun Form(on: (QuestAction<Charge>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
@@ -21,10 +21,10 @@ import de.westnordost.streetcomplete.resources.*
 class AddParkingCharge : OsmFilterQuestType<Charge>() {
     override val elementFilter = """
         nodes, ways, relations with amenity = parking
-        and access ~ yes|customers|public
-        and fee = yes
-        and !charge:conditional
-        and (!charge or charge older today -18 months)
+          and access ~ yes|customers|public
+          and fee = yes
+          and !charge:conditional
+          and (!charge or charge older today -18 months)
     """
     override val changesetComment = "Add parking charges"
     override val wikiLink = "Key:charge"
@@ -34,8 +34,8 @@ class AddParkingCharge : OsmFilterQuestType<Charge>() {
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-             nodes, ways, relations with amenity = parking
-         """.toElementFilterExpression())
+            nodes, ways, relations with amenity = parking
+        """.toElementFilterExpression())
 
     @Composable
     override fun Form(on: (QuestAction<Charge>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charge/AddParkingCharge.kt
@@ -34,7 +34,8 @@ class AddParkingCharge : OsmFilterQuestType<Charge>() {
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-            nodes, ways, relations with amenity = parking
+            nodes, ways, relations with
+              amenity = parking
         """.toElementFilterExpression())
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationBicycleCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationBicycleCapacity.kt
@@ -30,7 +30,11 @@ class AddChargingStationBicycleCapacity : OsmFilterQuestType<Int>() {
     override val achievements = listOf(BICYCLIST)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways with amenity = charging_station and bicycle ~ yes|designated")
+        mapData.filter("""
+            nodes, ways with
+              amenity = charging_station
+              and bicycle ~ yes|designated
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<Int>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -34,7 +34,11 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>() {
     override val achievements = listOf(CAR)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways with amenity = charging_station and motorcar != no")
+        mapData.filter("""
+            nodes, ways with
+              amenity = charging_station
+              and motorcar != no
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<Int>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -19,7 +19,8 @@ class AddClothingBinOperator : OsmElementQuestType<ClothingBinOperatorAnswer> {
        contain any recycling:* = yes that is not shoes or clothes but this can not be expressed
        in the elements filter syntax */
     private val filter by lazy { """
-        nodes with amenity = recycling and recycling_type = container
+        nodes with
+         amenity = recycling and recycling_type = container
          and recycling:clothes = yes
          and !operator and !name and !brand
          and operator:signed != no

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/clothing_bin_operator/AddClothingBinOperator.kt
@@ -20,11 +20,11 @@ class AddClothingBinOperator : OsmElementQuestType<ClothingBinOperatorAnswer> {
        in the elements filter syntax */
     private val filter by lazy { """
         nodes with
-         amenity = recycling and recycling_type = container
-         and recycling:clothes = yes
-         and !operator and !name and !brand
-         and operator:signed != no
-         and brand:signed != no
+          amenity = recycling and recycling_type = container
+          and recycling:clothes = yes
+          and !operator and !name and !brand
+          and operator:signed != no
+          and brand:signed != no
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify clothing bin operators"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -36,10 +36,9 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
           or highway and oneway and oneway != no
     """.toElementFilterExpression() }
 
-    private val excludedAdjacentWaysFilter by lazy { """
-        ways with
-          footway = traffic_island
-    """.toElementFilterExpression() }
+    private val excludedAdjacentWaysFilter by lazy {
+        "ways with footway = traffic_island".toElementFilterExpression()
+    }
 
     override val changesetComment = "Specify whether pedestrian crossings have islands"
     override val wikiLink = "Key:crossing:island"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -37,7 +37,8 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
     """.toElementFilterExpression() }
 
     private val excludedAdjacentWaysFilter by lazy { """
-        ways with footway = traffic_island
+        ways with
+          footway = traffic_island
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether pedestrian crossings have islands"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -84,7 +84,8 @@ class AddCycleway(
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-            ways with (
+            ways with
+              (
                 highway ~ cycleway|path
                 or highway ~ footway|bridleway and bicycle ~ yes|designated
               )
@@ -128,7 +129,8 @@ private val roadsFilter by lazy { """
 
 // streets that do not have cycleway tagging yet
 private val untaggedRoadsFilter by lazy { """
-    ways with (
+    ways with
+      (
         highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified
         or highway = residential and (maxspeed > 33 or $FILTER_IS_IMPLICIT_MAX_SPEED_BUT_NOT_SLOW_ZONE)
       )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
@@ -62,12 +62,12 @@ fun AddCyclewayForm(
 
     val likelyNoBicycleContraflow = remember { """
         ways with
-        oneway:bicycle != no
-        and (
+          oneway:bicycle != no
+          and (
             oneway ~ yes|-1 and highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified
             or dual_carriageway = yes
             or junction ~ roundabout|circular
-        )
+          )
     """.toElementFilterExpression()
     }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
@@ -61,7 +61,9 @@ fun AddCyclewayForm(
     }
 
     val likelyNoBicycleContraflow = remember { """
-        ways with oneway:bicycle != no and (
+        ways with
+        oneway:bicycle != no
+        and (
             oneway ~ yes|-1 and highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified
             or dual_carriageway = yes
             or junction ~ roundabout|circular

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/defibrillator/AddDefibrillatorLocation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/defibrillator/AddDefibrillatorLocation.kt
@@ -16,10 +16,10 @@ class AddDefibrillatorLocation : OsmFilterQuestType<String>() {
 
     override val elementFilter = """
         nodes with
-        emergency = defibrillator
-        and !location and !defibrillator:location
-        and !~location:.* and !~defibrillator:location:.*
-        and access !~ private|no"
+          emergency = defibrillator
+          and !location and !defibrillator:location
+          and !~location:.* and !~defibrillator:location:.*
+          and access !~ private|no"
     """
     override val changesetComment = "Specify defibrillator location"
     override val wikiLink = "Tag:emergency=defibrillator"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
@@ -21,7 +21,7 @@ class AddGlutenFree : OsmFilterQuestType<DietAvailabilityAnswer>() {
           amenity ~ restaurant|cafe|fast_food|food_court and food != no
           or amenity ~ pub|nightclub|biergarten|bar and food = yes
           or shop ~ supermarket|convenience|deli|bakery|pastry
-          or tourism ~ alpine_hut and food != no
+          or tourism = alpine_hut and food != no
         )
         and (
           !diet:gluten_free

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
@@ -17,16 +17,16 @@ class AddGlutenFree : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|food_court and food != no
-          or amenity ~ pub|nightclub|biergarten|bar and food = yes
-          or shop ~ supermarket|convenience|deli|bakery|pastry
-          or tourism = alpine_hut and food != no
-        )
-        and (
-          !diet:gluten_free
-          or diet:gluten_free != only and diet:gluten_free older today -4 years
-        )
+          (
+            amenity ~ restaurant|cafe|fast_food|food_court and food != no
+            or amenity ~ pub|nightclub|biergarten|bar and food = yes
+            or shop ~ supermarket|convenience|deli|bakery|pastry
+            or tourism = alpine_hut and food != no
+          )
+          and (
+            !diet:gluten_free
+            or diet:gluten_free != only and diet:gluten_free older today -4 years
+          )
     """
     override val changesetComment = "Specify whether places are gluten-free"
     override val wikiLink = "Key:diet:gluten_free"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
@@ -17,14 +17,14 @@ class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|ice_cream|food_court and food != no
-          or shop ~ butcher|supermarket|ice_cream|convenience
-        )
-        and (
-          !diet:halal
-          or diet:halal != only and diet:halal older today -4 years
-        )
+          (
+            amenity ~ restaurant|cafe|fast_food|ice_cream|food_court and food != no
+            or shop ~ butcher|supermarket|ice_cream|convenience
+          )
+          and (
+            !diet:halal
+            or diet:halal != only and diet:halal older today -4 years
+          )
     """
     override val changesetComment = "Specify whether places are halal"
     override val wikiLink = "Key:diet:halal"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -17,15 +17,15 @@ class AddKosher : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|ice_cream|food_court and food != no
-          or amenity ~ pub|nightclub|biergarten|bar and food = yes
-          or shop ~ butcher|supermarket|ice_cream|convenience
-        )
-        and (
-          !diet:kosher
-          or diet:kosher != only and diet:kosher older today -4 years
-        )
+          (
+            amenity ~ restaurant|cafe|fast_food|ice_cream|food_court and food != no
+            or amenity ~ pub|nightclub|biergarten|bar and food = yes
+            or shop ~ butcher|supermarket|ice_cream|convenience
+          )
+          and (
+            !diet:kosher
+            or diet:kosher != only and diet:kosher older today -4 years
+          )
     """
     override val changesetComment = "Specify whether places are kosher"
     override val wikiLink = "Key:diet:kosher"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -18,19 +18,19 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity = ice_cream
-          or shop = pastry
-          or diet:vegetarian ~ yes|only and (
-            amenity ~ restaurant|cafe|fast_food|food_court and food != no
-            or amenity ~ pub|nightclub|biergarten|bar and food = yes
-            or tourism = alpine_hut and food != no
+          (
+            amenity = ice_cream
+            or shop = pastry
+            or diet:vegetarian ~ yes|only and (
+              amenity ~ restaurant|cafe|fast_food|food_court and food != no
+              or amenity ~ pub|nightclub|biergarten|bar and food = yes
+              or tourism = alpine_hut and food != no
+            )
           )
-        )
-        and (
-          !diet:vegan
-          or diet:vegan != only and diet:vegan older today -4 years
-        )
+          and (
+            !diet:vegan
+            or diet:vegan != only and diet:vegan older today -4 years
+          )
     """
     override val changesetComment = "Survey whether places have vegan food"
     override val wikiLink = "Key:diet"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -25,7 +25,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
           (
             amenity ~ restaurant|cafe|fast_food|food_court and food != no
             or amenity ~ pub|nightclub|biergarten|bar and food = yes
-            or tourism ~ alpine_hut and food != no
+            or tourism = alpine_hut and food != no
           )
         )
         and (

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -21,8 +21,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
         (
           amenity = ice_cream
           or shop = pastry
-          or diet:vegetarian ~ yes|only and
-          (
+          or diet:vegetarian ~ yes|only and (
             amenity ~ restaurant|cafe|fast_food|food_court and food != no
             or amenity ~ pub|nightclub|biergarten|bar and food = yes
             or tourism = alpine_hut and food != no

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -18,15 +18,15 @@ class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ restaurant|cafe|fast_food|food_court and food != no
-          or amenity ~ pub|nightclub|biergarten|bar and food = yes
-          or tourism = alpine_hut and food != no
-        )
-        and diet:vegan != only and (
-          !diet:vegetarian
-          or diet:vegetarian != only and diet:vegetarian older today -4 years
-        )
+          (
+            amenity ~ restaurant|cafe|fast_food|food_court and food != no
+            or amenity ~ pub|nightclub|biergarten|bar and food = yes
+            or tourism = alpine_hut and food != no
+          )
+          and diet:vegan != only and (
+            !diet:vegetarian
+            or diet:vegetarian != only and diet:vegetarian older today -4 years
+          )
     """
     override val changesetComment = "Survey whether places have vegetarian food"
     override val wikiLink = "Key:diet"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -21,7 +21,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
         (
           amenity ~ restaurant|cafe|fast_food|food_court and food != no
           or amenity ~ pub|nightclub|biergarten|bar and food = yes
-          or tourism ~ alpine_hut and food != no
+          or tourism = alpine_hut and food != no
         )
         and diet:vegan != only and (
           !diet:vegetarian

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/doctor_type/AddDoctorType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/doctor_type/AddDoctorType.kt
@@ -19,10 +19,8 @@ class AddDoctorType() : OsmFilterQuestType<List<Feature>>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
           amenity = doctors or healthcare = doctor
           and !healthcare:speciality
-        )
     """
     override val changesetComment = "Survey healthcare specialties"
     override val wikiLink = "Key:healthcare:speciality"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/doctor_type/AddDoctorType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/doctor_type/AddDoctorType.kt
@@ -38,5 +38,8 @@ class AddDoctorType() : OsmFilterQuestType<List<Feature>>() {
     }
 
     override fun getHighlightedElements(element: Element,mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways with amenity=doctors or healthcare = doctor")
+        mapData.filter("""
+            nodes, ways with
+                amenity = doctors or healthcare = doctor
+        """)
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -19,21 +19,21 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          man_made ~ water_tap|water_well
-          or natural = spring
-          or amenity = fountain and fountain = stone_block
-        )
-        and access !~ private|no and indoor != yes
-        and !drinking_water
-        and !drinking_water:legal
-        and drinking_water:signed != no
-        and drinking_water:legal:signed != no
-        and amenity != drinking_water
-        and (!intermittent or intermittent = no)
-        and (!seasonal or seasonal = no)
-        and (!disused or disused = no)
-        and (!ruins or ruins = no)
+          (
+            man_made ~ water_tap|water_well
+            or natural = spring
+            or amenity = fountain and fountain = stone_block
+          )
+          and access !~ private|no and indoor != yes
+          and !drinking_water
+          and !drinking_water:legal
+          and drinking_water:signed != no
+          and drinking_water:legal:signed != no
+          and amenity != drinking_water
+          and (!intermittent or intermittent = no)
+          and (!seasonal or seasonal = no)
+          and (!disused or disused = no)
+          and (!ruins or ruins = no)
     """
     override val changesetComment = "Specify whether water is drinkable"
     override val wikiLink = "Key:drinking_water"
@@ -44,13 +44,13 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
             nodes with
-             (
-                 man_made = water_tap
-                 or man_made = water_well
-                 or natural = spring
-                 or amenity = drinking_water
-             )
-             and access !~ private|no
+              (
+                man_made = water_tap
+                or man_made = water_well
+                or natural = spring
+                or amenity = drinking_water
+              )
+              and access !~ private|no
         """)
 
     @Composable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -18,7 +18,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
     override val elementFilter = """
-        nodes, ways with (
+        nodes, ways with
+        (
           man_made ~ water_tap|water_well
           or natural = spring
           or amenity = fountain and fountain = stone_block

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water/AddDrinkingWater.kt
@@ -19,8 +19,7 @@ class AddDrinkingWater : OsmFilterQuestType<DrinkingWater>() {
 
     override val elementFilter = """
         nodes, ways with (
-          man_made = water_tap
-          or man_made = water_well
+          man_made ~ water_tap|water_well
           or natural = spring
           or amenity = fountain and fountain = stone_block
         )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterType.kt
@@ -19,13 +19,13 @@ class AddDrinkingWaterType : OsmFilterQuestType<DrinkingWaterType>() {
 
     override val elementFilter = """
         nodes with
-        (
+          (
             (amenity = drinking_water and !disused:amenity)
             or (disused:amenity = drinking_water and !amenity and older today -1 years)
-        )
-        and (!intermittent or intermittent = no)
-        and (!seasonal or seasonal = no)
-        and !man_made and !natural and !fountain and !pump
+          )
+          and (!intermittent or intermittent = no)
+          and (!seasonal or seasonal = no)
+          and !man_made and !natural and !fountain and !pump
     """
 
     override val changesetComment = "Specify drinking water types"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/drinking_water_type/AddDrinkingWaterType.kt
@@ -21,8 +21,7 @@ class AddDrinkingWaterType : OsmFilterQuestType<DrinkingWaterType>() {
         nodes with
         (
             (amenity = drinking_water and !disused:amenity)
-            or
-            (disused:amenity = drinking_water and !amenity and older today -1 years)
+            or (disused:amenity = drinking_water and !amenity and older today -1 years)
         )
         and (!intermittent or intermittent = no)
         and (!seasonal or seasonal = no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -27,7 +27,8 @@ class CheckExistence(
 ) : OsmElementQuestType<Unit> {
 
     private val nodesFilter by lazy { """
-        nodes with ((
+        nodes with
+        ((
           (
             amenity = atm
             or amenity = telephone

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -76,9 +76,7 @@ class CheckExistence(
           )
           and (${lastChecked(6.0)})
         ) or (
-          (
-            amenity ~ bicycle_parking|motorcycle_parking|taxi|shelter
-          )
+          amenity ~ bicycle_parking|motorcycle_parking|taxi|shelter
           and (${lastChecked(10.0)})
         ) or (
           (

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -28,72 +28,72 @@ class CheckExistence(
 
     private val nodesFilter by lazy { """
         nodes with
-        ((
-          (
-            amenity = atm
-            or amenity = telephone
-            or amenity = vending_machine and vending !~ fuel|parking_tickets|public_transport_tickets
-            or amenity = parcel_locker
-            or amenity = public_bookcase
-            or amenity = give_box
-            or barrier = log
-          )
-          and (${lastChecked(2.0)})
-        ) or (
-          (
-            amenity = clock
-            or amenity = post_box
-            or leisure = picnic_table
-            or amenity = bbq
-            or amenity = car_sharing
-            or leisure = firepit
-            or (leisure = pitch and sport ~ table_tennis|chess|table_soccer|teqball)
-            or leisure = fitness_station
-            or amenity = grit_bin and seasonal = no
-            or amenity = vending_machine and vending ~ parking_tickets|public_transport_tickets
-            or amenity = ticket_validator
-            or amenity = bicycle_repair_station
-            or tourism = information and information ~ board|terminal|map
-            or advertising ~ column|board|poster_box
-            or (highway = emergency_access_point or emergency = access_point) and ref
-            or emergency ~ life_ring|phone
-            or emergency = defibrillator and (indoor = no or access = yes)
-            or (
-              man_made = surveillance
-              and surveillance:type = camera
-              and surveillance ~ outdoor|public
-              and !highway
+          ((
+            (
+              amenity = atm
+              or amenity = telephone
+              or amenity = vending_machine and vending !~ fuel|parking_tickets|public_transport_tickets
+              or amenity = parcel_locker
+              or amenity = public_bookcase
+              or amenity = give_box
+              or barrier = log
             )
-          )
-          and (${lastChecked(4.0)})
-        ) or (
-          (
-            amenity = bench
-            or amenity = lounger
-            or amenity = waste_basket
-            or amenity = recycling and recycling_type = container
-            or amenity = toilets
-            or amenity = shower
-            or amenity = drinking_water
-            or man_made = planter
-          )
-          and (${lastChecked(6.0)})
-        ) or (
-          amenity ~ bicycle_parking|motorcycle_parking|taxi|shelter
-          and (${lastChecked(10.0)})
-        ) or (
-          (
-            traffic_calming ~ bump|mini_bumps|hump|cushion|rumble_strip|dip|double_dip
-            or traffic_calming = table and !highway and !crossing
-          )
-          and (${lastChecked(14.0)})
-        ))
-        and access !~ no|private
-        and (!seasonal or seasonal = no)
-        and (!intermittent or intermittent = no)
-        and (!permanent or permanent != yes)
-        and (!heritage or heritage = no)
-        and !listed_status
+            and (${lastChecked(2.0)})
+          ) or (
+            (
+              amenity = clock
+              or amenity = post_box
+              or leisure = picnic_table
+              or amenity = bbq
+              or amenity = car_sharing
+              or leisure = firepit
+              or (leisure = pitch and sport ~ table_tennis|chess|table_soccer|teqball)
+              or leisure = fitness_station
+              or amenity = grit_bin and seasonal = no
+              or amenity = vending_machine and vending ~ parking_tickets|public_transport_tickets
+              or amenity = ticket_validator
+              or amenity = bicycle_repair_station
+              or tourism = information and information ~ board|terminal|map
+              or advertising ~ column|board|poster_box
+              or (highway = emergency_access_point or emergency = access_point) and ref
+              or emergency ~ life_ring|phone
+              or emergency = defibrillator and (indoor = no or access = yes)
+              or (
+                man_made = surveillance
+                and surveillance:type = camera
+                and surveillance ~ outdoor|public
+                and !highway
+              )
+            )
+            and (${lastChecked(4.0)})
+          ) or (
+            (
+              amenity = bench
+              or amenity = lounger
+              or amenity = waste_basket
+              or amenity = recycling and recycling_type = container
+              or amenity = toilets
+              or amenity = shower
+              or amenity = drinking_water
+              or man_made = planter
+            )
+            and (${lastChecked(6.0)})
+          ) or (
+            amenity ~ bicycle_parking|motorcycle_parking|taxi|shelter
+            and (${lastChecked(10.0)})
+          ) or (
+            (
+              traffic_calming ~ bump|mini_bumps|hump|cushion|rumble_strip|dip|double_dip
+              or traffic_calming = table and !highway and !crossing
+            )
+            and (${lastChecked(14.0)})
+          ))
+          and access !~ no|private
+          and (!seasonal or seasonal = no)
+          and (!intermittent or intermittent = no)
+          and (!permanent or permanent != yes)
+          and (!heritage or heritage = no)
+          and !listed_status
     """.toElementFilterExpression() }
     // - traffic_calming = table is often used as a property of a crossing: we don't want the app
     //    to delete the crossing if the table is not there anymore, so exclude that

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -58,7 +58,9 @@ class CheckExistence(
             or emergency ~ life_ring|phone
             or emergency = defibrillator and (indoor = no or access = yes)
             or (
-              man_made = surveillance and surveillance:type = camera and surveillance ~ outdoor|public
+              man_made = surveillance
+              and surveillance:type = camera
+              and surveillance ~ outdoor|public
               and !highway
             )
           )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessBicycle.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessBicycle.kt
@@ -24,10 +24,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddFerryAccessBicycle : OsmElementQuestType<FerryBicycleAccess> {
 
-    private val filter by lazy {
-        "ways, relations with route = ferry and !bicycle and !bicycle:signed"
-            .toElementFilterExpression()
-    }
+    private val filter by lazy { """
+        ways, relations with
+          route = ferry and !bicycle and !bicycle:signed
+    """.toElementFilterExpression() }
 
     override val changesetComment = "Specify ferry access for bicycles"
     override val wikiLink = "Tag:route=ferry"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessHgv.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessHgv.kt
@@ -23,10 +23,11 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddFerryAccessHgv : OsmElementQuestType<FerryHgvAccess> {
 
-    private val filter by lazy {
-        "ways, relations with route = ferry and !hgv and !hgv:signed"
-            .toElementFilterExpression()
-    }
+    private val filter by lazy { """
+        ways, relations with
+          route = ferry and !hgv and !hgv:signed
+    """.toElementFilterExpression() }
+
     override val changesetComment = "Specify ferry access for hgv"
     override val wikiLink = "Tag:route=ferry"
     override val icon = Res.drawable.quest_ferry_hgv

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessMotorVehicle.kt
@@ -19,10 +19,11 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddFerryAccessMotorVehicle : OsmElementQuestType<Boolean> {
 
-    private val filter by lazy {
-        "ways, relations with route = ferry and !motor_vehicle"
-            .toElementFilterExpression()
-    }
+    private val filter by lazy { """
+        ways, relations with
+          route = ferry and !motor_vehicle
+    """.toElementFilterExpression() }
+
     override val changesetComment = "Specify ferry access for motor vehicles"
     override val wikiLink = "Tag:route=ferry"
     override val icon = Res.drawable.quest_ferry

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/ferry/AddFerryAccessPedestrian.kt
@@ -19,10 +19,11 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddFerryAccessPedestrian : OsmElementQuestType<Boolean> {
 
-    private val filter by lazy {
-        "ways, relations with route = ferry and !foot"
-            .toElementFilterExpression()
-    }
+    private val filter by lazy { """
+        ways, relations with
+          route = ferry and !foot
+    """.toElementFilterExpression() }
+
     override val changesetComment = "Specify ferry access for pedestrians"
     override val wikiLink = "Tag:route=ferry"
     override val icon = Res.drawable.quest_ferry_pedestrian

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantType.kt
@@ -18,7 +18,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddFireHydrantType : OsmFilterQuestType<FireHydrantType>() {
 
-    override val elementFilter = "nodes with emergency = fire_hydrant and !fire_hydrant:type"
+    override val elementFilter = """
+        nodes with
+          emergency = fire_hydrant and !fire_hydrant:type
+    """
     override val changesetComment = "Specify fire hydrant types"
     override val wikiLink = "Tag:emergency=fire_hydrant"
     override val icon = Res.drawable.quest_fire_hydrant

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -17,11 +17,11 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
 
     override val elementFilter = """
         nodes with
-         emergency = fire_hydrant
-         and fire_hydrant:type
-         and fire_hydrant:type ~ pillar|underground
-         and !fire_hydrant:diameter
-         and (fire_hydrant:diameter:signed != no or fire_hydrant:diameter:signed older today -6 years)
+          emergency = fire_hydrant
+          and fire_hydrant:type
+          and fire_hydrant:type ~ pillar|underground
+          and !fire_hydrant:diameter
+          and (fire_hydrant:diameter:signed != no or fire_hydrant:diameter:signed older today -6 years)
     """
     override val changesetComment = "Specify fire hydrant diameters"
     override val wikiLink = "Tag:emergency=fire_hydrant"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -19,7 +19,7 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
         nodes with
          emergency = fire_hydrant
          and fire_hydrant:type and
-         (fire_hydrant:type = pillar or fire_hydrant:type = underground)
+         fire_hydrant:type ~ pillar|underground
          and !fire_hydrant:diameter
          and (fire_hydrant:diameter:signed != no or fire_hydrant:diameter:signed older today -6 years)
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_diameter/AddFireHydrantDiameter.kt
@@ -18,8 +18,8 @@ class AddFireHydrantDiameter : OsmFilterQuestType<FireHydrantDiameterAnswer>() {
     override val elementFilter = """
         nodes with
          emergency = fire_hydrant
-         and fire_hydrant:type and
-         fire_hydrant:type ~ pillar|underground
+         and fire_hydrant:type
+         and fire_hydrant:type ~ pillar|underground
          and !fire_hydrant:diameter
          and (fire_hydrant:diameter:signed != no or fire_hydrant:diameter:signed older today -6 years)
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -20,9 +20,9 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
 
     override val elementFilter = """
         nodes with
-         emergency = fire_hydrant and
-         (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme") and
-         fire_hydrant:type ~ pillar|underground
+         emergency = fire_hydrant
+         and (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme")
+         and fire_hydrant:type ~ pillar|underground
     """
     override val changesetComment = "Specify fire hydrant positions"
     override val wikiLink = "Tag:emergency=fire_hydrant"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -20,9 +20,9 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
 
     override val elementFilter = """
         nodes with
-         emergency = fire_hydrant
-         and (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme")
-         and fire_hydrant:type ~ pillar|underground
+          emergency = fire_hydrant
+          and (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme")
+          and fire_hydrant:type ~ pillar|underground
     """
     override val changesetComment = "Specify fire hydrant positions"
     override val wikiLink = "Tag:emergency=fire_hydrant"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -22,7 +22,7 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
         nodes with
          emergency = fire_hydrant and
          (!fire_hydrant:position or fire_hydrant:position ~ "\?|fixme") and
-         (fire_hydrant:type = pillar or fire_hydrant:type = underground)
+         fire_hydrant:type ~ pillar|underground
     """
     override val changesetComment = "Specify fire hydrant positions"
     override val wikiLink = "Tag:emergency=fire_hydrant"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_ref/AddFireHydrantRef.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/fire_hydrant_ref/AddFireHydrantRef.kt
@@ -15,8 +15,8 @@ class AddFireHydrantRef : OsmFilterQuestType<FireHydrantRefAnswer>() {
 
     override val elementFilter = """
         nodes with
-        emergency = fire_hydrant
-        and !name and !ref and noref != yes and ref:signed != no and !~"ref:.*"
+          emergency = fire_hydrant
+          and !name and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
     override val changesetComment = "Determine fire hydrant refs"
     override val wikiLink = "Key:ref"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/firewood/AddFirewood.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/firewood/AddFirewood.kt
@@ -43,7 +43,12 @@ class AddFirewood : OsmFilterQuestType<Boolean>() {
     override val achievements = listOf(OUTDOORS)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("nodes, ways with leisure = firepit or amenity = bbq or tourism = wilderness_hut")
+        mapData.filter("""
+            nodes, ways with
+              leisure = firepit
+              or amenity = bbq
+              or tourism = wilderness_hut
+        """)
 
     @Composable
     override fun Form(on: (QuestAction<Boolean>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/firewood/AddFirewood.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/firewood/AddFirewood.kt
@@ -19,13 +19,13 @@ class AddFirewood : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-            (
-                leisure = firepit
-                or (amenity = bbq and fuel = wood)
-                or (tourism = wilderness_hut and fireplace = yes)
-            )
-            and access !~ private|no
-            and !wood_provided
+          (
+            leisure = firepit
+            or (amenity = bbq and fuel = wood)
+            or (tourism = wilderness_hut and fireplace = yes)
+          )
+          and access !~ private|no
+          and !wood_provided
     """
 
     // for now only enabled in the nordics / high-trust societies

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/first_aid_kit/AddFirstAidKitLocation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/first_aid_kit/AddFirstAidKitLocation.kt
@@ -17,10 +17,10 @@ class AddFirstAidKitLocation : OsmFilterQuestType<String>() {
 
     override val elementFilter = """
         nodes with
-        emergency = first_aid_kit
-        and !location and !first_aid_kit:location
-        and !~location:.* and !~first_aid_kit:location:.*
-        and access !~ private|no
+          emergency = first_aid_kit
+          and !location and !first_aid_kit:location
+          and !~location:.* and !~first_aid_kit:location:.*
+          and access !~ private|no
     """
     override val changesetComment = "Specify first aid kit location"
     override val wikiLink = "Tag:emergency=first_aid_kit"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -22,16 +22,16 @@ import org.jetbrains.compose.resources.stringResource
 class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansAnswer>() {
     override val elementFilter = """
         ways with
-        (
-          sidewalk:both ~ none|no
-          or sidewalk ~ none|no
-          or (sidewalk:left ~ none|no and sidewalk:right ~ none|no)
-        )
-        and verge !~ yes|both
-        and shoulder !~ yes|both
-        and shoulder:left != yes and shoulder:right != yes and shoulder:both != yes
-        and !foot
-        and access !~ private|no
+          (
+            sidewalk:both ~ none|no
+            or sidewalk ~ none|no
+            or (sidewalk:left ~ none|no and sidewalk:right ~ none|no)
+          )
+          and verge !~ yes|both
+          and shoulder !~ yes|both
+          and shoulder:left != yes and shoulder:right != yes and shoulder:both != yes
+          and !foot
+          and access !~ private|no
         """ +
         /* asking for any road without sidewalk is too much. Main interesting situations are
            certain road sections within large intersections, overpasses, underpasses,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -21,7 +21,8 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansAnswer>() {
     override val elementFilter = """
-        ways with (
+        ways with
+        (
           sidewalk:both ~ none|no
           or sidewalk ~ none|no
           or (sidewalk:left ~ none|no and sidewalk:right ~ none|no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -19,34 +19,34 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>() {
     // We further exclude dual use charging stations as payment may be waived only for cyclists increasing risk of incorrect answers
     override val elementFilter = """
         nodes, ways with
-         (
-           (
-             amenity = charging_station
-             and bicycle ~ yes|designated
-             and (!motorcar or motorcar = no)
-             and (!motorcycle or motorcycle = no)
-             and (!truck or truck = no)
-           )
-           or (
-             tourism = camp_site
-             and (
+          (
+            (
+              amenity = charging_station
+              and bicycle ~ yes|designated
+              and (!motorcar or motorcar = no)
+              and (!motorcycle or motorcycle = no)
+              and (!truck or truck = no)
+            )
+            or (
+              tourism = camp_site
+              and (
                 camp_site = basic
                 or backcountry = yes
                 or shower = no
                 or toilets = no
-             )
-           )
-           or tourism ~ museum|gallery|caravan_site|zoo|aquarium|wilderness_hut
-           or leisure ~ beach_resort|disc_golf_course
-           or amenity ~ sanitary_dump_station|shower|water_point|public_bath|bicycle_wash|binoculars|device_charging_station|vacuum_cleaner
-           or natural = cave_entrance and access=yes
-           or man_made = tower and tower:type = observation and access=yes
-           or historic = castle and access = yes
-           or waterway = water_point
-         )
-         and access !~ private|no
-         and !fee
-         and !fee:conditional
+              )
+            )
+            or tourism ~ museum|gallery|caravan_site|zoo|aquarium|wilderness_hut
+            or leisure ~ beach_resort|disc_golf_course
+            or amenity ~ sanitary_dump_station|shower|water_point|public_bath|bicycle_wash|binoculars|device_charging_station|vacuum_cleaner
+            or natural = cave_entrance and access=yes
+            or man_made = tower and tower:type = observation and access=yes
+            or historic = castle and access = yes
+            or waterway = water_point
+          )
+          and access !~ private|no
+          and !fee
+          and !fee:conditional
     """
     override val changesetComment = "Specify whether places take fees to visit"
     override val wikiLink = "Key:fee"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/hairdresser/AddHairdresserCustomers.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/hairdresser/AddHairdresserCustomers.kt
@@ -19,12 +19,10 @@ class AddHairdresserCustomers : OsmFilterQuestType<HairdresserCustomers>() {
 
     override val elementFilter = """
         nodes, ways with
-          (
-              shop = hairdresser
-              and hairdresser != barber
-              and !female and !male
-              and !male:signed and !female:signed
-          )
+          shop = hairdresser
+          and hairdresser != barber
+          and !female and !male
+          and !male:signed and !female:signed
     """
     override val changesetComment = "Survey hairdresser's customers"
     override val wikiLink = "Tag:shop=hairdresser"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -18,16 +18,16 @@ class AddHandrail : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         ways with
-         highway = steps
-         and (!indoor or indoor = no)
-         and access !~ private|no
-         and (!conveying or conveying = no)
-         and (
-           !handrail and !handrail:center and !handrail:left and !handrail:right
-           or handrail = no and handrail older today -4 years
-           or handrail older today -8 years
-           or older today -8 years
-         )
+          highway = steps
+          and (!indoor or indoor = no)
+          and access !~ private|no
+          and (!conveying or conveying = no)
+          and (
+            !handrail and !handrail:center and !handrail:left and !handrail:right
+            or handrail = no and handrail older today -4 years
+            or handrail older today -8 years
+            or older today -8 years
+          )
     """
 
     override val changesetComment = "Specify whether steps have handrails"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -17,7 +17,8 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddHandrail : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        ways with highway = steps
+        ways with
+         highway = steps
          and (!indoor or indoor = no)
          and access !~ private|no
          and (!conveying or conveying = no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handwashing/AddHandwashing.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/handwashing/AddHandwashing.kt
@@ -16,10 +16,10 @@ class AddHandwashing : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        amenity = toilets
-        and toilets:disposal
-        and toilets:disposal != flush
-        and !toilets:handwashing
+          amenity = toilets
+          and toilets:disposal
+          and toilets:disposal != flush
+          and !toilets:handwashing
     """
     override val changesetComment = "Survey availability of handwashing capabilites"
     override val wikiLink = "Key:toilets:handwashing"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddBicycleIncline.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddBicycleIncline.kt
@@ -18,12 +18,12 @@ class AddBicycleIncline : OsmElementQuestType<BicycleInclineAnswer> {
 
     private val tagFilter by lazy { """
         ways with
-         mtb:scale:uphill
-         and highway ~ footway|cycleway|path|bridleway|track
-         and (!indoor or indoor = no)
-         and area != yes
-         and access !~ private|no
-         and !incline
+          mtb:scale:uphill
+          and highway ~ footway|cycleway|path|bridleway|track
+          and (!indoor or indoor = no)
+          and area != yes
+          and access !~ private|no
+          and !incline
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify which way leads up (where mtb:scale:uphill is present)"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddStepsIncline.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddStepsIncline.kt
@@ -13,7 +13,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddStepsIncline : OsmFilterQuestType<Incline>() {
 
     override val elementFilter = """
-        ways with highway = steps
+        ways with
+         highway = steps
          and (!indoor or indoor = no)
          and area != yes
          and access !~ private|no

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddStepsIncline.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddStepsIncline.kt
@@ -14,11 +14,11 @@ class AddStepsIncline : OsmFilterQuestType<Incline>() {
 
     override val elementFilter = """
         ways with
-         highway = steps
-         and (!indoor or indoor = no)
-         and area != yes
-         and access !~ private|no
-         and !incline
+          highway = steps
+          and (!indoor or indoor = no)
+          and area != yes
+          and access !~ private|no
+          and !incline
     """
     override val changesetComment = "Specify which way leads up for steps"
     override val wikiLink = "Key:incline"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -15,21 +15,21 @@ class AddInternetAccess : OsmFilterQuestType<Set<InternetAccess>>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
-          amenity ~ library|community_centre|youth_centre|hospital|ranger_station
-          or tourism ~ hotel|guest_house|motel|hostel|alpine_hut|apartment|resort|caravan_site|chalet|wilderness_hut
-          or tourism = camp_site and backcountry != yes and camp_site != basic
-          or aeroway = terminal
-          or shop ~ mall|department_store
-          or tourism = information and information ~ office|visitor_center
-          or leisure = marina
-        )
-        and access !~ no|private
-        and (
-          !internet_access
-          or internet_access = yes
-          or internet_access older today -2 years
-        )
+          (
+            amenity ~ library|community_centre|youth_centre|hospital|ranger_station
+            or tourism ~ hotel|guest_house|motel|hostel|alpine_hut|apartment|resort|caravan_site|chalet|wilderness_hut
+            or tourism = camp_site and backcountry != yes and camp_site != basic
+            or aeroway = terminal
+            or shop ~ mall|department_store
+            or tourism = information and information ~ office|visitor_center
+            or leisure = marina
+          )
+          and access !~ no|private
+          and (
+            !internet_access
+            or internet_access = yes
+            or internet_access older today -2 years
+          )
     """
     /* Asked less often than for example opening hours because this quest is only asked for
        tendentially larger places which are less likely to change often */

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/leaf_detail/AddForestLeafType.kt
@@ -20,11 +20,15 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddForestLeafType : OsmElementQuestType<ForestLeafType> {
     private val areaFilter by lazy { """
-        ways, relations with (landuse = forest or natural = wood) and !leaf_type
+        ways, relations with
+          (landuse = forest or natural = wood)
+          and !leaf_type
     """.toElementFilterExpression() }
 
     private val wayFilter by lazy { """
-        ways with natural = tree_row and !leaf_type
+        ways with
+          natural = tree_row
+          and !leaf_type
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify leaf types"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevel.kt
@@ -32,11 +32,11 @@ class AddLevel : OsmElementQuestType<String> {
      * like small airport terminals, like Mo Chit 2 in Bangkok*/
     private val mallFilter by lazy { """
         ways, relations with
-         shop = mall
-         or aeroway = terminal
-         or railway = station
-         or amenity = bus_station
-         or public_transport = station
+          shop = mall
+          or aeroway = terminal
+          or railway = station
+          or amenity = bus_station
+          or public_transport = station
     """.toElementFilterExpression() }
 
     override val changesetComment = "Determine on which level shops are in a building"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevelThing.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevelThing.kt
@@ -28,11 +28,11 @@ class AddLevelThing : OsmElementQuestType<String> {
      * like small airport terminals, like Mo Chit 2 in Bangkok*/
     private val mallFilter by lazy { """
         ways, relations with
-         shop ~ department_store|mall
-         or aeroway = terminal
-         or railway = station
-         or amenity = bus_station
-         or public_transport = station
+          shop ~ department_store|mall
+          or aeroway = terminal
+          or railway = station
+          or amenity = bus_station
+          or public_transport = station
     """.toElementFilterExpression() }
 
     override val changesetComment = "Determine on which level things are in a building"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -22,21 +22,21 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer> {
 
     private val nodeFilter by lazy { """
         nodes with
-        (
-          barrier = height_restrictor
-          or amenity = parking_entrance and parking ~ underground|multi-storey
-        )
-        and $noMaxHeight
+          (
+            barrier = height_restrictor
+            or amenity = parking_entrance and parking ~ underground|multi-storey
+          )
+          and $noMaxHeight
     """.toElementFilterExpression() }
 
     private val roadsWithoutMaxHeightFilter by lazy { """
         ways with
-        (
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|track|road|busway
-          or (highway = service and access !~ private|no and vehicle !~ private|no)
-        )
-        and $noMaxHeight
-        and (access !~ private|no or (foot and foot !~ private|no))
+          (
+            highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|track|road|busway
+            or (highway = service and access !~ private|no and vehicle !~ private|no)
+          )
+          and $noMaxHeight
+          and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }
 
     private val railwayCrossingsFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -25,7 +25,8 @@ class AddMaxPhysicalHeight(
     // quest if that quest was already answered with maxheight:signed = no
 
     private val nodeFilter by lazy { """
-        nodes with (
+        nodes with
+        (
           barrier = height_restrictor
           or amenity = parking_entrance and parking ~ underground|multi-storey
         )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxPhysicalHeight.kt
@@ -26,19 +26,19 @@ class AddMaxPhysicalHeight(
 
     private val nodeFilter by lazy { """
         nodes with
-        (
-          barrier = height_restrictor
-          or amenity = parking_entrance and parking ~ underground|multi-storey
-        )
-        and (
-          maxheight = below_default
-          or source:maxheight ~ ".*estimat.*"
-          or maxheight:signed = no and !maxheight
-        )
-        and maxheight != default
-        and !maxheight:physical
-        and access !~ private|no
-        and vehicle !~ private|no
+          (
+            barrier = height_restrictor
+            or amenity = parking_entrance and parking ~ underground|multi-storey
+          )
+          and (
+            maxheight = below_default
+            or source:maxheight ~ ".*estimat.*"
+            or maxheight:signed = no and !maxheight
+          )
+          and maxheight != default
+          and !maxheight:physical
+          and access !~ private|no
+          and vehicle !~ private|no
     """.toElementFilterExpression() }
     // leaving out railway = level_crossing is deliberate, we do not want people to measure overhead
     // cables by hand - bzzzt! - but also (if measured with laser) the result would be wrong, as
@@ -46,19 +46,19 @@ class AddMaxPhysicalHeight(
 
     private val wayFilter by lazy { """
         ways with
-        highway ~ ${(ALL_ROADS - MOTORWAYS).joinToString("|")}
-        and (
-          maxheight = below_default
-          or source:maxheight ~ ".*estimat.*"
-          or maxheight:signed = no and !maxheight
-        )
-        and maxheight != default
-        and !maxheight:physical
-        and access !~ private|no
-        and vehicle !~ private|no
-        and motorroad != yes
-        and motorway != yes
-        and expressway != yes
+          highway ~ ${(ALL_ROADS - MOTORWAYS).joinToString("|")}
+          and (
+            maxheight = below_default
+            or source:maxheight ~ ".*estimat.*"
+            or maxheight:signed = no and !maxheight
+          )
+          and maxheight != default
+          and !maxheight:physical
+          and access !~ private|no
+          and vehicle !~ private|no
+          and motorroad != yes
+          and motorway != yes
+          and expressway != yes
     """.toElementFilterExpression() }
     // explicitly removed motorway-style ways (highway=motorway*, motorroad/motorway=yes,
     // expressway=yes) from ever being matched as measuring heights on these ways likely is

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_height/MaxHeightUtils.kt
@@ -33,7 +33,8 @@ val tunnelFilter: ElementFilterExpression by lazy { """
 """.toElementFilterExpression() }
 
 val bridgeFilter by lazy { """
-    ways with (
+    ways with
+      (
         (
           highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
           or railway ~ rail|light_rail|subway|narrow_gauge|tram|disused|preserved|funicular|monorail

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -21,16 +21,16 @@ class AddMaxSpeed (
 
     override val elementFilter = """
         ways with
-         highway ~ motorway|trunk|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
-         and !maxspeed and !maxspeed:advisory and !maxspeed:forward and !maxspeed:backward
-         and ${MAX_SPEED_TYPE_KEYS.joinToString(" and ") { "!$it" }}
-         and surface !~ ${UNPAVED_SURFACES.joinToString("|")}
-         and cyclestreet != yes and bicycle_road != yes
-         and living_street != yes
-         and motor_vehicle !~ private|no
-         and vehicle !~ private|no
-         and area != yes
-         and (access !~ private|no or (foot and foot !~ private|no))
+          highway ~ motorway|trunk|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
+          and !maxspeed and !maxspeed:advisory and !maxspeed:forward and !maxspeed:backward
+          and ${MAX_SPEED_TYPE_KEYS.joinToString(" and ") { "!$it" }}
+          and surface !~ ${UNPAVED_SURFACES.joinToString("|")}
+          and cyclestreet != yes and bicycle_road != yes
+          and living_street != yes
+          and motor_vehicle !~ private|no
+          and vehicle !~ private|no
+          and area != yes
+          and (access !~ private|no or (foot and foot !~ private|no))
     """
     override val changesetComment = "Specify speed limits"
     override val wikiLink = "Key:maxspeed"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -22,29 +22,29 @@ class AddMaxWeight : OsmElementQuestType<List<MaxWeight>> {
     // The general filter is used for both:
     private val generalFilter by lazy { """
         ways, relations with
-         !maxweight and maxweight:signed != no
-         and !maxaxleload
-         and !maxbogieweight
-         and !maxweight:hgv and !maxweight:bus and !maxweight:hgv_articulated and !maxweight:tourist_bus and !maxweight:coach
-         and !maxweightrating and !maxweightrating:hgv and !maxweightrating:bus and !hgv
-         and !maxunladenweight and !maxunladenweight:hgv and !maxunladenweight:bus
-         and vehicle !~ private|no
-         and (access !~ private|no or (foot and foot !~ private|no))
-         and area != yes
+          !maxweight and maxweight:signed != no
+          and !maxaxleload
+          and !maxbogieweight
+          and !maxweight:hgv and !maxweight:bus and !maxweight:hgv_articulated and !maxweight:tourist_bus and !maxweight:coach
+          and !maxweightrating and !maxweightrating:hgv and !maxweightrating:bus and !hgv
+          and !maxunladenweight and !maxunladenweight:hgv and !maxunladenweight:bus
+          and vehicle !~ private|no
+          and (access !~ private|no or (foot and foot !~ private|no))
+          and area != yes
     """.toElementFilterExpression() }
 
     private val highwayFilter by lazy { """
         ways with
-         highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|busway
-         and bridge and bridge != no
-         and service != driveway
-         and motor_vehicle !~ private|no
+          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|busway
+          and bridge and bridge != no
+          and service != driveway
+          and motor_vehicle !~ private|no
     """.toElementFilterExpression() }
 
     private val ferryFilter by lazy { """
         ways, relations with
-         route = ferry
-         and motor_vehicle = yes
+          route = ferry
+          and motor_vehicle = yes
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify maximum allowed weights"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/moped/AddMopedAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/moped/AddMopedAccess.kt
@@ -18,14 +18,14 @@ class AddMopedAccess : OsmFilterQuestType<MopedAccessAnswer>() {
 
     override val elementFilter = """
         ways with
-        (
+          (
             highway = cycleway
             or highway = path and bicycle = designated
             or highway = footway and bicycle = designated
-        )
-        and !moped
-        and !moped:signed
-        and (motor_vehicle != no or !motor_vehicle)
+          )
+          and !moped
+          and !moped:signed
+          and (motor_vehicle != no or !motor_vehicle)
     """
     override val enabledInCountries = NoCountriesExcept(
         "BE", // https://github.com/streetcomplete/StreetComplete/issues/5565

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/moped/AddMopedAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/moped/AddMopedAccess.kt
@@ -17,7 +17,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddMopedAccess : OsmFilterQuestType<MopedAccessAnswer>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+        (
             highway = cycleway
             or highway = path and bicycle = designated
             or highway = footway and bicycle = designated

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -19,10 +19,10 @@ class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
 
     override val elementFilter = """
         nodes, ways with
-         amenity = motorcycle_parking
-         and access !~ private|no
-         and (!capacity or capacity older today -4 years)
-         and markings != no
+          amenity = motorcycle_parking
+          and access !~ private|no
+          and (!capacity or capacity older today -4 years)
+          and markings != no
     """
     override val changesetComment = "Specify motorcycle parking capacities"
     override val wikiLink = "Tag:amenity=motorcycle_parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_capacity/AddMotorcycleParkingCapacity.kt
@@ -18,7 +18,8 @@ import org.jetbrains.compose.resources.painterResource
 class AddMotorcycleParkingCapacity : OsmFilterQuestType<Int>() {
 
     override val elementFilter = """
-        nodes, ways with amenity = motorcycle_parking
+        nodes, ways with
+         amenity = motorcycle_parking
          and access !~ private|no
          and (!capacity or capacity older today -4 years)
          and markings != no

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -18,10 +18,10 @@ class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-        amenity = motorcycle_parking
-        and access !~ private|no
-        and !covered
-        and motorcycle_parking !~ shed|garage_boxes|building
+          amenity = motorcycle_parking
+          and access !~ private|no
+          and !covered
+          and motorcycle_parking !~ shed|garage_boxes|building
     """
     override val changesetComment = "Specify motorcycle parkings covers"
     override val wikiLink = "Tag:amenity=motorcycle_parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/motorcycle_parking_cover/AddMotorcycleParkingCover.kt
@@ -17,7 +17,8 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddMotorcycleParkingCover : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        nodes, ways with amenity = motorcycle_parking
+        nodes, ways with
+        amenity = motorcycle_parking
         and access !~ private|no
         and !covered
         and motorcycle_parking !~ shed|garage_boxes|building

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -27,7 +27,8 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
 
     /** find only those roads eligible for asking for oneway */
     private val elementFilter by lazy { """
-        ways with highway ~ living_street|residential|service|tertiary|unclassified|busway
+        ways with
+         highway ~ living_street|residential|service|tertiary|unclassified|busway
          and width <= 4 and (!lanes or lanes <= 1)
          and !oneway and area != yes and junction != roundabout
          and (access !~ private|no or (foot and foot !~ private|no))

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -28,10 +28,10 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
     /** find only those roads eligible for asking for oneway */
     private val elementFilter by lazy { """
         ways with
-         highway ~ living_street|residential|service|tertiary|unclassified|busway
-         and width <= 4 and (!lanes or lanes <= 1)
-         and !oneway and area != yes and junction != roundabout
-         and (access !~ private|no or (foot and foot !~ private|no))
+          highway ~ living_street|residential|service|tertiary|unclassified|busway
+          and width <= 4 and (!lanes or lanes <= 1)
+          and !oneway and area != yes and junction != roundabout
+          and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether narrow roads are one-ways"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOneway.kt
@@ -22,7 +22,9 @@ class AddOneway : OsmElementQuestType<OnewayAnswer> {
 
     /** find all roads */
     private val allRoadsFilter by lazy { """
-        ways with highway ~ ${ALL_ROADS.joinToString("|")} and area != yes
+        ways with
+          highway ~ ${ALL_ROADS.joinToString("|")}
+          and area != yes
     """.toElementFilterExpression() }
 
     /** find only those roads eligible for asking for oneway */

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
@@ -20,8 +20,8 @@ class AddOnewayAerialway : OsmElementQuestType<OnewayAnswer> {
 
     private val elementFilter by lazy { """
         ways with
-        aerialway ~ gondola|mixed_lift|chair_lift|t-bar|j-bar|platter
-        and !oneway
+          aerialway ~ gondola|mixed_lift|chair_lift|t-bar|j-bar|platter
+          and !oneway
     """.toElementFilterExpression() }
 
     override val changesetComment = "Specify whether aerial ways can be used both ways"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/oneway/AddOnewayAerialway.kt
@@ -39,9 +39,7 @@ class AddOnewayAerialway : OsmElementQuestType<OnewayAnswer> {
         elementFilter.matches(element)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
-        mapData.filter("""
-            nodes, ways with aerialway
-        """.toElementFilterExpression())
+        mapData.filter("nodes, ways with aerialway".toElementFilterExpression())
 
     @Composable
     override fun Form(on: (QuestAction<OnewayAnswer>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -117,8 +117,7 @@ mapOf(
 ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") + "\n" + """
     )
     and (!opening_hours or opening_hours older today -1 years)
-    and
-    (
+    and (
         name
         or brand
         or noname = yes

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -164,14 +164,14 @@ mapOf(
     """
     private val filter by lazy { """
         nodes, ways with
-        (
+          (
             $namedFilterFragment
             or $unnamedFilterFragment
             or $updateFilterFragment
-        )
-        and access !~ private|no
-        and street_vendor != yes
-        and opening_hours:signed != no
+          )
+          and access !~ private|no
+          and street_vendor != yes
+          and opening_hours:signed != no
     """.toElementFilterExpression() }
 
     override val changesetComment = "Survey opening hours"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -14,9 +14,9 @@ class AddOrchardProduce : OsmFilterQuestType<Set<OrchardProduce>>() {
 
     override val elementFilter = """
         ways, relations with
-        landuse = orchard
-        and !trees and !produce and !crop
-        and orchard != meadow_orchard
+          landuse = orchard
+          and !trees and !produce and !crop
+          and orchard != meadow_orchard
     """
     override val changesetComment = "Specify orchard produces"
     override val wikiLink = "Tag:landuse=orchard"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduce.kt
@@ -13,7 +13,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddOrchardProduce : OsmFilterQuestType<Set<OrchardProduce>>() {
 
     override val elementFilter = """
-        ways, relations with landuse = orchard
+        ways, relations with
+        landuse = orchard
         and !trees and !produce and !crop
         and orchard != meadow_orchard
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parcel_locker_brand/AddParcelLockerBrand.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parcel_locker_brand/AddParcelLockerBrand.kt
@@ -15,7 +15,11 @@ import de.westnordost.streetcomplete.ui.common.quest.NameWithSuggestionsQuestFor
 
 class AddParcelLockerBrand : OsmFilterQuestType<String>() {
 
-    override val elementFilter = "nodes with amenity = parcel_locker and !brand and !name and !operator"
+    override val elementFilter = """
+        nodes with
+          amenity = parcel_locker
+          and !brand and !name and !operator
+    """
     override val changesetComment = "Specify parcel locker brand"
     override val wikiLink = "Tag:amenity=parcel_locker"
     override val icon = Res.drawable.quest_parcel_locker_brand

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -19,9 +19,9 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     // AddBikeParkingFee and because those are uncontroversial. See #2496 and #2517
     override val elementFilter = """
         nodes, ways, relations with
-        amenity = bicycle_parking
-        and bicycle_parking ~ building|lockers|shed
-        and (!access or access = unknown)
+          amenity = bicycle_parking
+          and bicycle_parking ~ building|lockers|shed
+          and (!access or access = unknown)
     """
 
     override val changesetComment = "Specify bicycle parking access"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddBikeParkingAccess.kt
@@ -18,7 +18,8 @@ class AddBikeParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     // Only include these bicycle_parking types, because access for these types is needed for
     // AddBikeParkingFee and because those are uncontroversial. See #2496 and #2517
     override val elementFilter = """
-        nodes, ways, relations with amenity = bicycle_parking
+        nodes, ways, relations with
+        amenity = bicycle_parking
         and bicycle_parking ~ building|lockers|shed
         and (!access or access = unknown)
     """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -28,14 +28,14 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
         nodes, ways, relations with amenity ~ parking|motorcycle_parking
         and (
             access = unknown
-            or (!access and parking !~ street_side|lane) and
-            !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar and
-            !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated and
-            !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv and
-            !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi and
-            !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water and
-            !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank and
-            !motor_vehicle and !vehicle
+            or (!access and parking !~ street_side|lane)
+            and !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar
+            and !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated
+            and !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv
+            and !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi
+            and !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water
+            and !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank
+            and !motor_vehicle and !vehicle
         )
     """
     override val changesetComment = "Specify parking access"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -25,7 +25,8 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     // Cf. #2408: Parking access might omit parking=street_side
     // Cf. #4538: should skip elements with more specific access tag already mapped
     override val elementFilter = """
-        nodes, ways, relations with amenity ~ parking|motorcycle_parking
+        nodes, ways, relations with
+        amenity ~ parking|motorcycle_parking
         and (
             access = unknown
             or (!access and parking !~ street_side|lane)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -28,15 +28,17 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
         nodes, ways, relations with
           amenity ~ parking|motorcycle_parking
           and (
-            access = unknown
-            or (!access and parking !~ street_side|lane)
-            and !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar
-            and !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated
-            and !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv
-            and !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi
-            and !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water
-            and !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank
-            and !motor_vehicle and !vehicle
+            access = unknown or (
+              parking !~ street_side|lane
+              and !access
+              and !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar
+              and !motorhome and !tourist_bus and !coach and !goods and !hgv and !hgv_articulated
+              and !bdouble and !agricultural and !auto_rickshaw and !nev and !golf_cart and !atv
+              and !ohv and !snowmobile and !psv and !bus and !taxi and !minibus and !share_taxi
+              and !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water
+              and !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank
+              and !motor_vehicle and !vehicle
+            )
           )
     """
     override val changesetComment = "Specify parking access"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -26,8 +26,8 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
     // Cf. #4538: should skip elements with more specific access tag already mapped
     override val elementFilter = """
         nodes, ways, relations with
-        amenity ~ parking|motorcycle_parking
-        and (
+          amenity ~ parking|motorcycle_parking
+          and (
             access = unknown
             or (!access and parking !~ street_side|lane)
             and !trailer and !caravan and !double_tracked_motor_vehicle and !motorcar
@@ -37,7 +37,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>() {
             and !hov and !carpool and !car_sharing and !emergency and !hazmat and !hazmat:water
             and !school_bus and !disabled and !4wd_only and !roadtrain and !lhv and !tank
             and !motor_vehicle and !vehicle
-        )
+          )
     """
     override val changesetComment = "Specify parking access"
     override val wikiLink = "Tag:amenity=parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -14,7 +14,8 @@ class AddBikeParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
 
     // element selection logic by @DerDings in #2507
     override val elementFilter = """
-        nodes, ways, relations with amenity = bicycle_parking
+        nodes, ways, relations with
+        amenity = bicycle_parking
         and access ~ yes|customers|public
         and (
             name

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddBikeParkingFee.kt
@@ -15,17 +15,17 @@ class AddBikeParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
     // element selection logic by @DerDings in #2507
     override val elementFilter = """
         nodes, ways, relations with
-        amenity = bicycle_parking
-        and access ~ yes|customers|public
-        and (
+          amenity = bicycle_parking
+          and access ~ yes|customers|public
+          and (
             name
             or bicycle_parking ~ building|lockers|shed
             or capacity >= 100
-        )
-        and (
+          )
+          and (
             !fee and !fee:conditional
             or fee older today -8 years
-        )
+          )
     """
     override val changesetComment = "Specify bicycle parking fees"
     override val wikiLink = "Tag:amenity=bicycle_parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddMotorcycleParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddMotorcycleParkingFee.kt
@@ -13,7 +13,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddMotorcycleParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
 
     override val elementFilter = """
-        nodes, ways, relations with amenity = motorcycle_parking
+        nodes, ways, relations with
+        amenity = motorcycle_parking
         and access ~ yes|customers|public
         and (
             !fee and !fee:conditional

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddMotorcycleParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddMotorcycleParkingFee.kt
@@ -14,12 +14,12 @@ class AddMotorcycleParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        amenity = motorcycle_parking
-        and access ~ yes|customers|public
-        and (
+          amenity = motorcycle_parking
+          and access ~ yes|customers|public
+          and (
             !fee and !fee:conditional
             or fee older today -8 years
-        )
+          )
     """
     override val changesetComment = "Specify motorcycle parking fees"
     override val wikiLink = "Tag:amenity=motorcycle_parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -13,7 +13,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
 
     override val elementFilter = """
-        nodes, ways, relations with amenity = parking
+        nodes, ways, relations with
+        amenity = parking
         and access ~ yes|public
         and (
             !fee and !fee:conditional

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFee.kt
@@ -14,12 +14,12 @@ class AddParkingFee : OsmFilterQuestType<ParkingFeeAnswer>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        amenity = parking
-        and access ~ yes|public
-        and (
+          amenity = parking
+          and access ~ yes|public
+          and (
             !fee and !fee:conditional
             or fee older today -8 years
-        )
+          )
     """
     override val changesetComment = "Specify whether parking requires a fee"
     override val wikiLink = "Tag:amenity=parking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -17,18 +17,18 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         ways with
-        (
+          (
             leisure ~ pitch|track|fitness_station
             or piste:type and !highway
-        )
-        and access !~ private|no
-        and indoor != yes and (!building or building = no)
-        and (
-          !lit
-          or lit = no and lit older today -8 years
-          or lit older today -16 years
-        )
-        and !piste:lit
+          )
+          and access !~ private|no
+          and indoor != yes and (!building or building = no)
+          and (
+            !lit
+            or lit = no and lit older today -8 years
+            or lit older today -16 years
+          )
+          and !piste:lit
     """
     override val changesetComment = "Specify whether pitches are lit"
     override val wikiLink = "Key:lit"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -20,7 +20,7 @@ class AddPitchLit : OsmFilterQuestType<Boolean>() {
             leisure ~ pitch|track|fitness_station
             or piste:type and !highway
         )
-        and (access !~ private|no)
+        and access !~ private|no
         and indoor != yes and (!building or building = no)
         and (
           !lit

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -16,7 +16,8 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddPitchLit : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+        (
             leisure ~ pitch|track|fitness_station
             or piste:type and !highway
         )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -25,15 +25,15 @@ class AddPlaceName(
 
     private val filter by lazy { ("""
         nodes, ways with
-        (
-          shop and shop !~ no|vacant
-          or office and office !~ no|vacant
-          or craft
-          or amenity = recycling and recycling_type = centre
-          or amenity = shelter and shelter_type = basic_hut
-          or tourism = information and information ~ office|visitor_centre
-          or natural = cave_entrance and fee = yes
-          or """ +
+          (
+            shop and shop !~ no|vacant
+            or office and office !~ no|vacant
+            or craft
+            or amenity = recycling and recycling_type = centre
+            or amenity = shelter and shelter_type = basic_hut
+            or tourism = information and information ~ office|visitor_centre
+            or natural = cave_entrance and fee = yes
+            or """ +
 
         // The common list is shared by the opening hours quest and the wheelchair quest.
         // It is also mostly shared by the name quest, that has some wildcards (for say craft and office)
@@ -136,16 +136,16 @@ class AddPlaceName(
                 "fuel",
             ),
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
-        )
-        and (
+          )
+          and (
             (
-                !name
-                and !brand
-                and noname != yes
+              !name
+              and !brand
+              and noname != yes
             )
             or ~fixme|FIXME ~ name|name\?|Name|Name\?
-        )
-        and name:signed != no
+          )
+          and name:signed != no
     """).toElementFilterExpression() }
 
     override val changesetComment = "Determine place names"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/police_type/AddPoliceType.kt
@@ -16,7 +16,10 @@ import org.jetbrains.compose.resources.painterResource
 
 class AddPoliceType : OsmFilterQuestType<PoliceType>() {
 
-    override val elementFilter = "nodes, ways with amenity = police and !operator"
+    override val elementFilter = """
+        nodes, ways with
+          amenity = police and !operator
+    """
     override val changesetComment = "Specify Italian police types"
     override val wikiLink = "Tag:amenity=police"
     override val icon = Res.drawable.quest_police

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -21,7 +21,8 @@ import de.westnordost.streetcomplete.util.countryboundaries.NoCountriesExcept
 class AddPostboxCollectionTimes : OsmElementQuestType<CollectionTimesAnswer> {
 
     private val filter by lazy { """
-        nodes with amenity = post_box
+        nodes with
+          amenity = post_box
           and access !~ private|no
           and collection_times:signed != no
           and (!collection_times or collection_times older today -2 years)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_ref/AddPostboxRef.kt
@@ -17,8 +17,8 @@ class AddPostboxRef : OsmFilterQuestType<PostboxRefAnswer>() {
 
     override val elementFilter = """
         nodes with
-        amenity = post_box
-        and !ref and noref != yes and ref:signed != no and !~"ref:.*"
+          amenity = post_box
+          and !ref and noref != yes and ref:signed != no and !~"ref:.*"
     """
     override val changesetComment = "Specify postbox refs"
     override val wikiLink = "Tag:amenity=post_box"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/postbox_royal_cypher/AddPostboxRoyalCypher.kt
@@ -19,7 +19,9 @@ import org.jetbrains.compose.resources.painterResource
 class AddPostboxRoyalCypher : OsmFilterQuestType<PostboxRoyalCypher>() {
 
     override val elementFilter = """
-        nodes with amenity = post_box and (!royal_cypher or royal_cypher = yes)
+        nodes with
+            amenity = post_box
+            and (!royal_cypher or royal_cypher = yes)
     """
     override val changesetComment = "Specify postbox royal cyphers"
     override val wikiLink = "Key:royal_cypher"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterial.kt
@@ -32,9 +32,17 @@ class AddPowerPolesMaterial : OsmFilterQuestType<PowerPolesMaterialAnswer>() {
     override val achievements = listOf(BUILDING)
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
+        mapData.filter("""
+            nodes with
+              power = pole or man_made = utility_pole
+        """) +
         // and also show the (power) lines themselves
-        mapData.filter("nodes with power = pole or man_made = utility_pole") +
-        mapData.filter("ways with power ~ line|minor_line or communication = line or telecom = line")
+        mapData.filter("""
+            ways with
+              power ~ line|minor_line
+              or communication = line
+              or telecom = line
+        """)
 
     // map data density is usually lower where there are power poles and more context is necessary
     // when looking at them from afar

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/recycling/AddRecyclingType.kt
@@ -21,7 +21,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddRecyclingType : OsmFilterQuestType<RecyclingType>() {
 
-    override val elementFilter = "nodes, ways with amenity = recycling and !recycling_type"
+    override val elementFilter = """
+        nodes, ways with
+          amenity = recycling and !recycling_type
+    """
     override val changesetComment = "Specify type of recycling amenities"
     override val wikiLink = "Key:recycling_type"
     override val icon = Res.drawable.quest_recycling

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/religion/AddReligionToPlaceOfWorship.kt
@@ -14,12 +14,8 @@ class AddReligionToPlaceOfWorship : OsmFilterQuestType<Religion>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-            amenity = place_of_worship
-            or
-            amenity = monastery
-        )
-        and !religion
+          amenity ~ place_of_worship|monastery
+          and !religion
     """
     override val changesetComment = "Specify religion for places of worship"
     override val wikiLink = "Key:religion"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -21,8 +21,8 @@ class AddRoadName : OsmFilterQuestType<List<LocalizedName>>() {
         ways with
           highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
           and (
-             !name and !name:left and !name:right
-             or ~fixme|FIXME ~ name|name\?|Name|Name\?
+            !name and !name:left and !name:right
+            or ~fixme|FIXME ~ name|name\?|Name|Name\?
           )
           and !ref
           and noname != yes

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadNameForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadNameForm.kt
@@ -58,7 +58,8 @@ fun AddRoadNameForm(
     )
 }
 
-private val roadsWithNamesFilter by lazy {
-    "ways with highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")} and name"
-        .toElementFilterExpression()
-}
+private val roadsWithNamesFilter by lazy { """
+    ways with
+      highway ~ ${(ALL_ROADS + ALL_PATHS).joinToString("|")}
+      and name
+""".toElementFilterExpression() }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -28,7 +28,7 @@ class AddRoofShape(
 
     private val filter by lazy { """
         ways, relations with
-          ((building:levels or roof:levels) or (building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")}))
+          ((building:levels or roof:levels) or building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")})
           and !roof:shape and !3dr:type and !3dr:roof
           and building
           and building !~ no|construction

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShape.kt
@@ -28,7 +28,7 @@ class AddRoofShape(
 
     private val filter by lazy { """
         ways, relations with
-          ((building:levels or roof:levels) or building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")})
+          (building:levels or roof:levels or building ~ ${BUILDINGS_WITH_LEVELS.joinToString("|")})
           and !roof:shape and !3dr:type and !3dr:roof
           and building
           and building !~ no|construction

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sanitary_dump_station/AddSanitaryDumpStation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sanitary_dump_station/AddSanitaryDumpStation.kt
@@ -16,13 +16,13 @@ class AddSanitaryDumpStation : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways with
-         (
-           tourism = caravan_site
-           or tourism = camp_site and caravans = yes and !backcountry
-           or leisure = marina
-         )
-         and access !~ private|no
-         and !sanitary_dump_station
+          (
+            tourism = caravan_site
+            or tourism = camp_site and caravans = yes and !backcountry
+            or leisure = marina
+          )
+          and access !~ private|no
+          and !sanitary_dump_station
     """
 
     override val changesetComment = "Specify if there is a sanitary dump station at camp or caravan site"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -17,22 +17,22 @@ class AddCyclewaySegregation : OsmFilterQuestType<CyclewaySegregation>() {
 
     override val elementFilter = """
         ways with
-        (
-          (highway = path and bicycle = designated and foot = designated)
-          or (highway = footway and bicycle = designated)
-          or (highway = cycleway and foot ~ designated|yes)
-          or (
-            highway ~ path|footway|cycleway
-            and (footway:surface or cycleway:surface)
-            and foot !~ private|no
-            and bicycle !~ private|no
+          (
+            (highway = path and bicycle = designated and foot = designated)
+            or (highway = footway and bicycle = designated)
+            or (highway = cycleway and foot ~ designated|yes)
+            or (
+              highway ~ path|footway|cycleway
+              and (footway:surface or cycleway:surface)
+              and foot !~ private|no
+              and bicycle !~ private|no
+            )
           )
-        )
-        and surface ~ ${PAVED_SURFACES.joinToString("|")}
-        and area != yes
-        and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
-        and !segregated
-        and ~path|footway|cycleway !~ link
+          and surface ~ ${PAVED_SURFACES.joinToString("|")}
+          and area != yes
+          and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
+          and !segregated
+          and ~path|footway|cycleway !~ link
     """
     override val changesetComment = "Specify whether combined foot- and cycleways are segregated"
     override val wikiLink = "Key:segregated"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -21,13 +21,12 @@ class AddCyclewaySegregation : OsmFilterQuestType<CyclewaySegregation>() {
           (highway = path and bicycle = designated and foot = designated)
           or (highway = footway and bicycle = designated)
           or (highway = cycleway and foot ~ designated|yes)
-          or
-            (
+          or (
             highway ~ path|footway|cycleway
             and (footway:surface or cycleway:surface)
             and foot !~ private|no
             and bicycle !~ private|no
-            )
+          )
         )
         and surface ~ ${PAVED_SURFACES.joinToString("|")}
         and area != yes

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/self_service/AddSelfServiceLaundry.kt
@@ -19,7 +19,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddSelfServiceLaundry : OsmFilterQuestType<SelfServiceLaundry>() {
 
-    override val elementFilter = "nodes, ways with shop = laundry and !self_service"
+    override val elementFilter = """
+        nodes, ways with
+          shop = laundry and !self_service
+    """
     override val changesetComment = "Survey whether laundries provide self-service"
     override val wikiLink = "Tag:shop=laundry"
     override val icon = Res.drawable.quest_laundry

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -20,7 +20,7 @@ import de.westnordost.streetcomplete.util.getNameLabel
 class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
     override val elementFilter = """
-        nodes, ways with (
+        nodes, ways with
          shop ~ yes|hobby
          and !man_made
          and !historic
@@ -35,7 +35,6 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
          and !craft
          and !healthcare
          and !office
-        )
     """
     override val changesetComment = "Survey shop types"
     override val wikiLink = "Key:shop"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -21,20 +21,20 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
     override val elementFilter = """
         nodes, ways with
-         shop ~ yes|hobby
-         and !man_made
-         and !historic
-         and !military
-         and !power
-         and !tourism
-         and !attraction
-         and !amenity
-         and !leisure
-         and !aeroway
-         and !railway
-         and !craft
-         and !healthcare
-         and !office
+          shop ~ yes|hobby
+          and !man_made
+          and !historic
+          and !military
+          and !power
+          and !tourism
+          and !attraction
+          and !amenity
+          and !leisure
+          and !aeroway
+          and !railway
+          and !craft
+          and !healthcare
+          and !office
     """
     override val changesetComment = "Survey shop types"
     override val wikiLink = "Key:shop"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -85,7 +85,8 @@ class AddSidewalk : OsmElementQuestType<Sides<Sidewalk>> {
 
     override fun getHighlightedElements(element: Element, mapData: MapDataWithGeometry) =
         mapData.filter("""
-            ways with (
+            ways with
+              (
                 highway ~ path|footway|steps
                 or highway ~ cycleway|bridleway and foot ~ yes|designated
               )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -33,8 +33,7 @@ class AddSidewalk : OsmElementQuestType<Sides<Sidewalk>> {
               and expressway != yes
               and foot != no
             )
-            or
-            (
+            or (
               highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
               and (foot ~ yes|designated or bicycle ~ yes|designated)
             )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
@@ -29,21 +29,21 @@ class AddSmoking : OsmFilterQuestType<SmokingAllowed>() {
           as otherwise we assume they don't provide seating (like bakery, wine shop...)
      */
     override val elementFilter = """
-         nodes, ways with
-         (
-             amenity ~ bar|cafe|biergarten|restaurant|food_court and (indoor_seating != no or outdoor_seating != no)
-             or leisure = outdoor_seating
-             or amenity ~ nightclub|stripclub|pub
-             or (
-                 (amenity ~ fast_food|ice_cream or shop ~ ice_cream|deli|bakery|coffee|tea|wine)
-                 and (
-                     (outdoor_seating and outdoor_seating != no)
-                     or (indoor_seating and indoor_seating != no)
-                 )
-             )
-         )
-         and takeaway != only
-         and (!smoking or smoking older today -8 years)
+        nodes, ways with
+          (
+            amenity ~ bar|cafe|biergarten|restaurant|food_court and (indoor_seating != no or outdoor_seating != no)
+            or leisure = outdoor_seating
+            or amenity ~ nightclub|stripclub|pub
+            or (
+              (amenity ~ fast_food|ice_cream or shop ~ ice_cream|deli|bakery|coffee|tea|wine)
+              and (
+                (outdoor_seating and outdoor_seating != no)
+                or (indoor_seating and indoor_seating != no)
+              )
+            )
+          )
+          and takeaway != only
+          and (!smoking or smoking older today -8 years)
     """
     override val changesetComment = "Survey whether smoking is allowed or prohibited"
     override val wikiLink = "Key:smoking"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -14,7 +14,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+          (
             highway ~ ${ROADS_TO_ASK_SMOOTHNESS_FOR.joinToString("|")}
             or highway = service and service !~ driveway|slipway
           )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -16,16 +16,16 @@ class AddStepCount : OsmFilterQuestType<Int>() {
 
     override val elementFilter = """
         nodes, ways with
-        (
           (
-            highway = steps
-            and (!indoor or indoor = no)
-            and (!conveying or conveying = no)
+            (
+              highway = steps
+              and (!indoor or indoor = no)
+              and (!conveying or conveying = no)
+            )
+            or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
           )
-          or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
-        )
-        and access !~ private|no
-        and !step_count
+          and access !~ private|no
+          and !step_count
     """
     override val changesetComment = "Specify step counts"
     override val wikiLink = "Key:step_count"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -19,19 +19,19 @@ class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
 
     override val elementFilter = """
         ways with
-         highway = steps
-         and (!indoor or indoor = no)
-         and access !~ private|no
-         and surface ~ ${PAVED_SURFACES.joinToString("|")}
-         and !sac_scale
-         and (!conveying or conveying = no)
-         and ramp != separate
-         and (
-           !ramp
-           or (ramp = yes and !ramp:stroller and !ramp:bicycle and !ramp:wheelchair)
-           or ramp = no and ramp older today -4 years
-           or ramp older today -8 years
-         )
+          highway = steps
+          and (!indoor or indoor = no)
+          and access !~ private|no
+          and surface ~ ${PAVED_SURFACES.joinToString("|")}
+          and !sac_scale
+          and (!conveying or conveying = no)
+          and ramp != separate
+          and (
+            !ramp
+            or (ramp = yes and !ramp:stroller and !ramp:bicycle and !ramp:wheelchair)
+            or ramp = no and ramp older today -4 years
+            or ramp older today -8 years
+          )
     """
     override val changesetComment = "Specify whether steps have a ramp"
     override val wikiLink = "Key:ramp"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRamp.kt
@@ -18,7 +18,8 @@ import de.westnordost.streetcomplete.util.ktx.toYesNo
 class AddStepsRamp : OsmFilterQuestType<StepsRampAnswer>() {
 
     override val elementFilter = """
-        ways with highway = steps
+        ways with
+         highway = steps
          and (!indoor or indoor = no)
          and access !~ private|no
          and surface ~ ${PAVED_SURFACES.joinToString("|")}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -18,7 +18,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddCyclewayPartSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+        (
           highway = cycleway
           or (highway ~ path|footway and bicycle and bicycle != no)
           or (highway = bridleway and bicycle ~ designated|yes)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddCyclewayPartSurface.kt
@@ -19,29 +19,29 @@ class AddCyclewayPartSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
         ways with
-        (
-          highway = cycleway
-          or (highway ~ path|footway and bicycle and bicycle != no)
-          or (highway = bridleway and bicycle ~ designated|yes)
-        )
-        and segregated = yes
-        and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
-        and (
-          !cycleway:surface
-          or cycleway:surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            cycleway:surface ~ paved|unpaved
-            and !cycleway:surface:note
-            and !check_date:cycleway:surface
+          (
+            highway = cycleway
+            or (highway ~ path|footway and bicycle and bicycle != no)
+            or (highway = bridleway and bicycle ~ designated|yes)
           )
-          or cycleway:surface older today -8 years
-        )
-        and (
-          access !~ private|no
-          or (foot and foot !~ private|no)
-          or (bicycle and bicycle !~ private|no)
-        )
-        and ~path|footway|cycleway|bridleway !~ link
+          and segregated = yes
+          and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
+          and (
+            !cycleway:surface
+            or cycleway:surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+              cycleway:surface ~ paved|unpaved
+              and !cycleway:surface:note
+              and !check_date:cycleway:surface
+            )
+            or cycleway:surface older today -8 years
+          )
+          and (
+            access !~ private|no
+            or (foot and foot !~ private|no)
+            or (bicycle and bicycle !~ private|no)
+          )
+          and ~path|footway|cycleway|bridleway !~ link
     """
     override val changesetComment = "Specify cycleway path surfaces"
     override val wikiLink = "Key:surface"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -20,28 +20,28 @@ class AddFootwayPartSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
         ways with
-        (
-          highway = footway
-          or highway = path and foot != no
-          or (highway ~ cycleway|bridleway and foot and foot != no)
-        )
-        and segregated = yes
-        and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
-        and (
-          !footway:surface
-          or footway:surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            footway:surface ~ paved|unpaved
-            and !footway:surface:note
-            and !check_date:footway:surface
+          (
+            highway = footway
+            or highway = path and foot != no
+            or (highway ~ cycleway|bridleway and foot and foot != no)
           )
-          or footway:surface older today -8 years
-        )
-        and (
-          access !~ private|no
-          or (foot and foot !~ private|no)
-        )
-        and ~path|footway|cycleway|bridleway !~ link
+          and segregated = yes
+          and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
+          and (
+            !footway:surface
+            or footway:surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+              footway:surface ~ paved|unpaved
+              and !footway:surface:note
+              and !check_date:footway:surface
+            )
+            or footway:surface older today -8 years
+          )
+          and (
+            access !~ private|no
+            or (foot and foot !~ private|no)
+          )
+          and ~path|footway|cycleway|bridleway !~ link
     """
     override val changesetComment = "Add footway path surfaces"
     override val wikiLink = "Key:surface"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddFootwayPartSurface.kt
@@ -19,7 +19,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddFootwayPartSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+        (
           highway = footway
           or highway = path and foot != no
           or (highway ~ cycleway|bridleway and foot and foot != no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -20,24 +20,24 @@ class AddPathSurface : OsmFilterQuestType<PathSurfaceAnswer>() {
 
     override val elementFilter = """
         ways with
-        highway ~ path|footway|cycleway|bridleway|steps
-        and segregated != yes
-        and access !~ private|no
-        and (!conveying or conveying = no)
-        and (!indoor or indoor = no)
-        and (
-          !surface
-          or surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            surface ~ paved|unpaved
-            and !surface:note
-            and !note:surface
-            and !check_date:surface
+          highway ~ path|footway|cycleway|bridleway|steps
+          and segregated != yes
+          and access !~ private|no
+          and (!conveying or conveying = no)
+          and (!indoor or indoor = no)
+          and (
+            !surface
+            or surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+              surface ~ paved|unpaved
+              and !surface:note
+              and !note:surface
+              and !check_date:surface
+            )
+            or surface older today -8 years
           )
-          or surface older today -8 years
-        )
-        and ~path|footway|cycleway|bridleway !~ link
-        and ice_road != yes
+          and ~path|footway|cycleway|bridleway !~ link
+          and ice_road != yes
     """
 
     override val changesetComment = "Specify path surfaces"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -19,7 +19,8 @@ import de.westnordost.streetcomplete.resources.*
 class AddPathSurface : OsmFilterQuestType<PathSurfaceAnswer>() {
 
     override val elementFilter = """
-        ways with highway ~ path|footway|cycleway|bridleway|steps
+        ways with
+        highway ~ path|footway|cycleway|bridleway|steps
         and segregated != yes
         and access !~ private|no
         and (!conveying or conveying = no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -37,22 +37,22 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
         ways with
-         leisure ~ pitch|track
-         and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
-         and access !~ private|no
-         and indoor != yes and (!building or building = no)
-         and athletics !~ high_jump|pole_vault
-         and (
-          !surface
-          or surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            surface ~ paved|unpaved
-            and !surface:note
-            and !note:surface
-            and !check_date:surface
+          leisure ~ pitch|track
+          and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
+          and access !~ private|no
+          and indoor != yes and (!building or building = no)
+          and athletics !~ high_jump|pole_vault
+          and (
+            !surface
+            or surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+              surface ~ paved|unpaved
+              and !surface:note
+              and !note:surface
+              and !check_date:surface
+            )
+            or surface older today -12 years
           )
-          or surface older today -12 years
-        )
     """
 
     override val changesetComment = "Specify pitch surfaces"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -38,9 +38,9 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
     override val elementFilter = """
         ways with leisure ~ pitch|track
          and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
-         and (access !~ private|no)
+         and access !~ private|no
          and indoor != yes and (!building or building = no)
-         and (athletics !~ high_jump|pole_vault)
+         and athletics !~ high_jump|pole_vault
          and (
           !surface
           or surface ~ ${INVALID_SURFACES.joinToString("|")}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPitchSurface.kt
@@ -36,7 +36,8 @@ class AddPitchSurface : OsmFilterQuestType<Surface>() {
     )
 
     override val elementFilter = """
-        ways with leisure ~ pitch|track
+        ways with
+         leisure ~ pitch|track
          and sport ~ "(^|.*;)(${sportValuesWherePitchSurfaceQuestionIsInteresting.joinToString("|")})($|;.*)"
          and access !~ private|no
          and indoor != yes and (!building or building = no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -25,7 +25,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddRoadSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
-        ways with (
+        ways with
+        (
           highway ~ ${listOf(
             "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
             "unclassified", "residential", "living_street", "pedestrian", "track", "busway",

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -26,31 +26,31 @@ class AddRoadSurface : OsmFilterQuestType<Surface>() {
 
     override val elementFilter = """
         ways with
-        (
-          highway ~ ${listOf(
-            "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
-            "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
-            ).joinToString("|")
-          }
-          or highway = service and service !~ driveway|slipway
-        )
-        and (
-          !surface
-          or surface ~ ${INVALID_SURFACES.joinToString("|")}
-          or (
-            surface ~ paved|unpaved
-            and !surface:note
-            and !note:surface
-            and !check_date:surface
+          (
+            highway ~ ${listOf(
+              "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
+              "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
+              ).joinToString("|")
+            }
+            or highway = service and service !~ driveway|slipway
           )
-          or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and surface older today -6 years
-          or surface older today -12 years
-          ${INVALID_SURFACES_FOR_TRACKTYPES.entries.joinToString("\n") { (tracktype, surfaces) ->
-              "or tracktype = $tracktype and surface ~ ${surfaces.joinToString("|")}"
-          }}
-        )
-        and (access !~ private|no or (foot and foot !~ private|no))
-        and ice_road != yes
+          and (
+            !surface
+            or surface ~ ${INVALID_SURFACES.joinToString("|")}
+            or (
+              surface ~ paved|unpaved
+              and !surface:note
+              and !note:surface
+              and !check_date:surface
+            )
+            or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and surface older today -6 years
+            or surface older today -12 years
+            ${INVALID_SURFACES_FOR_TRACKTYPES.entries.joinToString("\n") { (tracktype, surfaces) ->
+            "or tracktype = $tracktype and surface ~ ${surfaces.joinToString("|")}"
+            }}
+          )
+          and (access !~ private|no or (foot and foot !~ private|no))
+          and ice_road != yes
     """
 
     override val changesetComment = "Specify road surfaces"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.kt
@@ -17,17 +17,17 @@ class AddTactilePavingBusStop : OsmFilterQuestType<Boolean>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-        (
-          public_transport = platform
-          or (highway = bus_stop and public_transport != stop_position)
-        )
-        and physically_present != no and naptan:BusStopType != HAR
-        and (
-          !tactile_paving
-          or tactile_paving = unknown
-          or tactile_paving = no and tactile_paving older today -8 years
-          or tactile_paving = yes and tactile_paving older today -12 years
-        )
+          (
+            public_transport = platform
+            or (highway = bus_stop and public_transport != stop_position)
+          )
+          and physically_present != no and naptan:BusStopType != HAR
+          and (
+            !tactile_paving
+            or tactile_paving = unknown
+            or tactile_paving = no and tactile_paving older today -8 years
+            or tactile_paving = yes and tactile_paving older today -12 years
+          )
     """
     override val changesetComment = "Specify whether public transport stops have tactile paving"
     override val wikiLink = "Key:tactile_paving"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
@@ -23,7 +23,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddTactilePavingSteps : OsmFilterQuestType<TactilePavingStepsAnswer>() {
 
     override val elementFilter = """
-        ways with highway = steps
+        ways with
+         highway = steps
          and surface ~ ${PAVED_SURFACES.joinToString("|")}
          and !sac_scale
          and (!conveying or conveying = no)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingSteps.kt
@@ -24,17 +24,17 @@ class AddTactilePavingSteps : OsmFilterQuestType<TactilePavingStepsAnswer>() {
 
     override val elementFilter = """
         ways with
-         highway = steps
-         and surface ~ ${PAVED_SURFACES.joinToString("|")}
-         and !sac_scale
-         and (!conveying or conveying = no)
-         and access !~ private|no
-        and (
-          !tactile_paving
-          or tactile_paving = unknown
-          or tactile_paving ~ no|partial|incorrect and tactile_paving older today -8 years
-          or tactile_paving = yes and tactile_paving older today -12 years
-        )
+          highway = steps
+          and surface ~ ${PAVED_SURFACES.joinToString("|")}
+          and !sac_scale
+          and (!conveying or conveying = no)
+          and access !~ private|no
+          and (
+            !tactile_paving
+            or tactile_paving = unknown
+            or tactile_paving ~ no|partial|incorrect and tactile_paving older today -8 years
+            or tactile_paving = yes and tactile_paving older today -12 years
+          )
     """
 
     override val changesetComment = "Survey tactile paving on steps"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/toilet_availability/AddToiletAvailability.kt
@@ -18,14 +18,14 @@ class AddToiletAvailability : OsmFilterQuestType<Boolean>() {
     // place to solve the quest. (Considering malls and department stores public enough)
     override val elementFilter = """
         nodes, ways with
-        (
-          shop ~ mall|department_store
-          or highway ~ services|rest_area|trailhead
-          or tourism ~ camp_site|caravan_site|wilderness_hut
-          or leisure ~ bathing_place|marina
-          or amenity = ranger_station
-        )
-        and !toilets
+          (
+            shop ~ mall|department_store
+            or highway ~ services|rest_area|trailhead
+            or tourism ~ camp_site|caravan_site|wilderness_hut
+            or leisure ~ bathing_place|marina
+            or amenity = ranger_station
+          )
+          and !toilets
     """
     override val changesetComment = "Survey toilet availabilities"
     override val wikiLink = "Key:toilets"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tourism_information/AddInformationToTourism.kt
@@ -18,7 +18,10 @@ import org.jetbrains.compose.resources.stringResource
 
 class AddInformationToTourism : OsmFilterQuestType<TourismInformation>() {
 
-    override val elementFilter = "nodes, ways with tourism = information and !information"
+    override val elementFilter = """
+        nodes, ways with
+          tourism = information and !information
+    """
     override val changesetComment = "Specify type of tourist informations"
     override val wikiLink = "Tag:tourism=information"
     override val icon = Res.drawable.quest_information

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tower_access/AddTowerAccess.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tower_access/AddTowerAccess.kt
@@ -17,15 +17,15 @@ class AddTowerAccess : OsmFilterQuestType<TowerAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-            man_made = tower
-            and (
-                tower:type = observation
-                or tower:type = watchtower and historic=yes
-            )
-            and disused != yes
-            and !emergency
-            and !military
-            and (!access or access = unknown)
+          man_made = tower
+          and (
+            tower:type = observation
+            or tower:type = watchtower and historic=yes
+          )
+          and disused != yes
+          and !emergency
+          and !military
+          and (!access or access = unknown)
         """
     override val changesetComment = "Specify access to observation towers"
     override val wikiLink = "Tag:man_made=tower"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -20,7 +20,8 @@ import org.jetbrains.compose.resources.stringResource
 class AddTracktype : OsmFilterQuestType<Tracktype>() {
 
     override val elementFilter = """
-        ways with highway = track
+        ways with
+        highway = track
         and (
           !tracktype
           or tracktype != grade1 and tracktype older today -6 years

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -21,16 +21,16 @@ class AddTracktype : OsmFilterQuestType<Tracktype>() {
 
     override val elementFilter = """
         ways with
-        highway = track
-        and (
-          !tracktype
-          or tracktype != grade1 and tracktype older today -6 years
-          or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and tracktype older today -6 years
-          or tracktype older today -8 years
-        )
-        and (access !~ private|no or (foot and foot !~ private|no))
-        and !bridge
-        and ice_road != yes
+          highway = track
+          and (
+            !tracktype
+            or tracktype != grade1 and tracktype older today -6 years
+            or surface ~ ${UNPAVED_SURFACES.joinToString("|")} and tracktype older today -6 years
+            or tracktype older today -8 years
+          )
+          and (access !~ private|no or (foot and foot !~ private|no))
+          and !bridge
+          and ice_road != yes
     """
     // ~paved tracks are less likely to change the surface type
     override val changesetComment = "Specify tracktypes"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/traffic_signals_sound/AddTrafficSignalsSound.kt
@@ -20,14 +20,14 @@ class AddTrafficSignalsSound : OsmElementQuestType<Boolean> {
 
     private val crossingFilter by lazy { """
         nodes with
-         (crossing = traffic_signals or crossing:signals = yes)
-         and highway ~ crossing|traffic_signals
-         and foot != no
-         and (
-          !$SOUND_SIGNALS
-          or $SOUND_SIGNALS = no and $SOUND_SIGNALS older today -4 years
-          or $SOUND_SIGNALS older today -8 years
-         )
+          (crossing = traffic_signals or crossing:signals = yes)
+          and highway ~ crossing|traffic_signals
+          and foot != no
+          and (
+            !$SOUND_SIGNALS
+            or $SOUND_SIGNALS = no and $SOUND_SIGNALS older today -4 years
+            or $SOUND_SIGNALS older today -8 years
+          )
     """.toElementFilterExpression() }
 
     private val excludedWaysFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/traffic_signals_vibrate/AddTrafficSignalsVibration.kt
@@ -24,14 +24,14 @@ class AddTrafficSignalsVibration : OsmElementQuestType<Boolean> {
 
     private val crossingFilter by lazy { """
         nodes with
-         (crossing = traffic_signals or crossing:signals = yes)
-         and highway ~ crossing|traffic_signals
-         and foot != no
-         and (
-          !$VIBRATING_BUTTON
-          or $VIBRATING_BUTTON = no and $VIBRATING_BUTTON older today -4 years
-          or $VIBRATING_BUTTON older today -8 years
-         )
+          (crossing = traffic_signals or crossing:signals = yes)
+          and highway ~ crossing|traffic_signals
+          and foot != no
+          and (
+            !$VIBRATING_BUTTON
+            or $VIBRATING_BUTTON = no and $VIBRATING_BUTTON older today -4 years
+            or $VIBRATING_BUTTON older today -8 years
+          )
     """.toElementFilterExpression() }
 
     private val excludedWaysFilter by lazy { """

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -36,8 +36,7 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
         ways with
         (
           highway ~ ${LIT_RESIDENTIAL_ROADS.joinToString("|")}
-          or highway ~ ${LIT_NON_RESIDENTIAL_ROADS.joinToString("|")} and
-          (
+          or highway ~ ${LIT_NON_RESIDENTIAL_ROADS.joinToString("|")} and (
             sidewalk ~ both|left|right|yes|separate
             or sidewalk:both = yes
             or sidewalk:left = yes
@@ -48,8 +47,7 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
           or highway ~ ${LIT_WAYS.joinToString("|")}
           or highway = path and (foot = designated or bicycle = designated)
         )
-        and
-        (
+        and (
           !lit
           or lit = no and lit older today -8 years
           or lit older today -16 years

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -34,27 +34,27 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>() {
         See #427 for discussion. */
     override val elementFilter = """
         ways with
-        (
-          highway ~ ${LIT_RESIDENTIAL_ROADS.joinToString("|")}
-          or highway ~ ${LIT_NON_RESIDENTIAL_ROADS.joinToString("|")} and (
-            sidewalk ~ both|left|right|yes|separate
-            or sidewalk:both = yes
-            or sidewalk:left = yes
-            or sidewalk:right = yes
-            or ~"${MAX_SPEED_TYPE_KEYS.joinToString("|")}" ~ ".*:(urban|.*zone.*|nsl_restricted)"
-            or maxspeed <= 60
+          (
+            highway ~ ${LIT_RESIDENTIAL_ROADS.joinToString("|")}
+            or highway ~ ${LIT_NON_RESIDENTIAL_ROADS.joinToString("|")} and (
+              sidewalk ~ both|left|right|yes|separate
+              or sidewalk:both = yes
+              or sidewalk:left = yes
+              or sidewalk:right = yes
+              or ~"${MAX_SPEED_TYPE_KEYS.joinToString("|")}" ~ ".*:(urban|.*zone.*|nsl_restricted)"
+              or maxspeed <= 60
+            )
+            or highway ~ ${LIT_WAYS.joinToString("|")}
+            or highway = path and (foot = designated or bicycle = designated)
           )
-          or highway ~ ${LIT_WAYS.joinToString("|")}
-          or highway = path and (foot = designated or bicycle = designated)
-        )
-        and (
-          !lit
-          or lit = no and lit older today -8 years
-          or lit older today -16 years
-        )
-        and (access !~ private|no or (foot and foot !~ private|no))
-        and indoor != yes
-        and ~path|footway|cycleway !~ link
+          and (
+            !lit
+            or lit = no and lit older today -8 years
+            or lit older today -16 years
+          )
+          and (access !~ private|no or (foot and foot !~ private|no))
+          and indoor != yes
+          and ~path|footway|cycleway !~ link
     """
 
     override val changesetComment = "Specify whether ways are lit"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -16,15 +16,15 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways, relations with
-         (
-           leisure = dog_park
-           or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
-           or natural = cave_entrance and fee=yes
-           or historic = castle and (access = yes or fee=yes)
-           or leisure = bird_hide
-         )
-         and access !~ no|private
-         and (!wheelchair or wheelchair older today -8 years)
+          (
+            leisure = dog_park
+            or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
+            or natural = cave_entrance and fee=yes
+            or historic = castle and (access = yes or fee=yes)
+            or leisure = bird_hide
+          )
+          and access !~ no|private
+          and (!wheelchair or wheelchair older today -8 years)
     """
     override val changesetComment = "Survey wheelchair accessibility of outside places"
     override val wikiLink = "Key:wheelchair"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransport.kt
@@ -15,13 +15,13 @@ class AddWheelchairAccessPublicTransport : OsmFilterQuestType<WheelchairAccess>(
 
     override val elementFilter = """
         nodes, ways, relations with
-         (amenity = bus_station or railway ~ station|subway_entrance)
-         and access !~ no|private
-         and (
-          !wheelchair
-          or wheelchair != yes and wheelchair older today -4 years
-          or wheelchair older today -8 years
-         )
+          (amenity = bus_station or railway ~ station|subway_entrance)
+          and access !~ no|private
+          and (
+            !wheelchair
+            or wheelchair != yes and wheelchair older today -4 years
+            or wheelchair older today -8 years
+          )
     """
     override val changesetComment = "Survey wheelchair accessibility of public transport platforms"
     override val wikiLink = "Key:wheelchair"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToilets.kt
@@ -15,13 +15,13 @@ class AddWheelchairAccessToilets : OsmFilterQuestType<WheelchairAccess>() {
 
     override val elementFilter = """
         nodes, ways with
-         amenity = toilets
-         and access !~ no|private
-         and (
-           !wheelchair
-           or wheelchair != yes and wheelchair older today -4 years
-           or wheelchair older today -8 years
-         )
+          amenity = toilets
+          and access !~ no|private
+          and (
+            !wheelchair
+            or wheelchair != yes and wheelchair older today -4 years
+            or wheelchair older today -8 years
+          )
     """
     override val changesetComment = "Specify wheelchair accessibility of toilets"
     override val wikiLink = "Key:wheelchair"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessToiletsPart.kt
@@ -25,18 +25,18 @@ class AddWheelchairAccessToiletsPart : OsmFilterQuestType<WheelchairAccessToilet
         nodes, ways with
           wheelchair = limited
           and (
-           toilets = yes
-           or !toilets and (
-             amenity ~ restaurant|pub|bar
-             or amenity ~ cafe|fast_food and indoor_seating = yes
-           )
-         )
-         and access !~ no|private
-         and (
-           !toilets:wheelchair
-           or toilets:wheelchair != yes and toilets:wheelchair older today -4 years
-           or toilets:wheelchair older today -8 years
-         )
+            toilets = yes
+            or !toilets and (
+              amenity ~ restaurant|pub|bar
+              or amenity ~ cafe|fast_food and indoor_seating = yes
+            )
+          )
+          and access !~ no|private
+          and (
+            !toilets:wheelchair
+            or toilets:wheelchair != yes and toilets:wheelchair older today -4 years
+            or toilets:wheelchair older today -8 years
+          )
     """
     override val changesetComment = "Specify wheelchair accessibility of toilets in places"
     override val wikiLink = "Key:toilets:wheelchair"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddCyclewayWidth.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddCyclewayWidth.kt
@@ -19,7 +19,8 @@ class AddCyclewayWidth(
     /* All either exclusive cycleways or ways that are cycleway + footway (or bridleway) but
      *  segregated */
     override val elementFilter = """
-        ways with (
+        ways with
+        (
           (
             highway = cycleway
             and foot !~ yes|designated

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddCyclewayWidth.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddCyclewayWidth.kt
@@ -20,25 +20,25 @@ class AddCyclewayWidth(
      *  segregated */
     override val elementFilter = """
         ways with
-        (
           (
-            highway = cycleway
-            and foot !~ yes|designated
-            and (!width or source:width ~ ".*estimat.*")
-          ) or (
-            segregated = yes
-            and (
-              highway = cycleway and foot ~ yes|designated
-              or highway ~ path|footway and bicycle != no
-              or highway = bridleway and bicycle ~ designated|yes
+            (
+              highway = cycleway
+              and foot !~ yes|designated
+              and (!width or source:width ~ ".*estimat.*")
+            ) or (
+              segregated = yes
+              and (
+                highway = cycleway and foot ~ yes|designated
+                or highway ~ path|footway and bicycle != no
+                or highway = bridleway and bicycle ~ designated|yes
+              )
+              and (!cycleway:width or source:cycleway:width ~ ".*estimat.*")
             )
-            and (!cycleway:width or source:cycleway:width ~ ".*estimat.*")
           )
-        )
-        and area != yes
-        and access !~ private|no
-        and placement != transition
-        and ~path|footway|cycleway|bridleway !~ link
+          and area != yes
+          and access !~ private|no
+          and placement != transition
+          and ~path|footway|cycleway|bridleway !~ link
     """
     override val changesetComment = "Specify cycleways width"
     override val wikiLink = "Key:width"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
@@ -23,37 +23,37 @@ class AddRoadWidth(
 ) : OsmElementQuestType<WidthAnswer> {
 
     private val nodeFilter by lazy { """
-       nodes with
-         traffic_calming ~ ${ROAD_NARROWERS.joinToString("|")}
-         and (!width or source:width ~ ".*estimat.*")
-         and (!maxwidth or source:maxwidth ~ ".*estimat.*")
+        nodes with
+          traffic_calming ~ ${ROAD_NARROWERS.joinToString("|")}
+          and (!width or source:width ~ ".*estimat.*")
+          and (!maxwidth or source:maxwidth ~ ".*estimat.*")
     """.toElementFilterExpression() }
 
     private val wayFilter by lazy { """
         ways with
-        (
           (
-            highway ~ trunk|primary|secondary|tertiary|unclassified|residential|busway
-            and (lane_markings = no or lanes < 2)
-          ) or (
-            highway = residential
-            and (
-              maxspeed < 33
-              or maxspeed = walk
-              or ~"${MAX_SPEED_TYPE_KEYS.joinToString("|")}" ~ ".*:(zone)?:?([1-9]|[1-2][0-9]|30)"
+            (
+              highway ~ trunk|primary|secondary|tertiary|unclassified|residential|busway
+              and (lane_markings = no or lanes < 2)
+            ) or (
+              highway = residential
+              and (
+                maxspeed < 33
+                or maxspeed = walk
+                or ~"${MAX_SPEED_TYPE_KEYS.joinToString("|")}" ~ ".*:(zone)?:?([1-9]|[1-2][0-9]|30)"
+              )
+              and lane_markings != yes and (!lanes or lanes < 2)
             )
-            and lane_markings != yes and (!lanes or lanes < 2)
+            or highway = living_street
+            or highway = service and service = alley
           )
-          or highway = living_street
-          or highway = service and service = alley
-        )
-        and area != yes
-        and (!width or source:width ~ ".*estimat.*")
-        and (traffic_calming !~ ${ROAD_NARROWERS.joinToString("|")} or !maxwidth or source:maxwidth ~".*estimat.*")
-        and (surface ~ ${PAVED_SURFACES.joinToString("|")} or highway ~ ${ROADS_ASSUMED_TO_BE_PAVED.joinToString("|")})
-        and (access !~ private|no or (foot and foot !~ private|no))
-        and foot != no
-        and placement != transition
+          and area != yes
+          and (!width or source:width ~ ".*estimat.*")
+          and (traffic_calming !~ ${ROAD_NARROWERS.joinToString("|")} or !maxwidth or source:maxwidth ~".*estimat.*")
+          and (surface ~ ${PAVED_SURFACES.joinToString("|")} or highway ~ ${ROADS_ASSUMED_TO_BE_PAVED.joinToString("|")})
+          and (access !~ private|no or (foot and foot !~ private|no))
+          and foot != no
+          and placement != transition
     """.toElementFilterExpression() }
 
     override val changesetComment = "Determine road widths"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
@@ -30,7 +30,8 @@ class AddRoadWidth(
     """.toElementFilterExpression() }
 
     private val wayFilter by lazy { """
-        ways with (
+        ways with
+        (
           (
             highway ~ trunk|primary|secondary|tertiary|unclassified|residential|busway
             and (lane_markings = no or lanes < 2)


### PR DESCRIPTION
See individual commits (then the diff is most readable):

- use `=` instead of `~` where there is no `|` afterwards
- use `~` instead of multiple consecutive comparisons
- remove some redundant parentheses where they don't increase readability
- make `and`/`or` wrapping more consistent
- make newline after `with` more consistent
- make indentation more consistent

Done in part by hand and in part by GitHub Copilot, but always with full review of the changes.