### PR TITLE
ChargingStationBicycles: only ask for charging stations with compatable sockets

### DIFF
--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1034,7 +1034,7 @@
     <string name="quest_carWashType_selfService">Self-service</string>
     <string name="quest_carWashType_service">Staff cleans car</string>
 
-    <string name="quest_charging_station_bicycles_title">Can bicycles be charged here, too?</string>
+    <string name="quest_charging_station_bicycles_title">Can bicycles be charged here?</string>
     <string name="quest_charging_station_bicycles_hint">Bicycle charger power adapters plug into normal household sockets.</string>
 
     <string name="quest_charging_station_capacity_title">How many cars can be charged here at the same time?</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1034,8 +1034,8 @@
     <string name="quest_carWashType_selfService">Self-service</string>
     <string name="quest_carWashType_service">Staff cleans car</string>
 
-    <string name="quest_charging_station_bicycles_title">Can bicycles be charged here?</string>
-    <string name="quest_charging_station_bicycles_hint">Bicycle charger power adapters plug into normal household sockets.</string>
+    <string name="quest_charging_station_bicycles_title">May bicycles be charged here?</string>
+    <string name="quest_charging_station_bicycles_hint">These plugs can be used to charge bicycles. Check if charging bicycles is prohibited or prevented here.</string>
 
     <string name="quest_charging_station_capacity_title">How many cars can be charged here at the same time?</string>
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
@@ -6,26 +6,37 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
-import de.westnordost.streetcomplete.data.osm.osmquests.Answer
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.quests.charging_station_bicycles.ChargingStationBicycles.NO
-import de.westnordost.streetcomplete.quests.charging_station_bicycles.ChargingStationBicycles.ONLY
-import de.westnordost.streetcomplete.quests.charging_station_bicycles.ChargingStationBicycles.YES
 import de.westnordost.streetcomplete.resources.*
-import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
-import de.westnordost.streetcomplete.ui.common.quest.QuestForm
-import org.jetbrains.compose.resources.stringResource
+import de.westnordost.streetcomplete.ui.common.quest.YesNoQuestForm
+import de.westnordost.streetcomplete.util.ktx.toYesNo
 
-class AddChargingStationBicycles : OsmFilterQuestType<ChargingStationBicycles>() {
+class AddChargingStationBicycles : OsmFilterQuestType<Boolean>() {
 
+    // Charging station with a socket that commonly supports bicycles.
     override val elementFilter = """
         nodes, ways with
           amenity = charging_station
           and !bicycle
           and access !~ private|no
+          and (
+             socket:ropd > 0
+             or socket:bosch_3pin > 0
+             or socket:shimano_steps_5pin > 0
+             or socket:xlr_3pin_cable > 0
+             or socket:domestic > 0
+             or socket:typec > 0
+             or socket:typee > 0
+             or socket:nema5_15 > 0
+             or socket:nema_5_20 > 0
+             or socket:nema_TT_30 > 0
+             or socket:schuko > 0
+             or socket:as3112 > 0
+             or socket:sev1011_t23 > 0
+          )
     """
     override val changesetComment = "Specify whether bicycles can be charged at charging stations"
     override val wikiLink = "Tag:amenity=charging_station"
@@ -38,29 +49,11 @@ class AddChargingStationBicycles : OsmFilterQuestType<ChargingStationBicycles>()
         mapData.filter("nodes, ways with amenity = charging_station")
 
     @Composable
-    override fun Form(on: (QuestAction<ChargingStationBicycles>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
-        QuestForm(
-            on = on,
-            answers = listOf(
-                AnswerItem(stringResource(Res.string.quest_generic_hasFeature_no)) { on(Answer(NO)) },
-                AnswerItem(stringResource(Res.string.quest_generic_hasFeature_yes)) { on(Answer(YES)) },
-                AnswerItem(stringResource(Res.string.quest_hasFeature_only)) { on(Answer(ONLY)) },
-            )
-        )
+    override fun Form(on: (QuestAction<Boolean>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
+        YesNoQuestForm(on)
     }
 
-    override fun applyAnswerTo(answer: ChargingStationBicycles, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        when (answer) {
-            ChargingStationBicycles.YES -> {
-                tags["bicycle"] = "yes"
-            }
-            ChargingStationBicycles.NO -> {
-                tags["bicycle"] = "no"
-            }
-            ChargingStationBicycles.ONLY -> {
-                tags["bicycle"] = "yes"
-                tags["motorcar"] = "no"
-            }
-        }
+    override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags["crossing:island"] = answer.toYesNo()
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
@@ -30,7 +30,7 @@ class AddChargingStationBicycles : OsmFilterQuestType<Boolean>() {
              or socket:domestic > 0
              or socket:typec > 0
              or socket:typee > 0
-             or socket:nema5_15 > 0
+             or socket:nema_5_15 > 0
              or socket:nema_5_20 > 0
              or socket:nema_TT_30 > 0
              or socket:schuko > 0

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicycles.kt
@@ -54,6 +54,6 @@ class AddChargingStationBicycles : OsmFilterQuestType<Boolean>() {
     }
 
     override fun applyAnswerTo(answer: Boolean, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        tags["crossing:island"] = answer.toYesNo()
+        tags["bicycle"] = answer.toYesNo()
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/ChargingStationBicycles.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/ChargingStationBicycles.kt
@@ -1,3 +1,0 @@
-package de.westnordost.streetcomplete.quests.charging_station_bicycles
-
-enum class ChargingStationBicycles { YES, NO, ONLY }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicyclesTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/charging_station_bicycles/AddChargingStationBicyclesTest.kt
@@ -1,0 +1,30 @@
+package de.westnordost.streetcomplete.quests.charging_station_bicycles
+
+import de.westnordost.streetcomplete.testutils.node
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddChargingStationBicyclesTest {
+
+    private val questType = AddChargingStationBicycles()
+
+    @Test fun `is not applicable to empty tags`() {
+        assertFalse(questType.isApplicableTo(node()))
+    }
+
+    @Test fun `is applicable to charging station with schuko = 2`() {
+        assertTrue(questType.isApplicableTo(node(tags = mapOf(
+            "amenity" to "charging_station",
+            "socket:schuko" to "2",
+        ))))
+    }
+
+    @Test fun `is not applicable charging station without bicycle compatible sockets`() {
+        assertFalse(questType.isApplicableTo(node(tags = mapOf(
+            "amenity" to "charging_station",
+            "socket:schuko" to "0",
+            "socket:type2" to "10",
+        ))))
+    }
+}


### PR DESCRIPTION
Further follow up to https://github.com/streetcomplete/StreetComplete/pull/6732

Refactors `ChargingStationBicycles`:

- Remove the "only" option, since this is now asked by [AddChargingStationMotorcar](https://github.com/streetcomplete/StreetComplete/pull/7083)
- Only ask for charging stations with compatible sockets (domestic, and bike only).

Since the socket filter is a bit more complex I also added tests

---

Alternatively we could also remove this quest entirely, since these sockets might imply that bicycles can be charged. However, I dislike this idea. Consider the following case of a bicycle only charging station with only one socket. It is tagged as:

`amenity=charging_station, socket:bosh_5 = 1`

Since no vehicles are tagged, we generally assume that this is a car only charging stations. Many car focused renderers will show it and many bicycle focused ones will not. 

Because of this, a quest will be generated to ask for sockets, which the user cannot meaningfully answer (no car sockets).
And the quests for Motorcar access will not be asked (no other vehicle tagged).

However, if we ask for bicycle access first, we can confirm that this is indeed a bicycle charging station, and then as a follow up ask if cars can also use it.

So it:

- Improves bad data
- Removes ambiguity if bicycles can use a charging station.

---

I suspect this will be quite spammy, however it will also be quite rare, so a user is unlikely to encounter it very often.

For the sockets, I  only included ones with more than 100 uses, though this will likely need to be updated as we promote more socket types.

Tested.